### PR TITLE
Add tests for game-rule enforcement and hero input validation

### DIFF
--- a/tests/heroes/test_crusader.py
+++ b/tests/heroes/test_crusader.py
@@ -101,6 +101,26 @@ class TestCrusader(unittest.TestCase):
         self.assertEqual(result.party.mage, 1)
         self.assertEqual(result.party.thief, 1)
 
+    def test_crusader_ability_default_target(self):
+        """Crusader ability defaults to 'cleric' (first sorted) when no target."""
+        world = droll.struct.World(
+            ability=True,
+            party=droll.struct.Party(fighter=1, cleric=1),
+        )
+        result = _crusader_ability(world, _UNUSED, "ability")
+        self.assertEqual(result.party.cleric, 2)
+
+    def test_paladin_ability_wrong_revivable_count(self):
+        """Paladin ability rejects wrong number of heroes for potions."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(potion=2),
+            party=droll.struct.Party(fighter=1),
+            treasure=droll.struct.Treasure(elixir=1),
+        )
+        with self.assertRaises(droll.error.DrollError):
+            _paladin_ability(world, _UNUSED, "ability", "elixir", "mage")
+
     def test_paladin_ability_requires_treasure(self):
         """Paladin ability fails without specifying treasure."""
         world = droll.struct.World(

--- a/tests/heroes/test_enchantress.py
+++ b/tests/heroes/test_enchantress.py
@@ -56,6 +56,18 @@ class TestEnchantress(unittest.TestCase):
         with self.assertRaises(droll.error.DrollError):
             _beguiler_ability(world, _UNUSED, "ability", "goblin")
 
+    def test_beguiler_rejects_too_many_targets(self):
+        """Beguiler rejects more than 2 targets."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+            party=droll.struct.Party(fighter=1),
+        )
+        with self.assertRaises(droll.error.DrollError):
+            _beguiler_ability(
+                world, _UNUSED, "ability", "goblin", "skeleton", "goblin"
+            )
+
     def test_enchantress_advances_to_beguiler(self):
         """Enchantress advances to Beguiler at 5+ experience."""
         low_xp = droll.struct.World(experience=4)

--- a/tests/heroes/test_halfgoblin.py
+++ b/tests/heroes/test_halfgoblin.py
@@ -67,6 +67,34 @@ class TestHalfGoblin(unittest.TestCase):
         self.assertEqual(result.dungeon.skeleton, 1)
         self.assertEqual(result.party.thief, 1)
 
+    def test_halfgoblin_rejects_non_goblin(self):
+        """HalfGoblin ability rejects non-goblin targets."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
+            party=droll.struct.Party(fighter=1),
+        )
+        with self.assertRaises(droll.error.DrollError):
+            _halfgoblin_ability(world, _UNUSED, "ability", "skeleton")
+
+    def test_chieftain_rejects_non_goblin_targets(self):
+        """Chieftain rejects non-goblin target, extra target, and excess targets."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+            party=droll.struct.Party(fighter=1),
+        )
+        with self.assertRaises(droll.error.DrollError):
+            _chieftain_ability(world, _UNUSED, "ability", "skeleton")
+        with self.assertRaises(droll.error.DrollError):
+            _chieftain_ability(
+                world, _UNUSED, "ability", "goblin", "skeleton"
+            )
+        with self.assertRaises(droll.error.DrollError):
+            _chieftain_ability(
+                world, _UNUSED, "ability", "goblin", "goblin", "goblin"
+            )
+
     def test_halfgoblin_advances_to_chieftain(self):
         """HalfGoblin advances to Chieftain at 5+ experience."""
         low_xp = droll.struct.World(experience=4)

--- a/tests/heroes/test_occultist.py
+++ b/tests/heroes/test_occultist.py
@@ -120,6 +120,18 @@ class TestOccultist(unittest.TestCase):
                 world, _UNUSED, "ability", "skeleton", "goblin"
             )
 
