### PR TITLE
Add help text for scale treasure type

### DIFF
--- a/droll/shell.py
+++ b/droll/shell.py
@@ -193,6 +193,9 @@ class Shell(cmd.Cmd):
         """
         )
 
+    def help_scale(self):
+        print("""Scales are treasures that score 2 points per pair.""")
+
     def help_sword(self):
         print("""Swords behave identically to a fighter.""")
 


### PR DESCRIPTION
Added help documentation for the `scale` treasure type in the shell interface.

Fixes #4 