### PR TITLE
Display "None" for empty dungeons instead of omitting them

### DIFF
--- a/droll/display.py
+++ b/droll/display.py
@@ -69,8 +69,8 @@ def _format_party(
 def _format_dungeon(
     dungeon: typing.Optional[struct.Dungeon],
 ) -> typing.Optional[str]:
-    """Format dungeon contents, returning None if empty."""
-    if dungeon is None or not any(struct.field_values(dungeon)):
+    """Format dungeon contents, returning None only if no dungeon exists."""
+    if dungeon is None:
         return None
     return _format_items(dungeon)
 

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -80,9 +80,9 @@ class TestFormatDungeon(unittest.TestCase):
         self.assertIsNone(display._format_dungeon(None))
 
     def test_empty_dungeon(self):
-        """Test formatting empty dungeon returns None."""
+        """Test formatting empty dungeon returns 'None' string."""
         dungeon = struct.Dungeon()
-        self.assertIsNone(display._format_dungeon(dungeon))
+        self.assertEqual(display._format_dungeon(dungeon), "None")
 
     def test_with_monsters(self):
         """Test formatting dungeon with monsters."""
@@ -169,8 +169,8 @@ class TestCompactSummary(unittest.TestCase):
             # Content should start at same column for all lines
             self.assertGreaterEqual(content_start, 13)
 
-    def test_dungeon_not_shown_when_empty(self):
-        """Test that empty dungeons are not displayed in the summary."""
+    def test_dungeon_shown_when_empty(self):
+        """Test that empty dungeons display 'Dungeon: None' in the summary."""
         world = struct.World(
             delve=1,
             depth=1,
@@ -183,7 +183,10 @@ class TestCompactSummary(unittest.TestCase):
         result = display.compact_summary(
             world, "Knight", 0, ["ability", "descend", "retire"]
         )
-        self.assertNotIn("Dungeon:", result)
+        lines = result.split("\n")
+        self.assertEqual(len(lines), 5)
+        self.assertIn("Dungeon:", lines[4])
+        self.assertIn("None", lines[4])
 
     def test_cleared_level_10(self):
         """Test compact summary after clearing dungeon level 10."""
@@ -202,7 +205,9 @@ class TestCompactSummary(unittest.TestCase):
         self.assertIn("scale×4 sceptre talisman tools", lines[1])
         self.assertIn("retire", lines[2])
         self.assertIn("champion scroll×2", lines[3])
-        self.assertEqual(len(lines), 4)  # No Dungeon line
+        self.assertIn("Dungeon:", lines[4])
+        self.assertIn("None", lines[4])
+        self.assertEqual(len(lines), 5)
 
     def test_ending_state(self):
         """After final delve, Available should show 'None'."""


### PR DESCRIPTION
## Summary
Changed the dungeon display behavior to show "Dungeon: None" for empty dungeons instead of omitting the dungeon line entirely from the summary output.

## Key Changes
- Modified `_format_dungeon()` to only return `None` when no dungeon object exists, rather than when the dungeon is empty
- Empty dungeons now return the string `"None"` instead of `None`, making them visible in the display
- Updated test expectations to verify that empty dungeons display as "Dungeon: None" on a dedicated line
- Updated docstring to clarify the new behavior

## Implementation Details
- The logic change in `_format_dungeon()` removes the check for empty dungeon contents (`not any(struct.field_values(dungeon))`)
- This ensures that empty `struct.Dungeon()` objects are formatted and displayed rather than being filtered out
- Tests now verify that the dungeon line appears at a consistent position (line 4, 0-indexed) in the compact summary output
- The change affects both the empty dungeon case and the cleared level 10 case, both now showing 5 lines instead of 4

https://claude.ai/code/session_01MAicp9Ty1yGSGGbJyM1m3e