### PR TITLE
Fix package discovery to include droll.heroes subpackage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,8 +36,9 @@ test = [
 [project.scripts]
 droll = "droll.__main__:main"
 
-[tool.setuptools]
-packages = ["droll"]
+[tool.setuptools.packages.find]
+where = ["."]
+include = ["droll*"]
 
 [tool.setuptools.package-data]
 "*" = ["*"]


### PR DESCRIPTION
The explicit `packages = ["droll"]` configuration was missing the
droll.heroes subpackage. Switch to using setuptools' automatic
package discovery with `[tool.setuptools.packages.find]` to include
all subpackages matching the droll* pattern.