### PR TITLE
Implement shallow copy for GameState to optimize undo tracking

### DIFF
--- a/droll/game.py
+++ b/droll/game.py
@@ -45,6 +45,14 @@ class Game:
             and self.randhash() == other.randhash()
         )
 
+    def __copy__(self):
+        """Shallow copy sharing frozen dataclass fields, copying random state."""
+        new = object.__new__(type(self))
+        new._player = self._player  # Frozen dataclass, safe to share
+        new._world = self._world  # Frozen dataclass, safe to share
+        new._random = copy.copy(self._random)  # Mutable, needs state copy
+        return new
+
     def randhash(self) -> int:
         """Hash of the current random state."""
         return hash(self._random.getstate())

--- a/droll/shell.py
+++ b/droll/shell.py
@@ -41,7 +41,7 @@ class Shell(cmd.Cmd):
     def onecmd(self, line, *, _raises=False) -> GameState:
         """Performs undo tracking whenever undo won't cause re-roll/re-draw."""
         # Track observable state before and after command processing.
-        before = copy.deepcopy(self._game)  # TODO Simplify from deepcopy?
+        before = copy.copy(self._game)
         try:
             result = GameState.PLAY
             result = super(Shell, self).onecmd(line)

--- a/droll/world.py
+++ b/droll/world.py
@@ -3,7 +3,6 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Functionality associated with world state and world mechanics."""
 
-import copy
 from dataclasses import replace
 
 from . import dice
@@ -48,8 +47,8 @@ def new_world() -> struct.World:
         ability=None,
         dungeon=None,
         party=None,
-        treasure=copy.deepcopy(struct.TREASURE_INITIAL),
-        reserve=copy.deepcopy(struct.RESERVE_INITIAL),
+        treasure=struct.TREASURE_INITIAL,
+        reserve=struct.RESERVE_INITIAL,
     )
 
 


### PR DESCRIPTION
Replaced `deepcopy` with a `__copy__` implementation for `GameState` to optimize undo tracking.
Employs the immutability of frozen dataclass fields while properly copying mutable random state.