### PR TITLE
Add underscore prefix to module-private functions

### DIFF
--- a/droll/display.py
+++ b/droll/display.py
@@ -27,28 +27,28 @@ def _format_item(name: str, count: int) -> typing.Optional[str]:
     return name
 
 
-def format_items(instance: typing.Any) -> str:
+def _format_items(instance: typing.Any) -> str:
     """Format dataclass fields as 'name' or 'name×N', in field order."""
     parts = (_format_item(n, c) for n, c in struct.field_items(instance))
     return " ".join(filter(None, parts)) or "none"
 
 
-def format_treasure(treasure: struct.Treasure) -> str:
+def _format_treasure(treasure: struct.Treasure) -> str:
     """Format treasure alphabetically."""
     parts = (_format_item(n, c) for n, c in sorted(struct.field_items(treasure)))
     return " ".join(filter(None, parts)) or "none"
 
 
-def format_available(available: typing.Sequence[str]) -> str:
+def _format_available(available: typing.Sequence[str]) -> str:
     """Format available commands alphabetically."""
     return " ".join(sorted(available)) or "None"
 
 
-def format_dungeon(dungeon: typing.Optional[struct.Dungeon]) -> typing.Optional[str]:
+def _format_dungeon(dungeon: typing.Optional[struct.Dungeon]) -> typing.Optional[str]:
     """Format dungeon contents, returning None if empty."""
     if dungeon is None or not any(struct.field_values(dungeon)):
         return None
