### PR TITLE
Exclude non-command treasures from completion suggestions

### DIFF
--- a/droll/player.py
+++ b/droll/player.py
@@ -198,6 +198,12 @@ def partify(token: str, artifacts: struct.Party):
 # Later tokens contain mixtures of present and requested items.
 # Attempts to specialize much beyond this seem to quickly go awry.
 # One notable special case is 'elixir' as any party die follows.
+
+# Treasures excluded from completion because they lack associated commands.
+# Portal and ring are auto-used; scale is for scoring only.
+TREASURE_NO_COMMAND = frozenset({"portal", "ring", "scale"})
+
+
 def complete(
     game: struct.World, tokens: typing.Sequence[str], text: str, position: int
 ) -> typing.Sequence[str]:
@@ -209,7 +215,7 @@ def complete(
             for source in (game.party, game.treasure)
             if source is not None
             for key, value in struct.field_items(source)
-            if value
+            if value and key not in TREASURE_NO_COMMAND
         }
         # Special command "reroll" is available iff "scroll" is available
         if "scroll" in candidates:

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -177,6 +177,22 @@ class TestComplete(unittest.TestCase):
         game = replace(game, treasure=replace(game.treasure, bait=1))
         assert ["bait"] == complete(game, ("bai",), "bai", 0)  # treasure
 
+    def test_complete0_excludes_noncommand_treasures(self):
+        """Non-command treasures (portal, ring, scale) excluded from position 0."""
+        game = self.game
+        # Add all three non-command treasures
+        game = replace(
+            game,
+            treasure=replace(game.treasure, portal=1, ring=1, scale=1),
+        )
+        # None of them should appear in completions
+        assert [] == complete(game, ("por",), "por", 0)
+        assert [] == complete(game, ("rin",), "rin", 0)
+        assert [] == complete(game, ("sca",), "sca", 0)
+        # But a command treasure like elixir should still work
+        game = replace(game, treasure=replace(game.treasure, elixir=1))
+        assert ["elixir"] == complete(game, ("eli",), "eli", 0)
+
     def test_complete1(self):
         """Complete available party and dungeon in the first position."""
         game = self.game


### PR DESCRIPTION
## Summary
Prevents portal, ring, and scale treasures from appearing in command completion suggestions, since these items are either auto-used or scoring-only and don't have associated player commands.

## Changes
- Added `TREASURE_NO_COMMAND` constant to identify treasures that shouldn't be completed: portal, ring, and scale
- Updated the `complete()` function to filter out these treasures when generating completion candidates
- Added comprehensive test coverage to verify non-command treasures are excluded while command treasures like elixir remain available

## Implementation Details
The fix is minimal and surgical—a single condition check (`key not in TREASURE_NO_COMMAND`) in the completion candidate filtering logic. This ensures the autocomplete feature only suggests items that actually have associated commands, improving the user experience by reducing noise in suggestions.

https://claude.ai/code/session_01XqiWiCzFvwdbV7LGfDFhfq