### PR TITLE
Reorder display output: show Available before Party

### DIFF
--- a/droll/display.py
+++ b/droll/display.py
@@ -70,8 +70,8 @@ def compact_summary(
     lines = [
         f"{'Score ' + str(score) + ':':<{width}} {location}",
         f"{'Treasure:':<{width}} {treasure_str}",
-        f"{'Party:':<{width}} {party_str}",
         f"{'Available:':<{width}} {available_str}",
+        f"{'Party:':<{width}} {party_str}",
     ]
     if dungeon_str:
         lines.append(f"{'Dungeon:':<{width}} {dungeon_str}")

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -101,10 +101,10 @@ class TestCompactSummary(unittest.TestCase):
         self.assertIn("delve 1 with experience 0", lines[0])
         self.assertIn("Treasure:", lines[1])
         self.assertIn("none", lines[1])
-        self.assertIn("Party:", lines[2])
-        self.assertIn("fighter×2", lines[2])
-        self.assertIn("Available:", lines[3])
-        self.assertIn("ability descend", lines[3])
+        self.assertIn("Available:", lines[2])
+        self.assertIn("ability descend", lines[2])
+        self.assertIn("Party:", lines[3])
+        self.assertIn("fighter×2", lines[3])
 
     def test_in_dungeon(self):
         world = struct.World(
@@ -123,8 +123,8 @@ class TestCompactSummary(unittest.TestCase):
         self.assertEqual(len(lines), 5)
         self.assertIn("depth 3 in delve 1 with experience 0", lines[0])
         self.assertIn("talisman", lines[1])
-        self.assertIn("fighter champion", lines[2])
-        self.assertIn("ability retreat", lines[3])
+        self.assertIn("ability retreat", lines[2])
+        self.assertIn("fighter champion", lines[3])
         self.assertIn("goblin skeleton×2 ooze×2", lines[4])
 
     def test_long_player_name_alignment(self):
@@ -179,6 +179,6 @@ class TestCompactSummary(unittest.TestCase):
         lines = result.split("\n")
         self.assertIn("depth 10 in delve 3 with experience 16", lines[0])
         self.assertIn("scale×4 sceptre talisman tools", lines[1])
-        self.assertIn("champion scroll×2", lines[2])
-        self.assertIn("retire", lines[3])
+        self.assertIn("retire", lines[2])
+        self.assertIn("champion scroll×2", lines[3])
         self.assertEqual(len(lines), 4)  # No Dungeon line


### PR DESCRIPTION
## Summary
Reordered the display output in the game summary to show the "Available" section before the "Party" section for better information hierarchy.

## Changes
- **display.py**: Swapped the order of "Available" and "Party" lines in the `compact_summary()` function output
- **test_display.py**: Updated all test assertions to match the new display order across four test cases:
  - `test_start_of_game`: Available now on line 2, Party on line 3
  - `test_in_dungeon`: Available now on line 2, Party on line 3
  - `test_cleared_level_10`: Available now on line 2, Party on line 3

## Rationale
This change improves the logical flow of the game state display by presenting available actions/abilities before the current party composition, which may be more intuitive for players reviewing their current situation.

https://claude.ai/code/session_01T17K3qitWtSxe1T7qaNadX