-    return format_items(dungeon)
+    return _format_items(dungeon)
 
 
 def compact_summary(
@@ -69,10 +69,10 @@ def compact_summary(
         location = f"delve {w.delve} with experience {w.experience}"
 
     # Format each component
-    treasure_str = format_treasure(w.treasure)
-    party_str = format_items(w.party) if w.party else "none"
-    available_str = format_available(available)
-    dungeon_str = format_dungeon(w.dungeon)
+    treasure_str = _format_treasure(w.treasure)
+    party_str = _format_items(w.party) if w.party else "none"
+    available_str = _format_available(available)
+    dungeon_str = _format_dungeon(w.dungeon)
 
     # Build lines with aligned colons
     lines = [

--- a/droll/game.py
+++ b/droll/game.py
@@ -137,7 +137,7 @@ class Game:
             possible.append("ability")
         try:
             world.next_dungeon(
-                self._world, self._player.roll.dungeon, dummy_randrange
+                self._world, self._player.roll.dungeon, _dummy_randrange
             )
             possible.append("descend")
         except error.DrollError:
@@ -170,6 +170,6 @@ class Game:
         )
 
 
-def dummy_randrange(start, stop=None):
+def _dummy_randrange(start, stop=None):
     """Non-random pseudorandom generator so that completion is stateless."""
     return start

--- a/droll/heroes/crusader.py
+++ b/droll/heroes/crusader.py
@@ -14,7 +14,7 @@ from .. import world
 from ..player import Default
 
 
-def crusader_ability(
+def _crusader_ability(
     game: struct.World,
     randrange: dice.RandRange,
     noun: str,
@@ -38,7 +38,7 @@ def crusader_ability(
     )
 
 
-def paladin_ability(
+def _paladin_ability(
     game: struct.World,
     randrange: dice.RandRange,
     noun: str,
@@ -100,7 +100,7 @@ _crusader_defeat_dragon = functools.partial(
 Paladin = replace(
     Default,
     name="Paladin",
-    ability=paladin_ability,
+    ability=_paladin_ability,
     advance=(lambda _: Paladin),
     party=replace(
         struct.update_party_dragon(Default.party, _crusader_defeat_dragon),
@@ -117,7 +117,7 @@ Paladin = replace(
 Crusader = replace(
     Default,
     name="Crusader",
-    ability=crusader_ability,
+    ability=_crusader_ability,
     advance=(lambda world: Crusader if world.experience < 5 else Paladin),
     party=Paladin.party,
 )

--- a/droll/heroes/enchantress.py
+++ b/droll/heroes/enchantress.py
@@ -14,7 +14,7 @@ from .. import world
 from ..player import Default
 
 
-def enchantress_ability(
+def _enchantress_ability(
     game: struct.World,
     randrange: dice.RandRange,
     noun: str,
@@ -27,7 +27,7 @@ def enchantress_ability(
     return action.consume_ability(replace(game, dungeon=dungeon))
 
 
-def beguiler_ability(
+def _beguiler_ability(
     game: struct.World,
     randrange: dice.RandRange,
     noun: str,
@@ -64,7 +64,7 @@ _beguiler_defeat_dragon = functools.partial(
 Beguiler = replace(
     Default,
     name="Beguiler",
-    ability=beguiler_ability,
+    ability=_beguiler_ability,
     advance=(lambda _: Beguiler),
     party=replace(
         Default.party,
@@ -84,7 +84,7 @@ Beguiler = replace(
 Enchantress = replace(
     Default,
     name="Enchantress",
-    ability=enchantress_ability,
+    ability=_enchantress_ability,
     advance=(lambda world: Enchantress if world.experience < 5 else Beguiler),
     party=Beguiler.party,
 )

--- a/droll/heroes/knight.py
+++ b/droll/heroes/knight.py
@@ -11,7 +11,7 @@ from .. import struct
 from ..player import Default
 
 
-def knight_roll_party(count: int, randrange: dice.RandRange) -> struct.Party:
+def _knight_roll_party(count: int, randrange: dice.RandRange) -> struct.Party:
     """Roll a new Party, changing all Scrolls into Champions."""
     default = dice.roll_party(dice=count, randrange=randrange)
     return replace(
@@ -19,7 +19,7 @@ def knight_roll_party(count: int, randrange: dice.RandRange) -> struct.Party:
     )
 
 
-def knight_bait_dragon(*args, **kwargs):
+def _knight_bait_dragon(*args, **kwargs):
     """Convert all monster faces into dragon dice."""
     return action.consume_ability(
         action.bait_dragon(*args, _require_treasure=False, **kwargs)
@@ -38,9 +38,9 @@ _dragonslayer_defeat_dragon = functools.partial(
 DragonSlayer = replace(
     Default,
     name="DragonSlayer",
-    ability=knight_bait_dragon,
+    ability=_knight_bait_dragon,
     advance=(lambda _: DragonSlayer),
-    roll=replace(Default.roll, party=knight_roll_party),
+    roll=replace(Default.roll, party=_knight_roll_party),
     party=struct.update_party_dragon(
         Default.party, _dragonslayer_defeat_dragon
     ),
@@ -50,7 +50,7 @@ DragonSlayer = replace(
 Knight = replace(
     Default,
     name="Knight",
-    ability=knight_bait_dragon,
+    ability=_knight_bait_dragon,
     advance=(lambda world: Knight if world.experience < 5 else DragonSlayer),
-    roll=replace(Default.roll, party=knight_roll_party),
+    roll=replace(Default.roll, party=_knight_roll_party),
 )

--- a/droll/heroes/minstrel.py
+++ b/droll/heroes/minstrel.py
@@ -13,7 +13,7 @@ from .. import struct
 from ..player import Default
 
 
-def minstrel_ability(
+def _minstrel_ability(
     game: struct.World,
     randrange: dice.RandRange,
     noun: str,
@@ -48,7 +48,7 @@ _Minstrel_Party = replace(
 Bard = replace(
     Default,
     name="Bard",
-    ability=minstrel_ability,
+    ability=_minstrel_ability,
     advance=(lambda _: Bard),  # Cannot advance further
     party=replace(
         _Minstrel_Party,
@@ -66,7 +66,7 @@ Bard = replace(
 Minstrel = replace(
     Default,
     name="Minstrel",
-    ability=minstrel_ability,
+    ability=_minstrel_ability,
     advance=(lambda world: Minstrel if world.experience < 5 else Bard),
     party=_Minstrel_Party,
 )

--- a/droll/heroes/spellsword.py
+++ b/droll/heroes/spellsword.py
@@ -13,7 +13,7 @@ from .. import struct
 from ..player import Default
 
 
-def spellsword_ability(
+def _spellsword_ability(
     game: struct.World,
     randrange: dice.RandRange,
     noun: str,
@@ -45,7 +45,7 @@ _spellsword_defeat_dragon = functools.partial(
 )
 
 
-def battlemage_ability(
+def _battlemage_ability(
     game: struct.World,
     randrange: dice.RandRange,
     noun: str,
@@ -63,7 +63,7 @@ def battlemage_ability(
 Battlemage = replace(
     Default,
     name="Battlemage",
-    ability=battlemage_ability,
+    ability=_battlemage_ability,
     advance=(lambda _: Battlemage),
     party=replace(
         struct.update_party_dragon(Default.party, _spellsword_defeat_dragon),
@@ -76,7 +76,7 @@ Battlemage = replace(
 Spellsword = replace(
     Default,
     name="Spellsword",
-    ability=spellsword_ability,
+    ability=_spellsword_ability,
     advance=(lambda world: Spellsword if world.experience < 5 else Battlemage),
     party=Battlemage.party,
 )

--- a/droll/player.py
+++ b/droll/player.py
@@ -105,9 +105,9 @@ def apply(
     Varargs 'additional' permits passing more required information.
     For example, what heroes to revive when quaffing a potion."""
     # Convert any artifacts in the command into any corresponding hero types
-    noun = partify(noun, player.artifacts)
-    target = partify(target, player.artifacts)
-    additional = tuple(partify(i, player.artifacts) for i in additional)
+    noun = _partify(noun, player.artifacts)
+    target = _partify(target, player.artifacts)
+    additional = tuple(_partify(i, player.artifacts) for i in additional)
 
     # One-off handling of some treasures, with error wrapping to aid usability
     if noun == "portal":
@@ -184,7 +184,7 @@ def apply(
     return game
 
 
-def partify(token: str, artifacts: struct.Party):
+def _partify(token: str, artifacts: struct.Party):
     """Possibly convert tokens from treasures into associated party members."""
     if token is None:
         return None

--- a/droll/shell.py
+++ b/droll/shell.py
@@ -97,7 +97,7 @@ class Shell(cmd.Cmd):
 
     def do_undo(self, line) -> GameState:
         """Undo prior commands.  Only permitted when nothing rolled/drawn."""
-        no_arguments(line)
+        _no_arguments(line)
         if self._undo:
             # Assertion confirms onecmd(...) processing matches expectations
             assert self._game.randhash() == self._undo[-1].randhash()
@@ -120,29 +120,29 @@ class Shell(cmd.Cmd):
 
     @functools.wraps(Game.ability)
     def do_ability(self, line) -> GameState:
-        return self._game.ability(*parse(line))
+        return self._game.ability(*_parse(line))
 
     @functools.wraps(Game.apply)
     def default(self, line) -> GameState:
-        return self._game.apply(*parse(line))
+        return self._game.apply(*_parse(line))
 
     @functools.wraps(Game.descend)
     def do_descend(self, line) -> GameState:
-        no_arguments(line)
+        _no_arguments(line)
         return self._game.descend()
 
     @functools.wraps(Game.reroll)
     def do_reroll(self, line) -> GameState:
-        return self._game.reroll(*parse(line))
+        return self._game.reroll(*_parse(line))
 
     @functools.wraps(Game.retire)
     def do_retire(self, line) -> GameState:
-        no_arguments(line)
+        _no_arguments(line)
         return self._game.retire()
 
     @functools.wraps(Game.retreat)
     def do_retreat(self, line) -> GameState:
-        no_arguments(line)
+        _no_arguments(line)
         return self._game.retreat()
 
     #######################
@@ -152,7 +152,7 @@ class Shell(cmd.Cmd):
     def completedefault(self, text, line, begidx, endidx):
         # Break line into tokens until and starting from present text
         names = self._game.completenames(
-            text=text, head=parse(line[:begidx]), tail=parse(line[begidx:])
+            text=text, head=_parse(line[:begidx]), tail=_parse(line[begidx:])
         )
         if self._undo and "undo".startswith(text):
             names.append("undo")
@@ -254,12 +254,12 @@ class Shell(cmd.Cmd):
         print("""Tools behave identically to a thief.""")
 
 
-def parse(line: str) -> typing.Tuple[str]:
+def _parse(line: str) -> typing.Tuple[str]:
     """Split a line into a tuple of whitespace-delimited tokens."""
     return tuple(line.split())
 
 
-def no_arguments(line):
+def _no_arguments(line):
     """Raise DrollError if line is non-empty."""
     if line:
         raise DrollError("Command accepts no arguments.")

--- a/droll/world.py
+++ b/droll/world.py
@@ -24,7 +24,7 @@ def defeated_dungeon(dungeon: struct.Dungeon) -> bool:
     )
 
 
-def blocking_dragon(dungeon: struct.Dungeon) -> bool:
+def _blocking_dragon(dungeon: struct.Dungeon) -> bool:
     """Is a dragon blocking progress to the next level?"""
     return defeated_monsters(dungeon) and not defeated_dungeon(dungeon)
 
@@ -35,7 +35,7 @@ def exhausted_dungeon(dungeon: struct.Dungeon) -> bool:
     In contrast to defeated_dungeon(...), returns True if chests/etc remain."""
     return (dungeon is None) or (
         (0 == sum(struct.field_values(dungeon)) - dungeon.dragon)
-        and not blocking_dragon(dungeon)
+        and not _blocking_dragon(dungeon)
     )
 
 
@@ -93,7 +93,7 @@ def next_dungeon(
 
     if not defeated_dungeon(world.dungeon):
         try:
-            world = apply_ring(world)
+            world = _apply_ring(world)
         except error.DrollError:
             raise error.DrollError(
                 "Dragon remains but a ring of" " invisibility is not in hand."
@@ -121,16 +121,16 @@ def retire(world: struct.World) -> struct.World:
 
     if not defeated_monsters(world.dungeon):
         try:
-            world = apply_portal(world)
+            world = _apply_portal(world)
         except error.DrollError:
             raise error.DrollError("Monsters remain but no portal in hand.")
-    elif blocking_dragon(world.dungeon):
+    elif _blocking_dragon(world.dungeon):
         # First attempt to use a ring then a portal (because portals are +2)
         try:
-            world = apply_ring(world)
+            world = _apply_ring(world)
         except error.DrollError:
             try:
-                world = apply_portal(world)
+                world = _apply_portal(world)
             except error.DrollError:
                 raise error.DrollError(
                     "Dragon remains but neither a ring of"
@@ -205,9 +205,9 @@ def replace_treasure(world: struct.World, item: str) -> struct.World:
     )
 
 
-def apply_ring(world: struct.World, *, noun: str = "ring") -> struct.World:
+def _apply_ring(world: struct.World, *, noun: str = "ring") -> struct.World:
     """Attempt to use a ring of invisibility towards sneaking past a dragon."""
-    if not blocking_dragon(world.dungeon):
+    if not _blocking_dragon(world.dungeon):
         raise error.DrollError(
             "A dragon must be present to use a {}".format(noun)
         )
@@ -215,7 +215,7 @@ def apply_ring(world: struct.World, *, noun: str = "ring") -> struct.World:
     return replace(world, dungeon=replace(world.dungeon, dragon=0))
 
 
-def apply_portal(world: struct.World, *, noun: str = "portal") -> struct.World:
+def _apply_portal(world: struct.World, *, noun: str = "portal") -> struct.World:
     """Attempt to use a town portal towards retiring to town."""
     # No need to reset monsters/dragon as dungeon will be wholly replaced
     if defeated_dungeon(world.dungeon):

--- a/tests/heroes/test_crusader.py
+++ b/tests/heroes/test_crusader.py
@@ -11,8 +11,8 @@ import droll.struct
 from droll.heroes.crusader import (
     Crusader,
     Paladin,
-    crusader_ability,
-    paladin_ability,
+    _crusader_ability,
+    _paladin_ability,
 )
 
 
@@ -31,7 +31,7 @@ class TestCrusader(unittest.TestCase):
             treasure=droll.struct.Treasure(),
             reserve=droll.struct.Treasure(),
         )
-        result = crusader_ability(world, state.randrange, "ability", "fighter")
+        result = _crusader_ability(world, state.randrange, "ability", "fighter")
         assert result.party.fighter == 2
         assert result.ability is False
 
@@ -48,7 +48,7 @@ class TestCrusader(unittest.TestCase):
             treasure=droll.struct.Treasure(),
             reserve=droll.struct.Treasure(),
         )
-        result = crusader_ability(world, state.randrange, "ability", "cleric")
+        result = _crusader_ability(world, state.randrange, "ability", "cleric")
         assert result.party.cleric == 2
 
     def test_crusader_ability_rejects_invalid_target(self):
@@ -65,7 +65,7 @@ class TestCrusader(unittest.TestCase):
             reserve=droll.struct.Treasure(),
         )
         with self.assertRaises(droll.error.DrollError):
-            crusader_ability(world, state.randrange, "ability", "mage")
+            _crusader_ability(world, state.randrange, "ability", "mage")
 
     def test_crusader_advances_to_paladin(self):
         """Crusader advances to Paladin at 5+ experience."""
@@ -105,7 +105,7 @@ class TestCrusader(unittest.TestCase):
             treasure=droll.struct.Treasure(elixir=1),
             reserve=droll.struct.Treasure(sword=1, talisman=1),
         )
-        result = paladin_ability(world, state.randrange, "ability", "elixir")
+        result = _paladin_ability(world, state.randrange, "ability", "elixir")
         assert sum(droll.struct.field_values(result.dungeon)) == 0
         assert result.treasure.elixir == 0
         assert result.ability is False
@@ -124,7 +124,7 @@ class TestCrusader(unittest.TestCase):
             reserve=droll.struct.Treasure(sword=1, talisman=1, sceptre=1),
         )
         pre_treasure = sum(droll.struct.field_values(world.treasure))
-        result = paladin_ability(world, state.randrange, "ability", "bait")
+        result = _paladin_ability(world, state.randrange, "ability", "bait")
         post_treasure = sum(droll.struct.field_values(result.treasure))
         assert (
             post_treasure == pre_treasure - 1 + 2
@@ -143,7 +143,7 @@ class TestCrusader(unittest.TestCase):
             treasure=droll.struct.Treasure(elixir=1),
             reserve=droll.struct.Treasure(),
         )
-        result = paladin_ability(
+        result = _paladin_ability(
             world, state.randrange, "ability", "elixir", "mage", "thief"
         )
         assert result.party.mage == 1
@@ -163,4 +163,4 @@ class TestCrusader(unittest.TestCase):
             reserve=droll.struct.Treasure(),
         )
         with self.assertRaises(droll.error.DrollError):
-            paladin_ability(world, state.randrange, "ability")
+            _paladin_ability(world, state.randrange, "ability")

--- a/tests/heroes/test_enchantress.py
+++ b/tests/heroes/test_enchantress.py
@@ -11,8 +11,8 @@ import droll.struct
 from droll.heroes.enchantress import (
     Enchantress,
     Beguiler,
-    enchantress_ability,
-    beguiler_ability,
+    _enchantress_ability,
+    _beguiler_ability,
 )
 
 
@@ -31,7 +31,7 @@ class TestEnchantress(unittest.TestCase):
             treasure=droll.struct.Treasure(),
             reserve=droll.struct.Treasure(),
         )
-        result = enchantress_ability(
+        result = _enchantress_ability(
             world, state.randrange, "ability", "goblin"
         )
         assert result.dungeon.goblin == 1
@@ -51,7 +51,7 @@ class TestEnchantress(unittest.TestCase):
             treasure=droll.struct.Treasure(),
             reserve=droll.struct.Treasure(),
         )
-        result = beguiler_ability(
+        result = _beguiler_ability(
             world, state.randrange, "ability", "goblin", "skeleton"
         )
         assert result.dungeon.goblin == 1
@@ -72,7 +72,7 @@ class TestEnchantress(unittest.TestCase):
             reserve=droll.struct.Treasure(),
         )
         with self.assertRaises(droll.error.DrollError):
-            beguiler_ability(world, state.randrange, "ability", "goblin")
+            _beguiler_ability(world, state.randrange, "ability", "goblin")
 
     def test_enchantress_advances_to_beguiler(self):
         """Enchantress advances to Beguiler at 5+ experience."""

--- a/tests/heroes/test_knight.py
+++ b/tests/heroes/test_knight.py
@@ -7,13 +7,13 @@ import random
 
 import droll.dice
 import droll.struct
-from droll.heroes.knight import Knight, DragonSlayer, knight_roll_party
+from droll.heroes.knight import Knight, DragonSlayer, _knight_roll_party
 
 
 def test_knight_roll_party_converts_scrolls():
     """Knight converts scrolls to champions when rolling party."""
     state = random.Random(4)
-    party = knight_roll_party(7, state.randrange)
+    party = _knight_roll_party(7, state.randrange)
     assert party.scroll == 0
     assert sum(droll.struct.field_values(party)) == 7
 

--- a/tests/heroes/test_minstrel.py
+++ b/tests/heroes/test_minstrel.py
@@ -8,7 +8,7 @@ import unittest
 
 import droll.error
 import droll.struct
-from droll.heroes.minstrel import Minstrel, Bard, minstrel_ability
+from droll.heroes.minstrel import Minstrel, Bard, _minstrel_ability
 import droll.action
 
 
@@ -27,7 +27,7 @@ class TestMinstrel(unittest.TestCase):
             treasure=droll.struct.Treasure(),
             reserve=droll.struct.Treasure(),
         )
-        result = minstrel_ability(world, state.randrange, "ability")
+        result = _minstrel_ability(world, state.randrange, "ability")
         assert result.dungeon.dragon == 0
         assert result.dungeon.goblin == 1
         assert result.ability is False
@@ -46,7 +46,7 @@ class TestMinstrel(unittest.TestCase):
             reserve=droll.struct.Treasure(),
         )
         with self.assertRaises(droll.error.DrollError):
-            minstrel_ability(world, state.randrange, "ability", "goblin")
+            _minstrel_ability(world, state.randrange, "ability", "goblin")
 
     def test_minstrel_advances_to_bard(self):
         """Minstrel advances to Bard at 5+ experience."""

--- a/tests/heroes/test_spellsword.py
+++ b/tests/heroes/test_spellsword.py
@@ -11,8 +11,8 @@ import droll.struct
 from droll.heroes.spellsword import (
     Spellsword,
     Battlemage,
-    spellsword_ability,
-    battlemage_ability,
+    _spellsword_ability,
+    _battlemage_ability,
 )
 
 
@@ -31,7 +31,7 @@ class TestSpellsword(unittest.TestCase):
             treasure=droll.struct.Treasure(),
             reserve=droll.struct.Treasure(),
         )
-        result = spellsword_ability(
+        result = _spellsword_ability(
             world, state.randrange, "ability", "fighter"
         )
         assert result.party.fighter == 2
@@ -50,7 +50,7 @@ class TestSpellsword(unittest.TestCase):
             treasure=droll.struct.Treasure(),
             reserve=droll.struct.Treasure(),
         )
-        result = spellsword_ability(world, state.randrange, "ability", "mage")
+        result = _spellsword_ability(world, state.randrange, "ability", "mage")
         assert result.party.mage == 2
 
     def test_spellsword_ability_rejects_invalid_target(self):
@@ -67,7 +67,7 @@ class TestSpellsword(unittest.TestCase):
             reserve=droll.struct.Treasure(),
         )
         with self.assertRaises(droll.error.DrollError):
-            spellsword_ability(world, state.randrange, "ability", "cleric")
+            _spellsword_ability(world, state.randrange, "ability", "cleric")
 
     def test_battlemage_ability_clears_dungeon(self):
         """Battlemage ability clears entire dungeon."""
@@ -84,7 +84,7 @@ class TestSpellsword(unittest.TestCase):
             treasure=droll.struct.Treasure(),
             reserve=droll.struct.Treasure(),
         )
-        result = battlemage_ability(world, state.randrange, "ability")
+        result = _battlemage_ability(world, state.randrange, "ability")
         assert sum(droll.struct.field_values(result.dungeon)) == 0
         assert result.ability is False
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -12,41 +12,41 @@ class TestFormatItems(unittest.TestCase):
 
     def test_empty_party(self):
         party = struct.Party()
-        self.assertEqual(display.format_items(party), "none")
+        self.assertEqual(display._format_items(party), "none")
 
     def test_single_items(self):
         party = struct.Party(fighter=1, cleric=1, mage=1)
-        self.assertEqual(display.format_items(party), "fighter cleric mage")
+        self.assertEqual(display._format_items(party), "fighter cleric mage")
 
     def test_multiple_items(self):
         party = struct.Party(fighter=2, cleric=1, mage=3)
         self.assertEqual(
-            display.format_items(party), "fighter×2 cleric mage×3"
+            display._format_items(party), "fighter×2 cleric mage×3"
         )
 
     def test_dragon_always_shows_count(self):
         dungeon = struct.Dungeon(dragon=1)
-        self.assertEqual(display.format_items(dungeon), "dragon×1")
+        self.assertEqual(display._format_items(dungeon), "dragon×1")
 
     def test_dragon_multiple(self):
         dungeon = struct.Dungeon(goblin=1, dragon=2)
-        self.assertEqual(display.format_items(dungeon), "goblin dragon×2")
+        self.assertEqual(display._format_items(dungeon), "goblin dragon×2")
 
 
 class TestFormatTreasure(unittest.TestCase):
 
     def test_empty_treasure(self):
         treasure = struct.Treasure()
-        self.assertEqual(display.format_treasure(treasure), "none")
+        self.assertEqual(display._format_treasure(treasure), "none")
 
     def test_single_items_alphabetized(self):
         treasure = struct.Treasure(talisman=1, elixir=1)
-        self.assertEqual(display.format_treasure(treasure), "elixir talisman")
+        self.assertEqual(display._format_treasure(treasure), "elixir talisman")
 
     def test_multiple_items_alphabetized(self):
         treasure = struct.Treasure(scale=4, sceptre=1, talisman=1, tools=1)
         self.assertEqual(
-            display.format_treasure(treasure),
+            display._format_treasure(treasure),
             "scale×4 sceptre talisman tools",
         )
 
@@ -56,29 +56,29 @@ class TestFormatAvailable(unittest.TestCase):
     def test_alphabetized(self):
         available = ["retreat", "ability", "reroll"]
         self.assertEqual(
-            display.format_available(available), "ability reroll retreat"
+            display._format_available(available), "ability reroll retreat"
         )
 
     def test_empty(self):
-        self.assertEqual(display.format_available([]), "None")
+        self.assertEqual(display._format_available([]), "None")
 
 
 class TestFormatDungeon(unittest.TestCase):
 
     def test_none_dungeon(self):
-        self.assertIsNone(display.format_dungeon(None))
+        self.assertIsNone(display._format_dungeon(None))
 
     def test_empty_dungeon(self):
         dungeon = struct.Dungeon()
-        self.assertIsNone(display.format_dungeon(dungeon))
+        self.assertIsNone(display._format_dungeon(dungeon))
 
     def test_with_monsters(self):
         dungeon = struct.Dungeon(goblin=1, skeleton=2)
-        self.assertEqual(display.format_dungeon(dungeon), "goblin skeleton×2")
+        self.assertEqual(display._format_dungeon(dungeon), "goblin skeleton×2")
 
     def test_with_dragon(self):
         dungeon = struct.Dungeon(dragon=2)
-        self.assertEqual(display.format_dungeon(dungeon), "dragon×2")
+        self.assertEqual(display._format_dungeon(dungeon), "dragon×2")
 
 
 class TestCompactSummary(unittest.TestCase):


### PR DESCRIPTION
Mark 20 functions as private that are only used within their own
modules:

- display.py: _format_items, _format_treasure, _format_available,
  _format_dungeon
- game.py: _dummy_randrange
- player.py: _partify
- shell.py: _parse, _no_arguments
- world.py: _blocking_dragon, _apply_ring, _apply_portal
- heroes/crusader.py: _crusader_ability, _paladin_ability
- heroes/enchantress.py: _enchantress_ability, _beguiler_ability
- heroes/knight.py: _knight_roll_party, _knight_bait_dragon
- heroes/minstrel.py: _minstrel_ability
- heroes/spellsword.py: _spellsword_ability, _battlemage_ability

Update test imports to reference the renamed private functions.

https://claude.ai/code/session_012PPHCkw6dHy777Efg7vdXN