### PR TITLE
Migrate test suite from pytest to unittest

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -24,8 +24,7 @@ jobs:
     steps:
       - checkout
       - run: python -m pip install .
-      - run: python -m pip install pytest
-      - run: python -m pytest tests/
+      - run: python -m unittest discover -s tests
       - run: droll --help
 
 workflows:

--- a/README.md
+++ b/README.md
@@ -264,10 +264,10 @@ pip install -e .
 
 When not installed, run unit tests with:
 ```
-PYTHONPATH=. python -m pytest ./tests/
+PYTHONPATH=. python -m unittest discover -s tests
 ```
 
 When installed, run unit tests with:
 ```
-python -m pytest
+python -m unittest discover -s tests
 ```

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -17,12 +17,8 @@ classifiers = [
 
 [project.optional-dependencies]
 dev = [
-    "pytest",
     "flake8",
     "Sphinx",
-]
-test = [
-    "pytest",
 ]
 
 [project.scripts]

--- a/tests/heroes/test_knight.py
+++ b/tests/heroes/test_knight.py
@@ -4,50 +4,51 @@
 """Tests for Knight/DragonSlayer hero abilities."""
 
 import random
+import unittest
 
 import droll.dice
 import droll.struct
 from droll.heroes.knight import Knight, DragonSlayer, _knight_roll_party
 
 
-def test_knight_roll_party_converts_scrolls():
-    """Knight converts scrolls to champions when rolling party."""
-    state = random.Random(4)
-    party = _knight_roll_party(7, state.randrange)
-    assert party.scroll == 0
-    assert sum(droll.struct.field_values(party)) == 7
+class TestKnight(unittest.TestCase):
 
+    def test_knight_roll_party_converts_scrolls(self):
+        """Knight converts scrolls to champions when rolling party."""
+        state = random.Random(4)
+        party = _knight_roll_party(7, state.randrange)
+        self.assertEqual(party.scroll, 0)
+        self.assertEqual(sum(droll.struct.field_values(party)), 7)
 
-def test_knight_ability_baits_dragon():
-    """Knight ability converts monsters to dragons without treasure."""
-    state = random.Random(4)
-    world = droll.struct.World(
-        delve=1,
-        depth=1,
-        experience=0,
-        ability=True,
-        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-        party=droll.struct.Party(fighter=2, champion=1),
-        treasure=droll.struct.Treasure(),
-        reserve=droll.struct.Treasure(),
-    )
-    result = Knight.ability(world, state.randrange, "ability")
-    assert result.dungeon.dragon == 3
-    assert result.dungeon.goblin == 0
-    assert result.dungeon.skeleton == 0
-    assert result.ability is False
+    def test_knight_ability_baits_dragon(self):
+        """Knight ability converts monsters to dragons without treasure."""
+        state = random.Random(4)
+        world = droll.struct.World(
+            delve=1,
+            depth=1,
+            experience=0,
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+            party=droll.struct.Party(fighter=2, champion=1),
+            treasure=droll.struct.Treasure(),
+            reserve=droll.struct.Treasure(),
+        )
+        result = Knight.ability(world, state.randrange, "ability")
+        self.assertEqual(result.dungeon.dragon, 3)
+        self.assertEqual(result.dungeon.goblin, 0)
+        self.assertEqual(result.dungeon.skeleton, 0)
+        self.assertFalse(result.ability)
 
-
-def test_dragonslayer_advance():
-    """DragonSlayer stays DragonSlayer after advancing."""
-    world = droll.struct.World(
-        delve=1,
-        depth=0,
-        experience=10,
-        ability=True,
-        dungeon=None,
-        party=None,
-        treasure=droll.struct.Treasure(),
-        reserve=droll.struct.Treasure(),
-    )
-    assert DragonSlayer.advance(world) == DragonSlayer
+    def test_dragonslayer_advance(self):
+        """DragonSlayer stays DragonSlayer after advancing."""
+        world = droll.struct.World(
+            delve=1,
+            depth=0,
+            experience=10,
+            ability=True,
+            dungeon=None,
+            party=None,
+            treasure=droll.struct.Treasure(),
+            reserve=droll.struct.Treasure(),
+        )
+        self.assertEqual(DragonSlayer.advance(world), DragonSlayer)


### PR DESCRIPTION
This PR migrates the test suite from pytest to Python's built-in unittest framework, removing the external pytest dependency.

## Summary
The project's test infrastructure has been refactored to use Python's standard `unittest` module instead of pytest, simplifying dependencies and reducing external tooling requirements.

## Key Changes
- **Test file refactoring**: Converted `tests/heroes/test_knight.py` from pytest-style functions to a `unittest.TestCase` class with methods
  - Replaced `assert` statements with appropriate `unittest` assertions (`assertEqual`, `assertFalse`)
  - Grouped related tests into a single `TestKnight` class
- **Test runner updates**: Updated documentation and CI configuration to use `python -m unittest discover` instead of `pytest`
- **Dependency cleanup**: Removed pytest from both dev and test optional dependencies in `pyproject.toml`
- **CI pipeline update**: Simplified CircleCI configuration to remove pytest installation step

## Implementation Details
- All test logic and assertions remain functionally equivalent
- The unittest discovery mechanism automatically finds and runs tests in the `tests/` directory
- No changes to the actual source code or test coverage

https://claude.ai/code/session_01Xrkb4WofzNwCZgyFR348Wi