### PR TITLE
Return regroup state from roll_party functions

### DIFF
--- a/droll/dice.py
+++ b/droll/dice.py
@@ -18,7 +18,7 @@ __all__ = (
 
 RandRange = typing.Callable[[int, int], int]
 RollDungeon = typing.Callable[[int, RandRange], struct.Dungeon]
-RollParty = typing.Callable[[int, RandRange], struct.Party]
+RollParty = typing.Callable[[int, RandRange], typing.Tuple[struct.Party, struct.Regroup]]
 
 
 def _roll(
@@ -43,8 +43,13 @@ def roll_dungeon(dice: int, randrange: RandRange) -> struct.Dungeon:
     )
 
 
-def roll_party(dice: int, randrange: RandRange) -> struct.Party:
+def roll_party(
+    dice: int, randrange: RandRange
+) -> typing.Tuple[struct.Party, struct.Regroup]:
     """Roll a new Party using given number of dice.
 
     Any implementation must follow type signature of RollParty."""
-    return struct.Party(*_roll(dice, 0, len(fields(struct.Party)), randrange))
+    return (
+        struct.Party(*_roll(dice, 0, len(fields(struct.Party)), randrange)),
+        struct.Regroup(),
+    )

--- a/droll/heroes/knight.py
+++ b/droll/heroes/knight.py
@@ -4,6 +4,7 @@
 """Hero definitions for Knight advancing to DragonSlayer."""
 from dataclasses import replace
 import functools
+import typing
 
 from .. import action
 from .. import dice
@@ -16,11 +17,14 @@ __all__ = (
 )
 
 
-def _knight_roll_party(count: int, randrange: dice.RandRange) -> struct.Party:
+def _knight_roll_party(
+    count: int, randrange: dice.RandRange
+) -> typing.Tuple[struct.Party, struct.Regroup]:
     """Roll a new Party, changing all Scrolls into Champions."""
-    default = dice.roll_party(dice=count, randrange=randrange)
-    return replace(
-        default, scroll=0, champion=default.champion + default.scroll
+    default, regroup = dice.roll_party(dice=count, randrange=randrange)
+    return (
+        replace(default, scroll=0, champion=default.champion + default.scroll),
+        regroup,
     )
 
 

--- a/droll/world.py
+++ b/droll/world.py
@@ -91,14 +91,15 @@ def delve(
     Argument roll_party can be dice.roll_party but other choices okay."""
     if world.delve >= 3:
         raise error.DrollError("At most three delves are permitted.")
+    party, regroup = roll_party(_party_dice, randrange)
     return replace(
         world,
         delve=(world.delve if world.delve else 0) + 1,
         depth=0,
         ability=True,
-        regroup=struct.Regroup(),
+        regroup=regroup,
         dungeon=None,
-        party=roll_party(_party_dice, randrange),
+        party=party,
     )
 
 

--- a/tests/heroes/test_knight.py
+++ b/tests/heroes/test_knight.py
@@ -19,9 +19,10 @@ class TestKnight(unittest.TestCase):
     def test_knight_roll_party_converts_scrolls(self):
         """Knight converts scrolls to champions when rolling party."""
         randrange = random.Random(4).randrange
-        party = _knight_roll_party(7, randrange)
+        party, regroup = _knight_roll_party(7, randrange)
         self.assertEqual(party.scroll, 0)
         self.assertEqual(sum(droll.struct.field_values(party)), 7)
+        self.assertEqual(regroup, droll.struct.Regroup())
 
     def test_knight_ability_baits_dragon(self):
         """Knight ability converts monsters to dragons without treasure."""


### PR DESCRIPTION
## Summary
Updated the `roll_party` function signature to return both a `Party` and `Regroup` object as a tuple, allowing callers to receive the regroup state directly from party rolling operations.

## Key Changes
- Modified `dice.roll_party()` to return `Tuple[struct.Party, struct.Regroup]` instead of just `struct.Party`
- Updated `_knight_roll_party()` in the Knight hero module to match the new signature and return both party and regroup
- Updated `world.delve()` to unpack the tuple returned by `roll_party()` and use the returned regroup state instead of creating a new empty one
- Updated the `RollParty` type alias in `dice.py` to reflect the new return type
- Updated corresponding test in `test_knight.py` to unpack and verify both return values

## Implementation Details
- The `roll_party()` function now returns a tuple containing the rolled `Party` and an empty `Regroup()` object
- This change allows hero implementations (like Knight) to customize the regroup state when rolling parties
- The `world.delve()` function now receives the regroup state from the roll_party call, enabling future customization of regroup behavior based on party rolling logic

https://claude.ai/code/session_015Ugx8e85G1nnYoTjS7wgKj