### PR TITLE
Add allow_dragon parameter to reroll function

### DIFF
--- a/droll/action.py
+++ b/droll/action.py
@@ -230,7 +230,11 @@ def quaff(
 
 
 def reroll(
-    world: struct.World, randrange: dice.RandRange, hero: str, *targets
+    world: struct.World,
+    randrange: dice.RandRange,
+    hero: str,
+    *targets,
+    allow_dragon: bool = False,
 ) -> struct.World:
     """Update world after hero re-rolls some number of targets."""
     if not targets:
@@ -239,7 +243,7 @@ def reroll(
     # Remove requested target from the dungeon
     reduced = world.dungeon
     for target in targets:
-        if target == "dragon":
+        if not allow_dragon and target == "dragon":
             raise error.DrollError("{} cannot be re-rolled".format(target))
         reduced = decrement_dungeon(reduced, target)
 


### PR DESCRIPTION
## Summary
Added an optional `allow_dragon` parameter to the `reroll()` function to conditionally permit re-rolling the dragon target.

## Key Changes
- Added `allow_dragon: bool = False` parameter to the `reroll()` function signature
- Updated the dragon validation logic to check `not allow_dragon and target == "dragon"` instead of just `target == "dragon"`
- Reformatted function parameters to follow multi-line style conventions

## Implementation Details
The change maintains backward compatibility by defaulting `allow_dragon` to `False`, preserving the existing behavior where dragons cannot be re-rolled by default. When `allow_dragon=True` is explicitly passed, the function will allow dragon targets to be re-rolled without raising a `DrollError`.

https://claude.ai/code/session_014LQ76hnBys871udMrgdrxV