### PR TITLE
Add Mercenary hero with advancement to Commander

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,12 +34,12 @@ said, I've done such things in neither 2018 nor 2026.
 ```
 $ droll --help
 usage: droll [-h] [--seed N]
-             {Default,Crusader,Enchantress,Knight,Minstrel,Occultist,Spellsword}
+             {Default,Crusader,Enchantress,Knight,Mercenary,Minstrel,Occultist,Spellsword}
 
 Command-line version of droll.
 
 positional arguments:
-  {Default,Crusader,Enchantress,HalfGoblin,Knight,Minstrel,Occultist,Spellsword}
+  {Default,Crusader,Enchantress,HalfGoblin,Knight,Mercenary,Minstrel,Occultist,Spellsword}
                         Select the hero for this game.
 
 options:

--- a/droll/heroes/__init__.py
+++ b/droll/heroes/__init__.py
@@ -11,6 +11,7 @@ from .crusader import Crusader, Paladin
 from .enchantress import Beguiler, Enchantress
 from .halfgoblin import Chieftain, HalfGoblin
 from .knight import Knight, DragonSlayer
+from .mercenary import Mercenary, Commander
 from .minstrel import Minstrel, Bard
 from .occultist import Occultist, Necromancer
 from .spellsword import Spellsword, Battlemage
@@ -21,11 +22,13 @@ __all__ = (
     Battlemage.name,
     Beguiler.name,
     Chieftain.name,
+    Commander.name,
     Crusader.name,
     DragonSlayer.name,
     Enchantress.name,
     HalfGoblin.name,
     Knight.name,
+    Mercenary.name,
     Minstrel.name,
     Necromancer.name,
     Occultist.name,
@@ -41,6 +44,7 @@ AVAILABLE = MappingProxyType(
             (Enchantress.name, Enchantress),
             (HalfGoblin.name, HalfGoblin),
             (Knight.name, Knight),
+            (Mercenary.name, Mercenary),
             (Minstrel.name, Minstrel),
             (Occultist.name, Occultist),
             (Spellsword.name, Spellsword),

--- a/droll/heroes/mercenary.py
+++ b/droll/heroes/mercenary.py
@@ -1,0 +1,97 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Hero definitions for Mercenary advancing to Commander."""
+from dataclasses import replace
+import functools
+import typing
+
+from .. import action
+from .. import dice
+from .. import error
+from .. import struct
+from ..player import Default
+
+__all__ = (
+    "Commander",
+    "Mercenary",
+)
+
+
+def _mercenary_roll_party(
+    count: int, randrange: dice.RandRange
+) -> typing.Tuple[struct.Party, struct.Regroup]:
+    """Roll a new Party, adding one bonus scroll discarded at next regroup."""
+    party, regroup = dice.roll_party(dice=count, randrange=randrange)
+    return (
+        replace(party, scroll=party.scroll + 1),
+        replace(regroup, discard=replace(regroup.discard, scroll=1)),
+    )
+
+
+def _mercenary_ability(
+    world: struct.World,
+    randrange: dice.RandRange,
+    noun: str,
+    target: typing.Optional[str] = None,
+    *additional,
+) -> struct.World:
+    """Defeat any 2 monsters."""
+    if target is None:
+        raise error.DrollError("Must specify target for {}.".format(noun))
+    # Temporarily add a champion to be consumed by defeat_one_plus_additional
+    world = replace(
+        world, party=action.increment_party(world.party, "champion")
+    )
+    world = action.defeat_one_plus_additional(
+        world, randrange, "champion", target, *additional
+    )
+    return action.consume_ability(world)
+
+
+def _commander_ability(
+    world: struct.World,
+    randrange: dice.RandRange,
+    noun: str,
+    target: typing.Optional[str] = None,
+    *additional,
+) -> struct.World:
+    """Rerolls any number of Party and Dungeon dice."""
+    if target is None:
+        raise error.DrollError(
+            "Must specify at least one target to reroll for {}.".format(noun)
+        )
+    # Temporarily add a scroll to be consumed by reroll
+    world = replace(world, party=action.increment_party(world.party, "scroll"))
+    world = action.reroll(
+        world, randrange, "scroll", target, *additional, allow_dragon=True
+    )
+    return action.consume_ability(world)
+
+
+# Defined in terms of Default, not Mercenary, to permit advance(...) closure
+Commander = replace(
+    Default,
+    name="Commander",
+    ability=_commander_ability,
+    advance=(lambda _: Commander),
+    roll=replace(Default.roll, party=_mercenary_roll_party),
+    party=replace(
+        Default.party,
+        fighter=replace(
+            Default.party.fighter,
+            goblin=action.defeat_all_plus_additional,
+            skeleton=action.defeat_one_plus_additional,
+            ooze=action.defeat_one_plus_additional,
+        ),
+    ),
+)
+
+# Defined after Commander to permit advance(...) closure
+Mercenary = replace(
+    Default,
+    name="Mercenary",
+    ability=_mercenary_ability,
+    advance=(lambda world: Mercenary if world.experience < 5 else Commander),
+    roll=replace(Default.roll, party=_mercenary_roll_party),
+)

--- a/droll/shell.py
+++ b/droll/shell.py
@@ -291,6 +291,16 @@ class Shell(cmd.Cmd):
             reroll skeleton goblin      # ...but 'reroll' forces re-rolling"""
         )
 
+    def help_reroll(self):
+        """Display help for the reroll command."""
+        print(self.do_reroll.__doc__)
+        print(
+            """
+            reroll goblin skeleton      # Re-roll a goblin and a skeleton
+            reroll fighter              # Re-roll one fighter into new party die
+            """
+        )
+
     def help_scale(self):
         """Display help for scale treasures."""
         print("""Scales are treasures that score 2 points per pair.""")

--- a/tests/heroes/test_mercenary.py
+++ b/tests/heroes/test_mercenary.py
@@ -1,0 +1,139 @@
+# This Source Code Form is subject to the terms of the Mozilla Public
+# License, v. 2.0. If a copy of the MPL was not distributed with this
+# file, You can obtain one at http://mozilla.org/MPL/2.0/.
+"""Tests for Mercenary/Commander hero abilities."""
+
+import random
+import unittest
+
+import droll.error
+import droll.struct
+from droll.heroes.mercenary import (
+    Commander,
+    Mercenary,
+    _commander_ability,
+    _mercenary_ability,
+    _mercenary_roll_party,
+)
+
+# Known to be unused because it would raise NameErrors on any use
+_UNUSED = object()
+
+
+class TestMercenary(unittest.TestCase):
+
+    def test_mercenary_roll_party_adds_bonus_scroll(self):
+        """Mercenary roll adds one bonus scroll with regroup discard."""
+        randrange = random.Random(4).randrange
+        party, regroup = _mercenary_roll_party(7, randrange)
+        self.assertEqual(sum(droll.struct.field_values(party)), 8)
+        self.assertEqual(regroup.discard.scroll, 1)
+
+    def test_mercenary_ability_defeats_two_monsters(self):
+        """Mercenary ability defeats 2 different monsters."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
+            party=droll.struct.Party(fighter=2),
+        )
+        result = _mercenary_ability(
+            world, _UNUSED, "ability", "goblin", "skeleton"
+        )
+        self.assertEqual(result.dungeon.goblin, 0)
+        self.assertEqual(result.dungeon.skeleton, 0)
+        self.assertEqual(result.party.fighter, 2)
+        self.assertFalse(result.ability)
+
+    def test_mercenary_ability_defeats_one_when_only_one(self):
+        """Mercenary ability defeats 1 monster when only 1 exists."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=1),
+            party=droll.struct.Party(fighter=2),
+        )
+        result = _mercenary_ability(world, _UNUSED, "ability", "goblin")
+        self.assertEqual(result.dungeon.goblin, 0)
+        self.assertFalse(result.ability)
+
+    def test_mercenary_ability_requires_target(self):
+        """Mercenary ability requires at least one target."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=1),
+            party=droll.struct.Party(fighter=2),
+        )
+        with self.assertRaises(droll.error.DrollError):
+            _mercenary_ability(world, _UNUSED, "ability")
+
+    def test_commander_ability_rerolls_dungeon_dice(self):
+        """Commander ability rerolls dungeon dice."""
+        randrange = random.Random(7).randrange
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+            party=droll.struct.Party(fighter=2),
+        )
+        result = _commander_ability(
+            world, randrange, "ability", "goblin", "goblin"
+        )
+        self.assertFalse(result.ability)
+        self.assertEqual(result.party.fighter, 2)
+
+    def test_commander_ability_rerolls_dragon(self):
+        """Commander ability can reroll dragon dice."""
+        randrange = random.Random(7).randrange
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(dragon=3),
+            party=droll.struct.Party(fighter=2),
+        )
+        result = _commander_ability(
+            world, randrange, "ability", "dragon", "dragon", "dragon"
+        )
+        self.assertFalse(result.ability)
+
+    def test_commander_ability_requires_target(self):
+        """Commander ability requires at least one target."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=1),
+            party=droll.struct.Party(fighter=2),
+        )
+        with self.assertRaises(droll.error.DrollError):
+            _commander_ability(world, _UNUSED, "ability")
+
+    def test_commander_fighter_defeats_goblin_plus_additional(self):
+        """Commander fighters defeat all goblins plus one additional."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+            party=droll.struct.Party(fighter=2),
+        )
+        result = Commander.party.fighter.goblin(
+            world, _UNUSED, "fighter", "goblin", "skeleton"
+        )
+        self.assertEqual(result.dungeon.goblin, 0)
+        self.assertEqual(result.dungeon.skeleton, 0)
+        self.assertEqual(result.party.fighter, 1)
+
+    def test_commander_fighter_defeats_skeleton_plus_additional(self):
+        """Commander fighters defeat one skeleton plus one additional."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(skeleton=2, ooze=1),
+            party=droll.struct.Party(fighter=2),
+        )
+        result = Commander.party.fighter.skeleton(
+            world, _UNUSED, "fighter", "skeleton", "ooze"
+        )
+        self.assertEqual(result.dungeon.skeleton, 1)
+        self.assertEqual(result.dungeon.ooze, 0)
+        self.assertEqual(result.party.fighter, 1)
+
+    def test_mercenary_advances_to_commander(self):
+        """Mercenary advances to Commander at 5+ experience."""
+        low_xp = droll.struct.World(experience=4)
+        high_xp = droll.struct.World(experience=5)
+        self.assertEqual(Mercenary.advance(low_xp), Mercenary)
+        self.assertEqual(Mercenary.advance(high_xp), Commander)
+        self.assertEqual(Commander.advance(high_xp), Commander)


### PR DESCRIPTION
## Summary
This PR introduces two new hero classes to the game: **Mercenary** and **Commander**. Mercenary is a starting hero that advances to Commander upon reaching 5+ experience points.

## Key Changes

- **New Hero Classes**: 
  - `Mercenary`: A starting hero with the ability to defeat any 2 monsters
  - `Commander`: An advanced form of Mercenary with the ability to reroll any number of party and dungeon dice
  
- **Shared Mechanics**:
  - Both heroes roll an extra bonus scroll during party rolls, which is discarded at the next regroup
  - Both use the same party rolling function (`_mercenary_roll_party`)

- **Commander-Specific Features**:
  - Fighters gain special bonuses against specific monsters:
    - Defeat all goblins plus one additional monster
    - Defeat one skeleton plus one additional monster
    - Defeat one ooze plus one additional monster
  - Ability to reroll dungeon dice including dragons

- **Module Integration**:
  - Added `mercenary.py` module with hero definitions
  - Exported `Mercenary` and `Commander` from `droll.heroes`
  - Updated hero registry to include both new heroes
  - Added help text for the `reroll` command in shell
  - Updated README with new hero options

## Implementation Details

- Heroes are defined using the `replace()` function to extend the `Default` hero template
- The `advance()` method uses a closure to enable Mercenary's progression to Commander at 5+ experience
- Mercenary's ability uses a temporary champion to leverage existing `defeat_one_plus_additional` action
- Commander's ability uses a temporary scroll to leverage existing `reroll` action with `allow_dragon=True`
- Comprehensive test coverage with 10 test cases covering all major functionality

https://claude.ai/code/session_01Jb5EEKpzCxdXV7vi7cogdA