### PR TITLE
Rename game parameter to world for consistency

### DIFF
--- a/droll/heroes/crusader.py
+++ b/droll/heroes/crusader.py
@@ -10,12 +10,12 @@ from .. import action
 from .. import dice
 from .. import error
 from .. import struct
-from .. import world
+from ..world import replace_treasure, draw_treasure
 from ..player import Default
 
 
 def _crusader_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -34,12 +34,12 @@ def _crusader_ability(
             "Target {} not one of {}".format(target, _acceptable_targets)
         )
     return action.consume_ability(
-        replace(game, party=action.increment_party(game.party, target))
+        replace(world, party=action.increment_party(world.party, target))
     )
 
 
 def _paladin_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -59,11 +59,11 @@ def _paladin_ability(
         )
 
     # Consume the specified treasure (will error if not possessed)
-    game = world.replace_treasure(game, target)
+    world = replace_treasure(world, target)
 
     # Validate potion/revivable count before making changes
-    if game.dungeon is not None:
-        potion_count = game.dungeon.potion
+    if world.dungeon is not None:
+        potion_count = world.dungeon.potion
         if len(revivable) != potion_count:
             raise error.DrollError(
                 "Require exactly {} heroes to revive for {} potions.".format(
@@ -72,19 +72,19 @@ def _paladin_ability(
             )
 
         # Draw treasure for each chest
-        for _ in range(game.dungeon.chest):
-            game = world.draw_treasure(game, randrange)
+        for _ in range(world.dungeon.chest):
+            world = draw_treasure(world, randrange)
 
         # Revive heroes for each potion
-        party = game.party
+        party = world.party
         for revived in revivable:
             party = action.increment_party(party, revived)
-        game = replace(game, party=party)
+        world = replace(world, party=party)
 
     # Clear the entire dungeon (all monsters, chests, potions, dragons)
-    game = replace(game, dungeon=struct.Dungeon())
+    world = replace(world, dungeon=struct.Dungeon())
 
-    return action.consume_ability(game)
+    return action.consume_ability(world)
 
 
 # Fighter/cleric are interchangeable for dragon defeats

--- a/droll/heroes/enchantress.py
+++ b/droll/heroes/enchantress.py
@@ -10,25 +10,25 @@ from .. import action
 from .. import dice
 from .. import error
 from .. import struct
-from .. import world
+from ..world import defeated_monsters
 from ..player import Default
 
 
 def _enchantress_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
 ) -> struct.World:
     """Transform exactly 1 monster into 1 potion."""
-    dungeon = game.dungeon
+    dungeon = world.dungeon
     dungeon = action.decrement_dungeon(dungeon, target)
     dungeon = action.increment_dungeon(dungeon, "potion")
-    return action.consume_ability(replace(game, dungeon=dungeon))
+    return action.consume_ability(replace(world, dungeon=dungeon))
 
 
 def _beguiler_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -37,19 +37,19 @@ def _beguiler_ability(
     """Transform at most 2 monsters into 1 potion.
 
     Requires transforming 2 monsters when 2+ monsters available."""
-    dungeon = game.dungeon
+    dungeon = world.dungeon
     dungeon = action.decrement_dungeon(dungeon, target)
     if len(extra_targets) > 1:
         raise error.DrollError("At most 2 targets can be transformed.")
     elif len(extra_targets) == 1:
         dungeon = action.decrement_dungeon(dungeon, extra_targets[0])
-    elif not world.defeated_monsters(dungeon):
+    elif not defeated_monsters(dungeon):
         assert len(extra_targets) == 0
         raise error.DrollError("Require 2 targets when 2+ available.")
     else:
         pass
     dungeon = action.increment_dungeon(dungeon, "potion")
-    return action.consume_ability(replace(game, dungeon=dungeon))
+    return action.consume_ability(replace(world, dungeon=dungeon))
 
 
 # Scrolls act as wildcards for dragon defeats

--- a/droll/heroes/halfgoblin.py
+++ b/droll/heroes/halfgoblin.py
@@ -15,7 +15,7 @@ from ..player import Default
 
 
 def _halfgoblin_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -26,21 +26,21 @@ def _halfgoblin_ability(
         raise error.DrollError("Ability can only target 1 goblin")
 
     # Change 1 goblin into 1 thief
-    dungeon = action.decrement_dungeon(game.dungeon, "goblin")
-    party = action.increment_party(game.party, "thief")
+    dungeon = action.decrement_dungeon(world.dungeon, "goblin")
+    party = action.increment_party(world.party, "thief")
 
     # Discarding if unused at the next regroup phase
-    regroup = game.regroup
+    regroup = world.regroup
     discard = regroup.discard
     discard = replace(discard, thief=getattr(discard, "thief", 0) + 1)
     regroup = replace(regroup, discard=discard)
 
-    game = replace(game, dungeon=dungeon, party=party, regroup=regroup)
-    return action.consume_ability(game)
+    world = replace(world, dungeon=dungeon, party=party, regroup=regroup)
+    return action.consume_ability(world)
 
 
 def _chieftain_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -55,9 +55,9 @@ def _chieftain_ability(
     if len(extra_targets) > 1:
         raise error.DrollError("At most 2 targets can be changed.")
 
-    dungeon = game.dungeon
-    party = game.party
-    regroup = game.regroup
+    dungeon = world.dungeon
+    party = world.party
+    regroup = world.regroup
     discard = regroup.discard
 
     # Always transform 2 when 2 are available
@@ -73,8 +73,8 @@ def _chieftain_ability(
         discard = replace(discard, thief=getattr(discard, "thief", 0) + 1)
 
     regroup = replace(regroup, discard=discard)
-    game = replace(game, dungeon=dungeon, party=party, regroup=regroup)
-    return action.consume_ability(game)
+    world = replace(world, dungeon=dungeon, party=party, regroup=regroup)
+    return action.consume_ability(world)
 
 
 # You may open chests and quaff potions at any time during the monster phase

--- a/droll/heroes/minstrel.py
+++ b/droll/heroes/minstrel.py
@@ -14,7 +14,7 @@ from ..player import Default
 
 
 def _minstrel_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -24,7 +24,7 @@ def _minstrel_ability(
     if target != "dragon":
         raise error.DrollError("Can only discard {} dice".format(target))
     return action.consume_ability(
-        replace(game, dungeon=action.eliminate_dungeon(game.dungeon, target))
+        replace(world, dungeon=action.eliminate_dungeon(world.dungeon, target))
     )
 
 

--- a/droll/heroes/occultist.py
+++ b/droll/heroes/occultist.py
@@ -14,7 +14,7 @@ from ..player import Default
 
 
 def _occultist_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -25,21 +25,21 @@ def _occultist_ability(
         raise error.DrollError("Ability can only target 1 skeleton")
 
     # Change 1 skeleton into 1 fighter
-    dungeon = action.decrement_dungeon(game.dungeon, "skeleton")
-    party = action.increment_party(game.party, "fighter")
+    dungeon = action.decrement_dungeon(world.dungeon, "skeleton")
+    party = action.increment_party(world.party, "fighter")
 
     # Discarding if unused at the next regroup phase
-    regroup = game.regroup
+    regroup = world.regroup
     discard = regroup.discard
     discard = replace(discard, fighter=getattr(discard, "fighter", 0) + 1)
     regroup = replace(regroup, discard=discard)
 
-    game = replace(game, dungeon=dungeon, party=party, regroup=regroup)
-    return action.consume_ability(game)
+    world = replace(world, dungeon=dungeon, party=party, regroup=regroup)
+    return action.consume_ability(world)
 
 
 def _necromancer_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -54,9 +54,9 @@ def _necromancer_ability(
     if len(extra_targets) > 1:
         raise error.DrollError("At most 2 targets can be changed.")
 
-    dungeon = game.dungeon
-    party = game.party
-    regroup = game.regroup
+    dungeon = world.dungeon
+    party = world.party
+    regroup = world.regroup
     discard = regroup.discard
 
     # Always transform 2 when 2 are available
@@ -72,8 +72,8 @@ def _necromancer_ability(
         discard = replace(discard, fighter=getattr(discard, "fighter", 0) + 1)
 
     regroup = replace(regroup, discard=discard)
-    game = replace(game, dungeon=dungeon, party=party, regroup=regroup)
-    return action.consume_ability(game)
+    world = replace(world, dungeon=dungeon, party=party, regroup=regroup)
+    return action.consume_ability(world)
 
 
 # Cleric/mage are interchangeable for dragon defeats

--- a/droll/heroes/spellsword.py
+++ b/droll/heroes/spellsword.py
@@ -14,7 +14,7 @@ from ..player import Default
 
 
 def _spellsword_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -33,7 +33,7 @@ def _spellsword_ability(
             "Target {} not one of {}".format(target, _acceptable_targets)
         )
     return action.consume_ability(
-        replace(game, party=action.increment_party(game.party, target))
+        replace(world, party=action.increment_party(world.party, target))
     )
 
 
@@ -48,7 +48,7 @@ _spellsword_defeat_dragon = functools.partial(
 
 
 def _battlemage_ability(
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: typing.Optional[str] = None,
@@ -60,7 +60,7 @@ def _battlemage_ability(
     """Discard all monsters, chests, potions, and dice in the dragon's lair."""
     if target is not None:
         raise error.DrollError("No targets accepted for {}".format(noun))
-    return action.consume_ability(replace(game, dungeon=struct.Dungeon()))
+    return action.consume_ability(replace(world, dungeon=struct.Dungeon()))
 
 
 # Defined in terms of Default, not Spellsword, to permit advance(...) closure

--- a/droll/player.py
+++ b/droll/player.py
@@ -10,7 +10,7 @@ from . import action
 from . import dice
 from . import error
 from . import struct
-from . import world
+from .world import replace_treasure
 
 # Rules governing a default player lacking any special abilities.
 # Effectively, this data is one large, dense dispatch table.
@@ -93,13 +93,13 @@ Default = struct.Player(
 
 def apply(
     player: struct.Player,
-    game: struct.World,
+    world: struct.World,
     randrange: dice.RandRange,
     noun: str,
     target: str = None,
     *additional,
 ) -> struct.World:
-    """Apply noun to target within game, returning a new version.
+    """Apply noun to target within world, returning a new version.
 
     Processes hero-like artifacts (i.e. not rings/portals/scales).
     Varargs 'additional' permits passing more required information.
@@ -119,19 +119,19 @@ def apply(
     if noun in {"ability", "bait", "elixir"}:
         try:
             action_ = getattr(player, noun)  # Else name collision w/ import
-            return action_(game, randrange, noun, target, *additional)
+            return action_(world, randrange, noun, target, *additional)
         except AttributeError as cause:
             raise error.DrollError(str(cause)) from cause
 
     # Many treasures behave exactly like party members, so
     # convert into party members prior to action invocation.
-    prior_treasure = game.treasure
-    game = replace(
-        game,
+    prior_treasure = world.treasure
+    world = replace(
+        world,
         party=replace(
-            game.party,
+            world.party,
             **{
-                hero: getattr(game.party, hero)
+                hero: getattr(world.party, hero)
                 + getattr(prior_treasure, artifact)
                 for hero, artifact in struct.field_items(player.artifacts)
                 if artifact is not None
@@ -143,7 +143,7 @@ def apply(
         # Re-roll is a special verb that always overrides scroll settings
         # found within struct.Player so, e.g., Beguiler can re-roll dice
         # with "reroll skeleton" because "scroll skeleton" kills a skeleton.
-        game = action.reroll(game, randrange, "scroll", target, *additional)
+        world = action.reroll(world, randrange, "scroll", target, *additional)
     else:
         # Apply a hero (possibly phantom per above) to some targets.
         try:
@@ -153,17 +153,17 @@ def apply(
                     '"{}" requires some target'.format(noun)
                 )
             action_ = getattr(action_, target)
-            game = action_(game, randrange, noun, target, *additional)
+            world = action_(world, randrange, noun, target, *additional)
         except AttributeError as cause:
             raise error.DrollError(str(cause)) from cause
 
     # Undo the prior transformation by subtracting prior_treasure.
-    game = replace(
-        game,
+    world = replace(
+        world,
         party=replace(
-            game.party,
+            world.party,
             **{
-                hero: getattr(game.party, hero)
+                hero: getattr(world.party, hero)
                 - getattr(prior_treasure, artifact)
                 for hero, artifact in struct.field_items(player.artifacts)
                 if artifact is not None
@@ -172,16 +172,16 @@ def apply(
     )
 
     # Consume treasure equivalent to any hero which has gone negative.
-    for hero, quantity in struct.field_items(game.party):
+    for hero, quantity in struct.field_items(world.party):
         if quantity >= 0:
             continue
         for _ in range(-min(0, quantity)):
-            game = world.replace_treasure(
-                game, getattr(player.artifacts, hero)
+            world = replace_treasure(
+                world, getattr(player.artifacts, hero)
             )
-        game = replace(game, party=replace(game.party, **{hero: 0}))
+        world = replace(world, party=replace(world.party, **{hero: 0}))
 
-    return game
+    return world
 
 
 def _partify(token: str, artifacts: struct.Party):
@@ -205,14 +205,14 @@ TREASURE_NO_COMMAND = frozenset({"portal", "ring", "scale"})
 
 
 def complete(
-    game: struct.World, tokens: typing.Sequence[str], text: str, position: int
+    world: struct.World, tokens: typing.Sequence[str], text: str, position: int
 ) -> typing.Sequence[str]:
     """Possible completions for text with position among (partial) tokens."""
     # First compute candidate completions independent of observed text
     if position == 0:
         candidates = {
             key
-            for source in (game.party, game.treasure)
+            for source in (world.party, world.treasure)
             if source is not None
             for key, value in struct.field_items(source)
             if value and key not in TREASURE_NO_COMMAND
@@ -225,7 +225,7 @@ def complete(
     elif position == 1:
         candidates = {
             key
-            for source in (game.party, game.dungeon)
+            for source in (world.party, world.dungeon)
             if source is not None
             for key, value in struct.field_items(source)
             if value

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -10,10 +10,10 @@ import unittest
 from droll import error, player, struct, world
 
 
-def _remove_monsters(game: struct.World) -> struct.World:
+def _remove_monsters(world: struct.World) -> struct.World:
     """Remove all monsters from dungeon for testing treasure interactions."""
     return replace(
-        game, dungeon=replace(game.dungeon, goblin=0, skeleton=0, ooze=0)
+        world, dungeon=replace(world.dungeon, goblin=0, skeleton=0, ooze=0)
     )
 
 


### PR DESCRIPTION
## Summary
This PR standardizes parameter naming across the codebase by renaming the `game` parameter to `world` in function signatures and their implementations. This improves consistency and clarity, as the parameter represents a `struct.World` object.

## Key Changes
- **droll/player.py**: Renamed `game` parameter to `world` in `apply()` and `complete()` functions, and updated all references throughout
- **droll/heroes/crusader.py**: Renamed `game` parameter to `world` in `_crusader_ability()` and `_paladin_ability()` functions
- **droll/heroes/halfgoblin.py**: Renamed `game` parameter to `world` in `_halfgoblin_ability()` and `_chieftain_ability()` functions
- **droll/heroes/occultist.py**: Renamed `game` parameter to `world` in `_occultist_ability()` and `_necromancer_ability()` functions
- **droll/heroes/enchantress.py**: Renamed `game` parameter to `world` in `_enchantress_ability()` and `_beguiler_ability()` functions
- **droll/heroes/spellsword.py**: Renamed `game` parameter to `world` in `_spellsword_ability()` and `_battlemage_ability()` functions
- **droll/heroes/minstrel.py**: Renamed `game` parameter to `world` in `_minstrel_ability()` function
- **tests/test_player.py**: Renamed `game` parameter to `world` in `_remove_monsters()` helper function

## Implementation Details
- Updated import statements in `droll/player.py` and `droll/heroes/crusader.py` to use direct function imports (`from .world import replace_treasure`) instead of module imports, reducing namespace pollution
- All internal variable references were updated to maintain consistency (e.g., `game.party` → `world.party`, `game.dungeon` → `world.dungeon`)
- No functional changes; this is purely a refactoring for improved code clarity and consistency

https://claude.ai/code/session_01QR7zhBSMPU7Umph8U2esy8