### PR TITLE
Use frozenset for immutable target type hints in hero abilities

### DIFF
--- a/droll/heroes/crusader.py
+++ b/droll/heroes/crusader.py
@@ -20,7 +20,7 @@ def crusader_ability(
     noun: str,
     target: typing.Optional[str] = None,
     *,
-    _acceptable_targets: typing.Set[str] = {"fighter", "cleric"}
+    _acceptable_targets: typing.FrozenSet[str] = frozenset({"fighter", "cleric"})
 ) -> struct.World:
     """Crusader usable as a fighter or a cleric, adding one hero.
 
@@ -42,7 +42,7 @@ def paladin_ability(
     noun: str,
     target: typing.Optional[str] = None,
     *revivable: str,
-    _acceptable_targets: typing.Set[str] = {"fighter", "cleric"}
+    _acceptable_targets: typing.FrozenSet[str] = frozenset({"fighter", "cleric"})
 ) -> struct.World:
     """Consume treasure to clear dungeon, open chests, and quaff potions.
 

--- a/droll/heroes/spellsword.py
+++ b/droll/heroes/spellsword.py
@@ -19,7 +19,7 @@ def spellsword_ability(
     noun: str,
     target: typing.Optional[str] = None,
     *,
-    _acceptable_targets: typing.Set[str] = {"fighter", "mage"}
+    _acceptable_targets: typing.FrozenSet[str] = frozenset({"fighter", "mage"})
 ) -> struct.World:
     """Spellsword usable as a fighter or a mage, adding one hero to party.
 
@@ -51,7 +51,7 @@ def battlemage_ability(
     noun: str,
     target: typing.Optional[str] = None,
     *,
-    _acceptable_targets: typing.Set[str] = {"fighter", "mage"}
+    _acceptable_targets: typing.FrozenSet[str] = frozenset({"fighter", "mage"})
 ) -> struct.World:
     """Discard all monsters, chests, potions, and dice in the dragon's lair."""
     if target is not None:


### PR DESCRIPTION
Frozenset to make default arguments imutable

- **crusader.py**: Updated `crusader_ability()` and `paladin_ability()` to use `FrozenSet[str]` with `frozenset()` defaults
- **spellsword.py**: Updated `spellsword_ability()` and `battlemage_ability()` to use `FrozenSet[str]` with `frozenset()` defaults