### PR TITLE
Fix discard counter not clearing when hero uses ability

### DIFF
--- a/droll/action.py
+++ b/droll/action.py
@@ -22,6 +22,7 @@ def defeat_one(
         game,
         party=decrement_hero(game.party, hero),
         dungeon=decrement_target(game.dungeon, target),
+        regroup=decrement_regroup(game.regroup, hero),
     )
 
 
@@ -40,6 +41,14 @@ def increment_hero(party: struct.Party, hero: str) -> struct.Party:
     if party is None:
         raise error.DrollError("No party currently active.")
     return replace(party, **{hero: getattr(party, hero) + 1})
+
+
+def decrement_regroup(regroup: struct.Regroup, hero: str) -> struct.Regroup:
+    """Decrement the regroup discard counter for hero, if positive."""
+    prior = getattr(regroup.discard, hero, 0)
+    return replace(
+        regroup, discard=replace(regroup.discard, **{hero: max(0, prior - 1)})
+    )
 
 
 def decrement_target(dungeon: struct.Dungeon, target: str) -> struct.Dungeon:
@@ -68,6 +77,7 @@ def defeat_all(
         game,
         party=decrement_hero(game.party, hero),
         dungeon=eliminate_targets(game.dungeon, target),
+        regroup=decrement_regroup(game.regroup, hero),
     )
 
 
@@ -136,6 +146,7 @@ def open_one(
         world.draw_treasure(game, randrange),
         party=decrement_hero(game.party, hero),
         dungeon=decrement_target(game.dungeon, target),
+        regroup=decrement_regroup(game.regroup, hero),
     )
 
 
@@ -159,6 +170,7 @@ def open_all(
         game,
         party=decrement_hero(game.party, hero),
         dungeon=eliminate_targets(game.dungeon, target),
+        regroup=decrement_regroup(game.regroup, hero),
     )
 
 
@@ -181,10 +193,12 @@ def quaff(
     if _after_monsters and not world.defeated_monsters(game.dungeon):
         raise error.DrollError("Monsters must be defeated before quaffing.")
     party = decrement_hero(game.party, hero)
+    regroup = decrement_regroup(game.regroup, hero)
     for revived in revivable:
         party = increment_hero(party, revived)
     return replace(
-        game, party=party, dungeon=eliminate_targets(game.dungeon, target)
+        game, party=party, dungeon=eliminate_targets(game.dungeon, target),
+        regroup=regroup,
     )
 
 
@@ -207,6 +221,7 @@ def reroll(
     return replace(
         game,
         party=decrement_hero(game.party, hero),
+        regroup=decrement_regroup(game.regroup, hero),
         dungeon=struct.Dungeon(
             *tuple(
                 map(
@@ -339,9 +354,11 @@ def defeat_dragon(
 
     # Confirm required number of distinct heroes available
     party = decrement_hero(game.party, hero)
+    regroup = decrement_regroup(game.regroup, hero)
     heroes = [hero]
     for other in others:
         party = decrement_hero(party, other)
+        regroup = decrement_regroup(regroup, other)
         heroes.append(other)
     if not _defeat_dragon_heroes(*heroes):
         raise RuntimeError("Unexpected result from _defeat_dragon_heroes")
@@ -352,6 +369,7 @@ def defeat_dragon(
         experience=game.experience + 1,
         party=party,
         dungeon=eliminate_targets(game.dungeon, target),
+        regroup=regroup,
     )
 
 

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -1060,7 +1060,7 @@ class TestHalfGoblin(unittest.TestCase):
         (delve=3, depth=3, experience=8, dungeon=(potion=1, dragon=2), party=(fighter=1, cleric=1, thief=1, champion=2, scroll=2), regroup=(discard=(thief=1)), treasure=(talisman=1, elixir=1))
         (Chieftain 10) thief potion cleric
 
-        (delve=3, depth=3, experience=8, dungeon=(dragon=2), party=(fighter=1, cleric=2, champion=2, scroll=2), regroup=(discard=(thief=1)), treasure=(talisman=1, elixir=1))
+        (delve=3, depth=3, experience=8, dungeon=(dragon=2), party=(fighter=1, cleric=2, champion=2, scroll=2), regroup=(discard=()), treasure=(talisman=1, elixir=1))
         (Chieftain 10) EOF
         """
         # Drive the game according to the script in the above docstring.

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -7,6 +7,7 @@ from dataclasses import replace
 import random
 import unittest
 
+import droll.action
 import droll.dice
 import droll.error
 import droll.struct
@@ -330,6 +331,41 @@ class TestWorld(unittest.TestCase):
                 fighter=0, cleric=0, mage=0, thief=0, champion=0, scroll=0
             ),
         )
+
+    def test_regroup_discard_after_quaff(self):
+        """Quaffing with a force-discard thief should clear its discard counter.
+
+        A thief gained via Half-Goblin ability (marked for discard) quaffs a
+        potion to revive another thief.  The revived thief should survive
+        regroup."""
+        # Setup: thief from ability (marked for discard), 1 potion available
+        pre = droll.struct.World(
+            delve=1,
+            depth=1,
+            experience=0,
+            ability=False,
+            dungeon=droll.struct.Dungeon(potion=1),
+            party=droll.struct.Party(thief=1),
+            regroup=droll.struct.Regroup(
+                discard=droll.struct.Party(thief=1)
+            ),
+            treasure=droll.struct.Treasure(),
+            reserve=droll.struct.Treasure(),
+        )
+        # Thief quaffs potion, reviving another thief
+        post = droll.action.quaff(
+            pre, None, "thief", "potion", "thief",
+            _after_monsters=False,
+        )
+        # The marked thief was consumed so the discard counter must drop
+        self.assertEqual(post.regroup.discard.thief, 0)
+        self.assertEqual(post.party.thief, 1)
+
+        # After descending the revived thief must survive regroup
+        descended = droll.world.descend(
+            post, droll.dice.roll_dungeon, random.Random(4).randrange,
+        )
+        self.assertEqual(descended.party.thief, 1)
 
     def test_exhausted_dungeon(self):
         """Test exhausted_dungeon detects when no actions remain."""


### PR DESCRIPTION
## Summary
Fixes issue #62 where a hero marked for discard (via the Half-Goblin ability) would retain its discard counter even after being consumed by an action like quaffing a potion. This caused the hero to be incorrectly discarded during regroup even though it was already removed from the party.

## Key Changes
- Added `decrement_regroup()` function to decrement the discard counter for a hero when they are consumed by an action
- Updated all hero-consuming actions to call `decrement_regroup()`:
  - `defeat_one()` and `defeat_all()` - when heroes are defeated
  - `open_one()` and `open_all()` - when heroes open chests
  - `quaff()` - when heroes drink potions
  - `reroll()` - when heroes reroll dungeon
  - `defeat_dragon()` - when heroes fight the dragon
- Added comprehensive test case `test_regroup_discard_after_quaff_issue62()` that reproduces the bug and verifies the fix

## Implementation Details
The `decrement_regroup()` function mirrors the pattern of `decrement_hero()` but operates on the regroup discard counter. It safely decrements the counter only if it's positive, preventing negative values. This ensures that when a hero marked for discard is consumed by any action, its discard counter is properly cleared so it won't be incorrectly removed during the subsequent regroup phase.

https://claude.ai/code/session_014j3arbYRVvTyVrXcodbRBB