+    def test_necromancer_rejects_too_many_targets(self):
+        """Necromancer rejects more than 2 targets."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(skeleton=3),
+            party=droll.struct.Party(cleric=1),
+        )
+        with self.assertRaises(droll.error.DrollError):
+            _necromancer_ability(
+                world, _UNUSED, "ability", "skeleton", "skeleton", "skeleton"
+            )
+
     def test_occultist_advances_to_necromancer(self):
         """Occultist advances to Necromancer at 5+ experience."""
         low_xp = droll.struct.World(experience=4)

--- a/tests/heroes/test_spellsword.py
+++ b/tests/heroes/test_spellsword.py
@@ -62,6 +62,25 @@ class TestSpellsword(unittest.TestCase):
         self.assertEqual(sum(droll.struct.field_values(result.dungeon)), 0)
         self.assertFalse(result.ability)
 
+    def test_spellsword_ability_default_target(self):
+        """Spellsword ability defaults to 'fighter' (first sorted) when no target."""
+        world = droll.struct.World(
+            ability=True,
+            party=droll.struct.Party(fighter=1, mage=1),
+        )
+        result = _spellsword_ability(world, _UNUSED, "ability")
+        self.assertEqual(result.party.fighter, 2)
+
+    def test_battlemage_ability_rejects_target(self):
+        """Battlemage ability rejects any target argument."""
+        world = droll.struct.World(
+            ability=True,
+            dungeon=droll.struct.Dungeon(goblin=1),
+            party=droll.struct.Party(fighter=1, mage=1),
+        )
+        with self.assertRaises(droll.error.DrollError):
+            _battlemage_ability(world, _UNUSED, "ability", "goblin")
+
     def test_spellsword_advances_to_battlemage(self):
         """Spellsword advances to Battlemage at 5+ experience."""
         low_xp = droll.struct.World(experience=4)

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -385,6 +385,97 @@ class TestRerollParty(unittest.TestCase):
             )
 
 
+class TestActionErrorPaths(unittest.TestCase):
+    """Tests for game-rule error paths in the action module."""
+
+    def test_decrement_dungeon_zero_target(self):
+        """Cannot decrement a dungeon target that is already zero."""
+        dungeon = struct.Dungeon(goblin=0, skeleton=1)
+        with self.assertRaises(DrollError):
+            action.decrement_dungeon(dungeon, "goblin")
+
+    def test_eliminate_dungeon_zero_target(self):
+        """Cannot eliminate a dungeon target that is already zero."""
+        dungeon = struct.Dungeon(goblin=0, skeleton=1)
+        with self.assertRaises(DrollError):
+            action.eliminate_dungeon(dungeon, "goblin")
+
+    def test_open_one_before_monsters_defeated(self):
+        """Cannot open chests while monsters remain."""
+        w = struct.World(
+            dungeon=struct.Dungeon(goblin=1, chest=1),
+            party=struct.Party(thief=1),
+        )
+        with self.assertRaises(DrollError):
+            action.open_one(w, _UNUSED, "thief", "chest")
+
+    def test_open_all_before_monsters_defeated(self):
+        """Cannot open all chests while monsters remain."""
+        w = struct.World(
+            dungeon=struct.Dungeon(goblin=1, chest=2),
+            party=struct.Party(thief=1),
+        )
+        with self.assertRaises(DrollError):
+            action.open_all(w, _UNUSED, "thief", "chest")
+
+    def test_quaff_no_potions(self):
+        """Cannot quaff when no potions are available."""
+        w = struct.World(
+            dungeon=struct.Dungeon(potion=0),
+            party=struct.Party(fighter=1),
+        )
+        with self.assertRaises(DrollError):
+            action.quaff(w, _UNUSED, "fighter", "potion")
+
+    def test_reroll_no_targets(self):
+        """Reroll requires at least one target."""
+        w = struct.World(
+            dungeon=struct.Dungeon(goblin=1),
+            party=struct.Party(scroll=1),
+        )
+        with self.assertRaises(DrollError):
+            action.reroll(w, _UNUSED, "scroll")
+
+    def test_reroll_dragon_disallowed(self):
+        """Cannot reroll dragon dice by default."""
+        w = struct.World(
+            dungeon=struct.Dungeon(dragon=3),
+            party=struct.Party(scroll=1),
+        )
+        with self.assertRaises(DrollError):
+            action.reroll(w, _UNUSED, "scroll", "dragon")
+
+    def test_interchangeable_disallowed_hero(self):
+        """Scrolls cannot defeat a dragon via interchangeable heroes."""
+        with self.assertRaises(DrollError):
+            action.defeat_dragon_heroes_interchangeable(
+                "scroll", "fighter", "thief",
+                _interchangeable={"fighter", "mage"},
+            )
+
+    def test_bait_non_dragon_target(self):
+        """Bait can only target dragons."""
+        w = struct.World(
+            dungeon=struct.Dungeon(goblin=1),
+            party=struct.Party(fighter=1),
+            treasure=struct.Treasure(bait=1),
+        )
+        with self.assertRaises(DrollError):
+            action.bait_dragon(w, _UNUSED, "bait", "goblin")
+
+    def test_consume_ability_when_unavailable(self):
+        """Cannot consume ability that is already used."""
+        w = struct.World(ability=False)
+        with self.assertRaises(DrollError):
+            action.consume_ability(w)
+
+    def test_nop_ability_rejects_target(self):
+        """Default nop ability rejects any target."""
+        w = struct.World(ability=True)
+        with self.assertRaises(DrollError):
+            action.nop_ability(w, _UNUSED, "ability", "fighter")
+
+
 class TestRegroupDiscard(unittest.TestCase):
 
     def test_regroup_discard_after_quaff(self):

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -107,6 +107,39 @@ class TestGame(unittest.TestCase):
         self.assertEqual(g._world.depth, 0)
         self.assertIsNotNone(g._world.party)
 
+    def test_completenames(self):
+        """completenames returns contextual completions including retire/retreat."""
+        g = Game(random=random.Random(4), player=Default)
+        g.descend()
+
+        # With monsters: retreat is possible, retire is not
+        g._world = replace(g._world, dungeon=struct.Dungeon(goblin=1))
+        names = g.completenames(text="", head=[], tail=[])
+        self.assertIn("ability", names)
+        self.assertIn("retreat", names)
+        self.assertNotIn("retire", names)
+        # Hero-related completions appear (dungeon not exhausted)
+        self.assertTrue(
+            any(n not in ("ability", "descend", "retire", "retreat") for n in names)
+        )
+
+        # With cleared dungeon: retire is possible
+        g._world = replace(g._world, dungeon=struct.Dungeon())
+        names = g.completenames(text="", head=[], tail=[])
+        self.assertIn("retire", names)
+
+    def test_completedefault(self):
+        """completedefault delegates to player.complete."""
+        g = Game(random=random.Random(4), player=Default)
+        g.descend()
+        g._world = replace(
+            g._world,
+            dungeon=struct.Dungeon(goblin=1),
+            party=struct.Party(fighter=1),
+        )
+        results = g.completedefault(text="fi", head=[], tail=[])
+        self.assertIn("fighter", results)
+
     def test_next_delve_returns_stop_after_three(self):
         """Game returns STOP when no more delves remain."""
         g = Game(random=random.Random(4), player=Default)

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -134,6 +134,11 @@ class TestPlayer(unittest.TestCase):
         self.assertEqual(game.dungeon.potion, 0)
         self.assertEqual(game.party.fighter, 4)
 
+    def test_apply_hero_without_target(self):
+        """Applying a hero without a target raises DrollError."""
+        with self.assertRaises(error.DrollError):
+            player.apply(player.Default, self.game, None, "fighter")
+
     def test_scroll_reroll(self):
         """Test scroll used to reroll dungeon dice."""
         # Consumed by canned_sequence just below


### PR DESCRIPTION
Covers error paths that enforce real game rules (opening chests before
defeating monsters, quaffing empty potions, rerolling dragons, baiting
non-dragons, ability re-use) and hero ability input validation (wrong
targets, default target selection, excess targets). Also tests
Game.completenames/completedefault tab-completion logic and
player.apply with missing target. Coverage 92% -> 95%.

https://claude.ai/code/session_01PMKxysz8PbYAkHjDxhY68f