### PR TITLE
Migrate namedtuples to frozen dataclasses

### DIFF
--- a/droll/action.py
+++ b/droll/action.py
@@ -4,7 +4,7 @@
 """Functionality associated with player action mechanics."""
 
 import collections
-import dataclasses
+from dataclasses import replace
 import operator
 import typing
 
@@ -18,7 +18,7 @@ def defeat_one(
     game: struct.World, randrange: dice.RandRange, hero: str, target: str
 ) -> struct.World:
     """Update game after hero handles exactly one target."""
-    return dataclasses.replace(
+    return replace(
         game,
         party=_decrement_hero(game.party, hero),
         dungeon=_decrement_target(game.dungeon, target),
@@ -31,13 +31,13 @@ def _decrement_hero(party: struct.Party, hero: str) -> struct.Party:
     prior_heroes = getattr(party, hero)
     if not prior_heroes:
         raise error.DrollError("Require at least one hero {}.".format(hero))
-    return dataclasses.replace(party, **{hero: prior_heroes - 1})
+    return replace(party, **{hero: prior_heroes - 1})
 
 
 def _increment_hero(party: struct.Party, hero: str) -> struct.Party:
     if party is None:
         raise error.DrollError("No party currently active.")
-    return dataclasses.replace(party, **{hero: getattr(party, hero) + 1})
+    return replace(party, **{hero: getattr(party, hero) + 1})
 
 
 def _decrement_target(dungeon: struct.Dungeon, target: str) -> struct.Dungeon:
@@ -46,21 +46,21 @@ def _decrement_target(dungeon: struct.Dungeon, target: str) -> struct.Dungeon:
     prior_targets = getattr(dungeon, target)
     if not prior_targets:
         raise ValueError("Require at least one target {}.".format(target))
-    return dataclasses.replace(dungeon, **{target: prior_targets - 1})
+    return replace(dungeon, **{target: prior_targets - 1})
 
 
 def _increment_target(dungeon: struct.Dungeon, target: str) -> struct.Dungeon:
     if dungeon is None:
         raise error.DrollError("No dungeon currently active.")
     prior_targets = getattr(dungeon, target, 0)
-    return dataclasses.replace(dungeon, **{target: prior_targets + 1})
+    return replace(dungeon, **{target: prior_targets + 1})
 
 
 def defeat_all(
     game: struct.World, randrange: dice.RandRange, hero: str, target: str
 ) -> struct.World:
     """Update game after hero handles all of one type of target."""
-    return dataclasses.replace(
+    return replace(
         game,
         party=_decrement_hero(game.party, hero),
         dungeon=_eliminate_targets(game.dungeon, target),
@@ -94,7 +94,7 @@ def defeat_all_plus_additional(
 
     # Last, attempt to defeat the additional monster using the same hero
     return defeat_one(
-        game=dataclasses.replace(game, party=_increment_hero(game.party, hero)),
+        game=replace(game, party=_increment_hero(game.party, hero)),
         randrange=randrange,
         hero=hero,
         target=additional[0],
@@ -109,7 +109,7 @@ def _eliminate_targets(
     prior_targets = getattr(dungeon, target)
     if not prior_targets:
         raise error.DrollError("Require at least 1 target {}.".format(target))
-    return dataclasses.replace(dungeon, **{target: 0})
+    return replace(dungeon, **{target: 0})
 
 
 def open_one(
@@ -123,7 +123,7 @@ def open_one(
     """Update game after hero opens exactly one chest."""
     if _after_monsters and not world.defeated_monsters(game.dungeon):
         raise error.DrollError("Monsters must be defeated before opening.")
-    return dataclasses.replace(
+    return replace(
         world.draw_treasure(game, randrange),
         party=_decrement_hero(game.party, hero),
         dungeon=_decrement_target(game.dungeon, target),
@@ -146,7 +146,7 @@ def open_all(
         raise error.DrollError("At least 1 {} required.".format(target))
     for _ in range(howmany):
         game = world.draw_treasure(game, randrange)
-    return dataclasses.replace(
+    return replace(
         game,
         party=_decrement_hero(game.party, hero),
         dungeon=_eliminate_targets(game.dungeon, target),
@@ -174,7 +174,7 @@ def quaff(
     party = _decrement_hero(game.party, hero)
     for revived in revivable:
         party = _increment_hero(party, revived)
-    return dataclasses.replace(
+    return replace(
         game, party=party, dungeon=_eliminate_targets(game.dungeon, target)
     )
 
@@ -195,7 +195,7 @@ def reroll(
 
     # Re-roll the necessary number of dice then add to anything left fixed
     increased = dice.roll_dungeon(dice=len(targets), randrange=randrange)
-    return dataclasses.replace(
+    return replace(
         game,
         party=_decrement_hero(game.party, hero),
         dungeon=struct.Dungeon(*tuple(map(operator.add, reduced, increased))),
@@ -330,7 +330,7 @@ def defeat_dragon(
         raise RuntimeError("Unexpected result from _defeat_dragon_heroes")
 
     # Attempt was successful, so update experience and treasure
-    return dataclasses.replace(
+    return replace(
         world.draw_treasure(game, randrange),
         experience=game.experience + 1,
         party=party,
@@ -361,16 +361,16 @@ def bait_dragon(
     if dungeon is not None:
         for enemy in _enemies:
             new_targets += getattr(game.dungeon, enemy)
-            dungeon = dataclasses.replace(dungeon, **{enemy: 0})
+            dungeon = replace(dungeon, **{enemy: 0})
     if not new_targets:
         raise error.DrollError(
             "At least one of {} required for '{}'.".format(_enemies, noun)
         )
 
     # Increment the number of targets (i.e. dragons)
-    return dataclasses.replace(
+    return replace(
         game,
-        dungeon=dataclasses.replace(
+        dungeon=replace(
             dungeon, **{target: getattr(dungeon, target) + new_targets}
         )
     )
@@ -380,7 +380,7 @@ def elixir(
     game: struct.World, randrange: dice.RandRange, noun: str, target: str
 ) -> struct.World:
     """Add one hero die of any requested type."""
-    return dataclasses.replace(
+    return replace(
         world.replace_treasure(game, noun),
         party=_increment_hero(game.party, target)
     )
@@ -389,7 +389,7 @@ def elixir(
 def consume_ability(game: struct.World):
     if not game.ability:
         raise error.DrollError("Ability not available for use.")
-    return dataclasses.replace(game, ability=False)
+    return replace(game, ability=False)
 
 
 def nop_ability(

--- a/droll/heroes/crusader.py
+++ b/droll/heroes/crusader.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Hero definitions for Crusader advancing to Paladin."""
-import dataclasses
+from dataclasses import replace
 import functools
 import typing
 
@@ -32,7 +32,7 @@ def crusader_ability(
             "Target {} not one of {}".format(target, _acceptable_targets)
         )
     return action.consume_ability(
-        dataclasses.replace(game, party=action._increment_hero(game.party, target))
+        replace(game, party=action._increment_hero(game.party, target))
     )
 
 
@@ -75,10 +75,10 @@ def paladin_ability(
         party = game.party
         for revived in revivable:
             party = action._increment_hero(party, revived)
-        game = dataclasses.replace(game, party=party)
+        game = replace(game, party=party)
 
     # Clear the entire dungeon (all monsters, chests, potions, dragons)
-    game = dataclasses.replace(
+    game = replace(
         game, dungeon=struct.Dungeon(*([0] * len(struct.Dungeon._fields)))
     )
 
@@ -95,24 +95,24 @@ _crusader_defeat_dragon = functools.partial(
 )
 
 # Defined in terms of Default, not Crusader, to permit advance(...) closure
-Paladin = dataclasses.replace(
+Paladin = replace(
     Default,
     name="Paladin",
     ability=paladin_ability,
     advance=(lambda _: Paladin),
-    party=dataclasses.replace(
+    party=replace(
         struct.update_party_dragon(Default.party, _crusader_defeat_dragon),
-        fighter=dataclasses.replace(
+        fighter=replace(
             Default.party.fighter, skeleton=Default.party.cleric.skeleton
         ),
-        cleric=dataclasses.replace(
+        cleric=replace(
             Default.party.cleric, goblin=Default.party.fighter.goblin
         ),
     ),
 )
 
 # Defined after Paladin to permit advance(...) closure
-Crusader = dataclasses.replace(
+Crusader = replace(
     Default,
     name="Crusader",
     ability=crusader_ability,

--- a/droll/heroes/enchantress.py
+++ b/droll/heroes/enchantress.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Hero definitions for Beguiler advancing to Enchantress."""
-import dataclasses
+from dataclasses import replace
 import functools
 import typing
 
@@ -24,7 +24,7 @@ def enchantress_ability(
     dungeon = game.dungeon
     dungeon = action._decrement_target(dungeon, target)
     dungeon = action._increment_target(dungeon, "potion")
-    return action.consume_ability(dataclasses.replace(game, dungeon=dungeon))
+    return action.consume_ability(replace(game, dungeon=dungeon))
 
 
 def beguiler_ability(
@@ -49,7 +49,7 @@ def beguiler_ability(
     else:
         pass
     dungeon = action._increment_target(dungeon, "potion")
-    return action.consume_ability(dataclasses.replace(game, dungeon=dungeon))
+    return action.consume_ability(replace(game, dungeon=dungeon))
 
 
 # Scrolls act as wildcards for dragon defeats
@@ -61,12 +61,12 @@ _beguiler_defeat_dragon = functools.partial(
 )
 
 # Defined in terms of Default, not Enchantress, to permit advance(...) closure
-Beguiler = dataclasses.replace(
+Beguiler = replace(
     Default,
     name="Beguiler",
     ability=beguiler_ability,
     advance=(lambda _: Beguiler),
-    party=dataclasses.replace(
+    party=replace(
         Default.party,
         # Scrolls act offensively (defeat enemies, not re-roll)
         scroll=struct.Dungeon(
@@ -81,7 +81,7 @@ Beguiler = dataclasses.replace(
 )
 
 # Defined after Beguiler to permit advance(...) closure
-Enchantress = dataclasses.replace(
+Enchantress = replace(
     Default,
     name="Enchantress",
     ability=enchantress_ability,

--- a/droll/heroes/knight.py
+++ b/droll/heroes/knight.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Hero definitions for Knight advancing to DragonSlayer."""
-import dataclasses
+from dataclasses import replace
 import functools
 
 from .. import action
@@ -14,7 +14,7 @@ from ..player import Default
 def knight_roll_party(count: int, randrange: dice.RandRange) -> struct.Party:
     """Roll a new Party, changing all Scrolls into Champions."""
     default = dice.roll_party(dice=count, randrange=randrange)
-    return dataclasses.replace(
+    return replace(
         default, scroll=0, champion=default.champion + default.scroll
     )
 
@@ -35,22 +35,22 @@ _dragonslayer_defeat_dragon = functools.partial(
 )
 
 # Defined in terms of Default, not Knight, to permit advance(...) closure
-DragonSlayer = dataclasses.replace(
+DragonSlayer = replace(
     Default,
     name="DragonSlayer",
     ability=knight_bait_dragon,
     advance=(lambda _: DragonSlayer),
-    roll=dataclasses.replace(Default.roll, party=knight_roll_party),
+    roll=replace(Default.roll, party=knight_roll_party),
     party=struct.update_party_dragon(
         Default.party, _dragonslayer_defeat_dragon
     ),
 )
 
 # Defined after DragonSlayer to permit advance(...) closure
-Knight = dataclasses.replace(
+Knight = replace(
     Default,
     name="Knight",
     ability=knight_bait_dragon,
     advance=(lambda world: Knight if world.experience < 5 else DragonSlayer),
-    roll=dataclasses.replace(Default.roll, party=knight_roll_party),
+    roll=replace(Default.roll, party=knight_roll_party),
 )

--- a/droll/heroes/minstrel.py
+++ b/droll/heroes/minstrel.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Hero definitions for Minstrel advancing to Bard."""
-import dataclasses
+from dataclasses import replace
 import functools
 import typing
 
@@ -24,7 +24,7 @@ def minstrel_ability(
     if target != "dragon":
         raise error.DrollError("Can only discard {} dice".format(target))
     return action.consume_ability(
-        dataclasses.replace(
+        replace(
             game, dungeon=action._eliminate_targets(game.dungeon, target)
         )
     )
@@ -40,21 +40,21 @@ _minstrel_defeat_dragon = functools.partial(
 )
 
 # Building block: dragon defeat + mage/thief interchangeability in combat
-_Minstrel_Party = dataclasses.replace(
+_Minstrel_Party = replace(
     struct.update_party_dragon(Default.party, _minstrel_defeat_dragon),
-    mage=dataclasses.replace(Default.party.mage, chest=Default.party.thief.chest),
-    thief=dataclasses.replace(Default.party.thief, ooze=Default.party.mage.ooze),
+    mage=replace(Default.party.mage, chest=Default.party.thief.chest),
+    thief=replace(Default.party.thief, ooze=Default.party.mage.ooze),
 )
 
 # Defined in terms of Default, not Minstrel, to permit advance(...) closure
-Bard = dataclasses.replace(
+Bard = replace(
     Default,
     name="Bard",
     ability=minstrel_ability,
     advance=(lambda _: Bard),  # Cannot advance further
-    party=dataclasses.replace(
+    party=replace(
         _Minstrel_Party,
-        champion=dataclasses.replace(
+        champion=replace(
             _Minstrel_Party.champion,
             # Champions defeat one additional monster when attacking monsters
             goblin=action.defeat_all_plus_additional,
@@ -65,7 +65,7 @@ Bard = dataclasses.replace(
 )
 
 # Defined after Bard to permit advance(...) closure
-Minstrel = dataclasses.replace(
+Minstrel = replace(
     Default,
     name="Minstrel",
     ability=minstrel_ability,

--- a/droll/heroes/spellsword.py
+++ b/droll/heroes/spellsword.py
@@ -2,7 +2,7 @@
 # License, v. 2.0. If a copy of the MPL was not distributed with this
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Hero definitions for Spellsword advancing to Battlemage."""
-import dataclasses
+from dataclasses import replace
 import functools
 import typing
 
@@ -31,7 +31,7 @@ def spellsword_ability(
             "Target {} not one of {}".format(target, _acceptable_targets)
         )
     return action.consume_ability(
-        dataclasses.replace(game, party=action._increment_hero(game.party, target))
+        replace(game, party=action._increment_hero(game.party, target))
     )
 
 
@@ -57,31 +57,31 @@ def battlemage_ability(
     if target is not None:
         raise error.DrollError("No targets accepted for {}".format(noun))
     return action.consume_ability(
-        dataclasses.replace(
+        replace(
             game, dungeon=struct.Dungeon(*([0] * len(struct.Dungeon._fields)))
         )
     )
 
 
 # Defined in terms of Default, not Spellsword, to permit advance(...) closure
-Battlemage = dataclasses.replace(
+Battlemage = replace(
     Default,
     name="Battlemage",
     ability=battlemage_ability,
     advance=(lambda _: Battlemage),
-    party=dataclasses.replace(
+    party=replace(
         struct.update_party_dragon(Default.party, _spellsword_defeat_dragon),
-        fighter=dataclasses.replace(
+        fighter=replace(
             Default.party.fighter, ooze=Default.party.mage.ooze
         ),
-        mage=dataclasses.replace(
+        mage=replace(
             Default.party.mage, goblin=Default.party.fighter.goblin
         ),
     ),
 )
 
 # Defined after Battlemage to permit advance(...) closure
-Spellsword = dataclasses.replace(
+Spellsword = replace(
     Default,
     name="Spellsword",
     ability=spellsword_ability,

--- a/droll/player.py
+++ b/droll/player.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Functionality associated with player action mechanics."""
 
-import dataclasses
+from dataclasses import replace
 import typing
 
 from . import action
@@ -125,9 +125,9 @@ def apply(
     # Many treasures behave exactly like party members, so
     # convert into party members prior to action invocation.
     prior_treasure = game.treasure
-    game = dataclasses.replace(
+    game = replace(
         game,
-        party=dataclasses.replace(
+        party=replace(
             game.party,
             **{
                 hero: getattr(game.party, hero)
@@ -157,9 +157,9 @@ def apply(
             raise error.DrollError(str(cause)) from cause
 
     # Undo the prior transformation by subtracting prior_treasure.
-    game = dataclasses.replace(
+    game = replace(
         game,
-        party=dataclasses.replace(
+        party=replace(
             game.party,
             **{
                 hero: getattr(game.party, hero)
@@ -179,8 +179,8 @@ def apply(
         for _ in range(-min(0, quantity)):
             game = world.replace_treasure(
                     game, getattr(player.artifacts, hero))
-        game = dataclasses.replace(
-            game, party=dataclasses.replace(game.party, **{hero: 0})
+        game = replace(
+            game, party=replace(game.party, **{hero: 0})
         )
 
     return game

--- a/droll/struct.py
+++ b/droll/struct.py
@@ -3,11 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Type definitions, generally of the struct-like variety."""
 import collections
-import dataclasses
+from dataclasses import dataclass, replace
 import typing
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class Dungeon:
     goblin: typing.Any = 0
     skeleton: typing.Any = 0
@@ -26,7 +26,7 @@ class Dungeon:
         return 6
 
 
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class Party:
     fighter: typing.Any = 0
     cleric: typing.Any = 0
@@ -44,7 +44,7 @@ class Party:
     def __len__(self):
         return 6
 
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class Roll:
     dungeon: typing.Any = None
     party: typing.Any = None
@@ -57,7 +57,7 @@ class Roll:
     def __len__(self):
         return 2
 
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class Player:
     name: typing.Any = None
     ability: typing.Any = None
@@ -93,7 +93,7 @@ _RESERVE = collections.OrderedDict(
     )
 )
 
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class Treasure:
     sword: typing.Any = 0
     talisman: typing.Any = 0
@@ -121,7 +121,7 @@ RESERVE_INITIAL = Treasure(*_RESERVE.values())
 
 TREASURE_INITIAL = Treasure(*([0] * len(_RESERVE)))
 
-@dataclasses.dataclass(frozen=True)
+@dataclass(frozen=True)
 class World:
     delve: typing.Any = None
     depth: typing.Any = None
@@ -146,7 +146,7 @@ class World:
 def update_party_dragon(party: Party, dragon_func) -> Party:
     """Update all heroes in a party to use a custom dragon defeat function."""
     return Party(*(
-        dataclasses.replace(hero_dungeon, dragon=dragon_func)
+        replace(hero_dungeon, dragon=dragon_func)
         for hero_dungeon in party
     ))
 

--- a/droll/world.py
+++ b/droll/world.py
@@ -4,7 +4,7 @@
 """Functionality associated with world state and world mechanics."""
 
 import copy
-import dataclasses
+from dataclasses import replace
 
 from . import dice
 from . import error
@@ -65,7 +65,7 @@ def next_delve(
     Argument roll_party can be dice.roll_party but other choices okay."""
     if world.delve >= 3:
         raise error.DrollError("At most three delves are permitted.")
-    return dataclasses.replace(
+    return replace(
         world,
         delve=(world.delve if world.delve else 0) + 1,
         depth=0,
@@ -107,8 +107,8 @@ def next_dungeon(
     dungeon = roll_dungeon(
         min(_dungeon_dice - prior_dragons, next_depth), randrange
     )
-    dungeon = dataclasses.replace(dungeon, dragon=dungeon.dragon + prior_dragons)
-    return dataclasses.replace(world, depth=next_depth, dungeon=dungeon)
+    dungeon = replace(dungeon, dragon=dungeon.dragon + prior_dragons)
+    return replace(world, depth=next_depth, dungeon=dungeon)
 
 
 def retire(world: struct.World) -> struct.World:
@@ -139,7 +139,7 @@ def retire(world: struct.World) -> struct.World:
 
     # Success above, so update the world in anticipation of the next delve
     # Upgrading a hero's ability after 5 experience points is done elsewhere.
-    return dataclasses.replace(
+    return replace(
         world, depth=0, experience=world.experience + world.depth, dungeon=None
     )
 
@@ -151,7 +151,7 @@ def retreat(world: struct.World) -> struct.World:
     if defeated_dungeon(world.dungeon):
         raise error.DrollError("Why retreat when you could instead retire?")
 
-    return dataclasses.replace(world, depth=0, dungeon=None)
+    return replace(world, depth=0, dungeon=None)
 
 
 def score(world: struct.World) -> int:
@@ -177,13 +177,13 @@ def draw_treasure(
 ) -> struct.World:
     """Draw a single item from the reserve into the player's treasures."""
     drawn = _draw(reserve=world.reserve, randrange=randrange)
-    treasure = dataclasses.replace(
+    treasure = replace(
         world.treasure, **{drawn: getattr(world.treasure, drawn) + 1}
     )
-    reserve = dataclasses.replace(
+    reserve = replace(
         world.reserve, **{drawn: getattr(world.reserve, drawn) - 1}
     )
-    return dataclasses.replace(world, treasure=treasure, reserve=reserve)
+    return replace(world, treasure=treasure, reserve=reserve)
 
 
 def replace_treasure(world: struct.World, item: str) -> struct.World:
@@ -191,10 +191,10 @@ def replace_treasure(world: struct.World, item: str) -> struct.World:
     prior_count = getattr(world.treasure, item)
     if not prior_count:
         raise error.DrollError("'{}' not in player's treasure".format(item))
-    return dataclasses.replace(
+    return replace(
         world,
-        treasure=dataclasses.replace(world.treasure, **{item: prior_count - 1}),
-        reserve=dataclasses.replace(
+        treasure=replace(world.treasure, **{item: prior_count - 1}),
+        reserve=replace(
             world.reserve, **{item: getattr(world.reserve, item) + 1}
         ),
     )
@@ -207,8 +207,8 @@ def apply_ring(world: struct.World, *, noun: str = "ring") -> struct.World:
             "A dragon must be present to use a {}".format(noun)
         )
     world = replace_treasure(world, noun)
-    return dataclasses.replace(
-        world, dungeon=dataclasses.replace(world.dungeon, dragon=0)
+    return replace(
+        world, dungeon=replace(world.dungeon, dragon=0)
     )
 
 
@@ -219,7 +219,7 @@ def apply_portal(world: struct.World, *, noun: str = "portal") -> struct.World:
         raise error.DrollError(
             "No need to apply {} when dungeon clear".format(noun)
         )
-    return dataclasses.replace(
+    return replace(
         replace_treasure(world, "portal"),
         dungeon=struct.Dungeon(*([0] * len(struct.Dungeon._fields)))
     )

--- a/tests/test_dragon.py
+++ b/tests/test_dragon.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Testing of world-to-world transitions stemming from attacking dragons."""
 
-import dataclasses
+from dataclasses import replace
 import random
 
 import pytest
@@ -18,7 +18,7 @@ import droll.world as world
 
 @pytest.fixture(name="game")
 def _game():
-    return dataclasses.replace(
+    return replace(
         world.new_world(),
         dungeon=struct.Dungeon(
             goblin=0, skeleton=0, ooze=0, chest=1, potion=2, dragon=3
@@ -45,11 +45,11 @@ def test_successful(game, randrange):
 
 
 def test_treasure_slot1(game, randrange):
-    game = dataclasses.replace(
-        game, treasure=dataclasses.replace(game.treasure, sword=7)
+    game = replace(
+        game, treasure=replace(game.treasure, sword=7)
     )
-    game = dataclasses.replace(
-        game, party=dataclasses.replace(game.party, fighter=0)
+    game = replace(
+        game, party=replace(game.party, fighter=0)
     )
     game = player.apply(
         player.Default,
@@ -70,11 +70,11 @@ def test_treasure_slot1(game, randrange):
 
 
 def test_treasure_slot3(game, randrange):
-    game = dataclasses.replace(
-        game, treasure=dataclasses.replace(game.treasure, talisman=7)
+    game = replace(
+        game, treasure=replace(game.treasure, talisman=7)
     )
-    game = dataclasses.replace(
-        game, party=dataclasses.replace(game.party, cleric=0)
+    game = replace(
+        game, party=replace(game.party, cleric=0)
     )
     game = player.apply(
         player.Default,
@@ -95,11 +95,11 @@ def test_treasure_slot3(game, randrange):
 
 
 def test_treasure_slot2(game, randrange):
-    game = dataclasses.replace(
-        game, treasure=dataclasses.replace(game.treasure, sceptre=7)
+    game = replace(
+        game, treasure=replace(game.treasure, sceptre=7)
     )
-    game = dataclasses.replace(
-        game, party=dataclasses.replace(game.party, mage=0)
+    game = replace(
+        game, party=replace(game.party, mage=0)
     )
     game = player.apply(
         player.Default,
@@ -120,8 +120,8 @@ def test_treasure_slot2(game, randrange):
 
 
 def test_monsters_remain(game, randrange):
-    game = dataclasses.replace(
-        game, dungeon=dataclasses.replace(game.dungeon, goblin=1)
+    game = replace(
+        game, dungeon=replace(game.dungeon, goblin=1)
     )
     with pytest.raises(error.DrollError):
         player.apply(

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Testing of world-to-world transitions stemming from player actions."""
 
-import dataclasses
+from dataclasses import replace
 import random
 
 import pytest
@@ -16,7 +16,7 @@ import droll.world as world
 
 @pytest.fixture(name="game")
 def _game():
-    return dataclasses.replace(
+    return replace(
         world.new_world(),
         dungeon=struct.Dungeon(*([2] * len(struct.Dungeon._fields))),
         party=struct.Party(*([2] * len(struct.Party._fields))),
@@ -24,8 +24,8 @@ def _game():
 
 
 def __remove_monsters(game: struct.World) -> struct.World:
-    return dataclasses.replace(
-        game, dungeon=dataclasses.replace(game.dungeon, goblin=0, skeleton=0, ooze=0)
+    return replace(
+        game, dungeon=replace(game.dungeon, goblin=0, skeleton=0, ooze=0)
     )
 
 
@@ -83,8 +83,8 @@ def test_thief(game, randrange):
     assert game.dungeon.chest == 0
     assert sum(game.treasure) == 2
 
-    game = dataclasses.replace(
-        game, party=dataclasses.replace(game.party, thief=1)
+    game = replace(
+        game, party=replace(game.party, thief=1)
     )  # Add one
     with pytest.raises(error.DrollError):
         player.apply(player.Default, game, None, "thief", "chest")
@@ -151,14 +151,14 @@ def complete(*args):
 def test_complete0(game):
     """Complete available party and treasure in the zeroth position."""
     assert ["fighter"] == complete(game, ("fig",), "fig", 0)
-    game = dataclasses.replace(
-        game, party=dataclasses.replace(game.party, fighter=0)
+    game = replace(
+        game, party=replace(game.party, fighter=0)
     )
     assert [] == complete(game, ("fig",), "fig", 0)  # party
     assert [] == complete(game, ("gob",), "gob", 0)  # dungeon
     assert [] == complete(game, ("bai",), "bai", 0)  # treasure
-    game = dataclasses.replace(
-        game, treasure=dataclasses.replace(game.treasure, bait=1)
+    game = replace(
+        game, treasure=replace(game.treasure, bait=1)
     )
     assert ["bait"] == complete(game, ("bai",), "bai", 0)  # treasure
 
@@ -168,22 +168,22 @@ def test_complete1(game):
     # Vanilla first position stuff
     assert ["goblin"] == complete(game, ("fig", "gob"), "gob", 1)
     assert ["fighter"] == complete(game, ("fig", "fig"), "fig", 1)  # party
-    game = dataclasses.replace(
-        game, dungeon=dataclasses.replace(game.dungeon, goblin=0)
+    game = replace(
+        game, dungeon=replace(game.dungeon, goblin=0)
     )
     assert [] == complete(game, ("fig", "gob"), "gob", 1)  # dungeon
-    game = dataclasses.replace(
-        game, party=dataclasses.replace(game.party, fighter=0)
+    game = replace(
+        game, party=replace(game.party, fighter=0)
     )
     assert [] == complete(game, ("fig", "fig"), "fig", 1)  # dungeon
-    game = dataclasses.replace(
-        game, treasure=dataclasses.replace(game.treasure, bait=1)
+    game = replace(
+        game, treasure=replace(game.treasure, bait=1)
     )
     assert [] == complete(game, ("fig", "bai"), "fig", 1)  # treasure
 
     # Special case associated with 'elixir'
-    game = dataclasses.replace(game, party=struct.Party(*([0] * len(game.party))))
-    game = dataclasses.replace(
+    game = replace(game, party=struct.Party(*([0] * len(game.party))))
+    game = replace(
         game, treasure=struct.Treasure(*([0] * len(game.treasure)))
     )
     assert list(sorted(struct.Party._fields)) == (
@@ -193,8 +193,8 @@ def test_complete1(game):
 
 def test_complete2(game):
     """Complete all party and dungeon in the second position."""
-    game = dataclasses.replace(
-        game, party=dataclasses.replace(game.party, fighter=0)
+    game = replace(
+        game, party=replace(game.party, fighter=0)
     )
     game = __remove_monsters(game)
     assert ["fighter"] == complete(game, ("X", "Y", "fig"), "fig", 2)

--- a/tests/test_treasure.py
+++ b/tests/test_treasure.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Testing of world-to-world transitions stemming from using treasure."""
 
-import dataclasses
+from dataclasses import replace
 import random
 
 import pytest
@@ -16,7 +16,7 @@ import droll.world as world
 
 @pytest.fixture(name="game")
 def _game():
-    return dataclasses.replace(
+    return replace(
         world.new_world(),
         dungeon=struct.Dungeon(*([2] * len(struct.Dungeon._fields))),
         party=struct.Party(*([0] * len(struct.Party._fields))),
@@ -29,8 +29,8 @@ def _randrange():
 
 
 def test_elixir(game, randrange):
-    game = dataclasses.replace(
-        game, treasure=dataclasses.replace(game.treasure, elixir=1)
+    game = replace(
+        game, treasure=replace(game.treasure, elixir=1)
     )
     game = player.apply(player.Default, game, randrange, "elixir", "cleric")
     assert game.party.cleric == 1
@@ -41,8 +41,8 @@ def test_elixir(game, randrange):
 
 
 def test_bait(game, randrange):
-    game = dataclasses.replace(
-        game, treasure=dataclasses.replace(game.treasure, bait=2)
+    game = replace(
+        game, treasure=replace(game.treasure, bait=2)
     )
     game = player.apply(player.Default, game, randrange, "bait", "dragon")
     assert game.treasure.bait == 1
@@ -58,8 +58,8 @@ def test_bait(game, randrange):
 # Should behave identically to test_fighter inside test_player.py,
 def helper_sword(identifier, game):
     """Test sword when referred to via identifier (e.g. 'sword', 'fighter'."""
-    game = dataclasses.replace(
-        game, treasure=dataclasses.replace(game.treasure, sword=2)
+    game = replace(
+        game, treasure=replace(game.treasure, sword=2)
     )
     game = player.apply(player.Default, game, None, identifier, "goblin")
     assert game.treasure.sword == 1

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -3,7 +3,7 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Testing of basic world-to-world transitions."""
 
-import dataclasses
+from dataclasses import replace
 import random
 
 import pytest
@@ -54,8 +54,8 @@ def test_draw_treasure(state):
 
 def test_replace_treasure():
     pre = droll.world.new_world()
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, elixir=1)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, elixir=1)
     )
     post = droll.world.replace_treasure(pre, "elixir")
     assert sum(pre.treasure) == 1
@@ -66,7 +66,7 @@ def test_replace_treasure():
 def test_retire_simple(state):
     pre = droll.world.new_world()
     pre = droll.world.next_delve(pre, droll.dice.roll_party, state.randrange)
-    pre = dataclasses.replace(
+    pre = replace(
         pre,
         depth=3,
         dungeon=droll.struct.Dungeon(
@@ -81,7 +81,7 @@ def test_retire_simple(state):
 def test_retire_monsters(state):
     pre = droll.world.new_world()
     pre = droll.world.next_delve(pre, droll.dice.roll_party, state.randrange)
-    pre = dataclasses.replace(
+    pre = replace(
         pre,
         depth=3,
         dungeon=droll.struct.Dungeon(
@@ -95,15 +95,15 @@ def test_retire_monsters(state):
         droll.world.retire(pre)
 
     # Ring of invisibility
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=1)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=1)
     )
     with pytest.raises(droll.error.DrollError):
         droll.world.retire(pre)
 
     # Town portal
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, portal=1)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, portal=1)
     )
     post = droll.world.retire(pre)
     assert post.experience == pre.depth + pre.experience
@@ -113,7 +113,7 @@ def test_retire_monsters(state):
 def test_retire_dragon(state):
     pre = droll.world.new_world()
     pre = droll.world.next_delve(pre, droll.dice.roll_party, state.randrange)
-    pre = dataclasses.replace(
+    pre = replace(
         pre,
         depth=3,
         dungeon=droll.struct.Dungeon(
@@ -127,8 +127,8 @@ def test_retire_dragon(state):
         droll.world.retire(pre)
 
     # Ring of invisibility
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=1, portal=0)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=1, portal=0)
     )
     post1 = droll.world.retire(pre)
     assert post1.experience == pre.depth + pre.experience
@@ -136,8 +136,8 @@ def test_retire_dragon(state):
     assert post1.treasure.portal == 0
 
     # Town portal
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=0, portal=1)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=0, portal=1)
     )
     post2 = droll.world.retire(pre)
     assert post2.experience == pre.depth + pre.experience
@@ -145,8 +145,8 @@ def test_retire_dragon(state):
     assert post2.treasure.portal == 0
 
     # Both should consume the ring of invisibility first
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=1, portal=1)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=1, portal=1)
     )
     post3 = droll.world.retire(pre)
     assert post3.experience == pre.depth + pre.experience
@@ -157,7 +157,7 @@ def test_retire_dragon(state):
 def test_next_dungeon_simple(state):
     pre = droll.world.new_world()
     pre = droll.world.next_delve(pre, droll.dice.roll_party, state.randrange)
-    pre = dataclasses.replace(
+    pre = replace(
         pre,
         depth=3,
         dungeon=droll.struct.Dungeon(
@@ -173,7 +173,7 @@ def test_next_dungeon_simple(state):
 def test_next_dungeon_monsters(state):
     pre = droll.world.new_world()
     pre = droll.world.next_delve(pre, droll.dice.roll_party, state.randrange)
-    pre = dataclasses.replace(
+    pre = replace(
         pre,
         depth=3,
         dungeon=droll.struct.Dungeon(
@@ -187,15 +187,15 @@ def test_next_dungeon_monsters(state):
         droll.world.next_dungeon(pre, droll.dice.roll_dungeon, state.randrange)
 
     # Ring of invisibility
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=1, portal=0)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=1, portal=0)
     )
     with pytest.raises(droll.error.DrollError):
         droll.world.next_dungeon(pre, droll.dice.roll_dungeon, state.randrange)
 
     # Town portal
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=1, portal=0)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=1, portal=0)
     )
     with pytest.raises(droll.error.DrollError):
         droll.world.next_dungeon(pre, droll.dice.roll_dungeon, state.randrange)
@@ -204,7 +204,7 @@ def test_next_dungeon_monsters(state):
 def test_next_dungeon_dragon(state):
     pre = droll.world.new_world()
     pre = droll.world.next_delve(pre, droll.dice.roll_party, state.randrange)
-    pre = dataclasses.replace(
+    pre = replace(
         pre,
         depth=3,
         dungeon=droll.struct.Dungeon(
@@ -218,8 +218,8 @@ def test_next_dungeon_dragon(state):
         droll.world.next_dungeon(pre, droll.dice.roll_dungeon, state.randrange)
 
     # Ring of invisibility
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=1, portal=0)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=1, portal=0)
     )
     post1 = droll.world.next_dungeon(
         pre, droll.dice.roll_dungeon, state.randrange
@@ -229,15 +229,15 @@ def test_next_dungeon_dragon(state):
     assert post1.treasure.portal == 0
 
     # Town portal
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=0, portal=1)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=0, portal=1)
     )
     with pytest.raises(droll.error.DrollError):
         droll.world.next_dungeon(pre, droll.dice.roll_dungeon, state.randrange)
 
     # Both should consume the ring of invisibility
-    pre = dataclasses.replace(
-        pre, treasure=dataclasses.replace(pre.treasure, ring=1, portal=1)
+    pre = replace(
+        pre, treasure=replace(pre.treasure, ring=1, portal=1)
     )
     post3 = droll.world.next_dungeon(
         pre, droll.dice.roll_dungeon, state.randrange


### PR DESCRIPTION
Refactored all namedtuple definitions in `droll/struct.py` to use frozen dataclasses.

Maintains backward compatibility through the addition of `_fields`, `__iter__()`, and `__len__()` methods.

## Key Changes
- Converted 6 namedtuple definitions to frozen dataclasses:
  - `Dungeon`
  - `Party`
  - `Roll`
  - `Player`
  - `Treasure`
  - `World`

- Added compatibility layer to each dataclass:
  - `_fields` tuple attribute for namedtuple-like field introspection
  - `__iter__()` method to support tuple unpacking and iteration
  - `__len__()` method to support `len()` calls

- Set appropriate default values:
  - Numeric fields default to `0`
  - Object/reference fields default to `None`