### PR TITLE
Fix unpacking of roll_party return value in reroll action

### DIFF
--- a/droll/action.py
+++ b/droll/action.py
@@ -321,7 +321,7 @@ def reroll(
 
     # Re-roll party dice and add to anything left fixed
     if party_targets:
-        increased = dice.roll_party(dice=len(party_targets), randrange=randrange)
+        increased, _ = dice.roll_party(dice=len(party_targets), randrange=randrange)
         party = struct.Party(
             *map(
                 operator.add,


### PR DESCRIPTION
## Summary
Fixed a bug in the `reroll` function where the return value from `dice.roll_party()` was not being properly unpacked.

## Changes
- Updated the `reroll` function to unpack both return values from `dice.roll_party()`, assigning the second value to an unused variable (`_`)
- This prevents a ValueError that would occur when trying to assign a tuple to a single variable

## Details
The `dice.roll_party()` function returns a tuple of two values, but the code was attempting to assign it to a single variable `increased`. This change properly unpacks the tuple, capturing the first value in `increased` and discarding the second value with the underscore convention.

https://claude.ai/code/session_01U4NUHAaLkSATfm5k8xF9PQ