### PR TITLE
Shorten exception raise sites via direct DrollError import

### DIFF
--- a/droll/action.py
+++ b/droll/action.py
@@ -10,7 +10,7 @@ from dataclasses import replace
 import operator
 
 from . import dice
-from . import error
+from .error import DrollError
 from . import struct
 from .world import defeated_monsters, draw_treasure, replace_treasure
 
@@ -58,10 +58,10 @@ def defeat_one(
 def _decrement_party(party: struct.Party, hero: str) -> struct.Party:
     """Decrease the count of the specified hero type by one."""
     if party is None:
-        raise error.DrollError("No party currently active.")
+        raise DrollError("No party currently active.")
     prior_heroes = getattr(party, hero)
     if not prior_heroes:
-        raise error.DrollError(f"At least 1 {hero} required.")
+        raise DrollError(f"At least 1 {hero} required.")
     return replace(party, **{hero: prior_heroes - 1})
 
 
@@ -77,24 +77,24 @@ def _decrement_regroup(regroup: struct.Regroup, hero: str) -> struct.Regroup:
 def decrement_dungeon(dungeon: struct.Dungeon, target: str) -> struct.Dungeon:
     """Decrease the count of the specified target type by one."""
     if dungeon is None:
-        raise error.DrollError("No dungeon currently active.")
+        raise DrollError("No dungeon currently active.")
     prior_targets = getattr(dungeon, target)
     if not prior_targets:
-        raise error.DrollError(f"At least 1 {target} required.")
+        raise DrollError(f"At least 1 {target} required.")
     return replace(dungeon, **{target: prior_targets - 1})
 
 
 def increment_party(party: struct.Party, hero: str) -> struct.Party:
     """Increase the count of the specified hero type by one."""
     if party is None:
-        raise error.DrollError("No party currently active.")
+        raise DrollError("No party currently active.")
     return replace(party, **{hero: getattr(party, hero) + 1})
 
 
 def increment_dungeon(dungeon: struct.Dungeon, target: str) -> struct.Dungeon:
     """Increase the count of the specified target type by one."""
     if dungeon is None:
-        raise error.DrollError("No dungeon currently active.")
+        raise DrollError("No dungeon currently active.")
     prior_targets = getattr(dungeon, target, 0)
     return replace(dungeon, **{target: prior_targets + 1})
 
@@ -120,17 +120,17 @@ def _defeat_plus_additional(
     """After the initial defeat, optionally defeat one additional monster."""
     if defeated_monsters(world.dungeon):
         if additional:
-            raise error.DrollError(
+            raise DrollError(
                 f"Additional {additional} given but no monsters left."
             )
         return world
 
     if not additional:
-        raise error.DrollError(
+        raise DrollError(
             "Monsters remain so one additional target required."
         )
     if len(additional) > 1:
-        raise error.DrollError(
+        raise DrollError(
             f"Only one additional target allowed but {len(additional)} provided."
         )
 
@@ -173,10 +173,10 @@ def defeat_one_plus_additional(
 def eliminate_dungeon(dungeon: struct.Dungeon, target: str) -> struct.Dungeon:
     """Remove all targets of the specified type from the dungeon."""
     if dungeon is None:
-        raise error.DrollError("No dungeon currently active.")
+        raise DrollError("No dungeon currently active.")
     prior_targets = getattr(dungeon, target)
     if not prior_targets:
-        raise error.DrollError(f"At least 1 {target} required.")
+        raise DrollError(f"At least 1 {target} required.")
     return replace(dungeon, **{target: 0})
 
 
@@ -190,7 +190,7 @@ def open_one(
 ) -> struct.World:
     """Update world after hero opens exactly one chest."""
     if _after_monsters and not defeated_monsters(world.dungeon):
-        raise error.DrollError("Monsters must be defeated before opening.")
+        raise DrollError("Monsters must be defeated before opening.")
     return replace(
         draw_treasure(world, randrange),
         dungeon=decrement_dungeon(world.dungeon, target),
@@ -209,10 +209,10 @@ def open_all(
 ) -> struct.World:
     """Update world after hero opens all chests."""
     if _after_monsters and not defeated_monsters(world.dungeon):
-        raise error.DrollError("Monsters must be defeated before opening.")
+        raise DrollError("Monsters must be defeated before opening.")
     howmany = getattr(world.dungeon, target)
     if not howmany:
-        raise error.DrollError(f"At least 1 {target} required.")
+        raise DrollError(f"At least 1 {target} required.")
     for _ in range(howmany):
         world = draw_treasure(world, randrange)
     return replace(
@@ -236,11 +236,11 @@ def quaff(
     Unlike {defend,open}_{one,all}(...), heroes to revive are arguments."""
     howmany = getattr(world.dungeon, target)
     if not howmany:
-        raise error.DrollError(f"At least 1 {target} required.")
+        raise DrollError(f"At least 1 {target} required.")
     if len(revivable) != howmany:
-        raise error.DrollError(f"Exactly {howmany} heroes to revive required.")
+        raise DrollError(f"Exactly {howmany} heroes to revive required.")
     if _after_monsters and not defeated_monsters(world.dungeon):
-        raise error.DrollError("Monsters must be defeated before quaffing.")
+        raise DrollError("Monsters must be defeated before quaffing.")
     party = _decrement_party(world.party, hero)
     for revived in revivable:
         party = increment_party(party, revived)
@@ -261,13 +261,13 @@ def _classify_reroll_targets(
     party_targets = []
     for target in dungeon_or_party:
         if not allow_dragon and target == "dragon":
-            raise error.DrollError(f"{target} cannot be re-rolled.")
+            raise DrollError(f"{target} cannot be re-rolled.")
         if target in _DUNGEON_NAMES:
             dungeon_targets.append(target)
         elif target in _PARTY_NAMES:
             party_targets.append(target)
         else:
-            raise error.DrollError(f"{target} cannot be re-rolled.")
+            raise DrollError(f"{target} cannot be re-rolled.")
     return dungeon_targets, party_targets
 
 
@@ -280,7 +280,7 @@ def reroll(
 ) -> struct.World:
     """Update world after hero re-rolls some number of dungeon or party dice."""
     if not dungeon_or_party:
-        raise error.DrollError("At least 1 reroll target required.")
+        raise DrollError("At least 1 reroll target required.")
 
     dungeon_targets, party_targets = _classify_reroll_targets(
         dungeon_or_party, allow_dragon
@@ -325,15 +325,15 @@ def defeat_dragon_heroes(
     """
     hero_set = {*heroes}
     if hero_set & {*_disallowed_heroes}:
-        raise error.DrollError(
+        raise DrollError(
             f"Heroes {_disallowed_heroes} cannot defeat a dragon."
         )
     if len(heroes) != _distinct_heroes:
-        raise error.DrollError(
+        raise DrollError(
             f"Exactly {_distinct_heroes} heroes required."
         )
     if len(hero_set) != _distinct_heroes:
-        raise error.DrollError(
+        raise DrollError(
             f"The {_distinct_heroes} heroes must all be distinct."
         )
     return True
@@ -350,7 +350,7 @@ def defeat_dragon_heroes_wildcard(
     """
     distinct_heroes = _distinct_heroes  # Allow mutation saving original
     if len(heroes) != distinct_heroes:
-        raise error.DrollError(
+        raise DrollError(
             f"Exactly {distinct_heroes} heroes required."
         )
 
@@ -360,7 +360,7 @@ def defeat_dragon_heroes_wildcard(
     heroes = non_wildcards
 
     if len({*heroes}) != distinct_heroes:
-        raise error.DrollError(  # Error message uses original count
+        raise DrollError(  # Error message uses original count
             f"The {_distinct_heroes} heroes must all be distinct."
         )
     return True
@@ -377,11 +377,11 @@ def defeat_dragon_heroes_interchangeable(
     Specifically, in the case when 'A may be used as B and B may be used as A'.
     """
     if {*heroes} & {*_disallowed_heroes}:
-        raise error.DrollError(
+        raise DrollError(
             f"Heroes {_disallowed_heroes} cannot defeat a dragon."
         )
     if len(heroes) != _required_heroes:
-        raise error.DrollError(
+        raise DrollError(
             f"Exactly {_required_heroes} heroes required."
         )
 
@@ -402,7 +402,7 @@ def defeat_dragon_heroes_interchangeable(
     # Sum the number of distinct heroes observed after these coercions.
     distinct_heroes = sum(counter.values())
     if distinct_heroes != _required_heroes:
-        raise error.DrollError(f"Heroes {heroes} not sufficiently distinct.")
+        raise DrollError(f"Heroes {heroes} not sufficiently distinct.")
 
     return True
 
@@ -421,11 +421,11 @@ def defeat_dragon(
     Additional required heroes are specified within variable-length others."""
     # Simple prerequisites for attempting to defeat the dragon
     if world.dungeon.dragon < _min_dragon_length:
-        raise error.DrollError(
+        raise DrollError(
             f"Enemy {target} only comes at length {_min_dragon_length}."
         )
     if not defeated_monsters(world.dungeon):
-        raise error.DrollError(
+        raise DrollError(
             f"Enemy {target} only comes after all others defeated."
         )
 
@@ -463,7 +463,7 @@ def bait_dragon(
     # Confirm well-formed request optionally containing a target
     target = "dragon" if target is None else target
     if target != "dragon":
-        raise error.DrollError(f"Cannot {noun} a {target}.")
+        raise DrollError(f"Cannot {noun} a {target}.")
     if _require_treasure:
         world = replace_treasure(world, noun)
 
@@ -475,7 +475,7 @@ def bait_dragon(
         else 0
     )
     if not new_targets:
-        raise error.DrollError(
+        raise DrollError(
             f"At least 1 of {_enemies} required for '{noun}'."
         )
 
@@ -533,7 +533,7 @@ def convert_dungeon_to_party(
 def consume_ability(world: struct.World):
     """Mark the hero's special ability as used."""
     if not world.ability:
-        raise error.DrollError("Ability not available.")
+        raise DrollError("Ability not available.")
     return replace(world, ability=False)
 
 
@@ -545,5 +545,5 @@ def nop_ability(
 ) -> struct.World:
     """No special ability available (though its consumption is tracked)"""
     if target is not None:
-        raise error.DrollError(f"No targets accepted for {noun}.")
+        raise DrollError(f"No targets accepted for {noun}.")
     return consume_ability(world)

--- a/droll/game.py
+++ b/droll/game.py
@@ -9,7 +9,7 @@ import copy
 import enum
 from random import Random
 
-from . import error
+from .error import DrollError
 from . import player
 from . import struct
 from . import world
@@ -80,7 +80,7 @@ class Game:
             # Permit the player to advance to higher abilities
             self._player = self._player.advance(self._world)
             return GameState.PLAY
-        except error.DrollError:
+        except DrollError:
             return GameState.STOP
 
     @property
@@ -170,7 +170,7 @@ class Game:
             try:
                 action()
                 possible.append(name)
-            except error.DrollError:
+            except DrollError:
                 pass
         return possible
 

--- a/droll/heroes/crusader.py
+++ b/droll/heroes/crusader.py
@@ -9,7 +9,7 @@ import functools
 
 from .. import action
 from .. import dice
-from .. import error
+from ..error import DrollError
 from .. import struct
 from ..world import replace_treasure, draw_treasure
 from ..player import Default
@@ -36,7 +36,7 @@ def _crusader_ability(
     if target is None:
         target = next(iter(sorted(_acceptable_targets)))
     if target not in _acceptable_targets:
-        raise error.DrollError(
+        raise DrollError(
             f"Target {target} not one of {_acceptable_targets}."
         )
     return action.consume_ability(
@@ -57,7 +57,7 @@ def _paladin_ability(
     For each potion, add one argument for the hero to review."""
     # Validate that a treasure was specified
     if target is None:
-        raise error.DrollError(
+        raise DrollError(
             f"Treasure to consume required for {noun}."
         )
 
@@ -68,7 +68,7 @@ def _paladin_ability(
     if world.dungeon is not None:
         potion_count = world.dungeon.potion
         if len(revivable) != potion_count:
-            raise error.DrollError(
+            raise DrollError(
                 f"Exactly {potion_count} heroes to revive required."
             )
 

--- a/droll/heroes/enchantress.py
+++ b/droll/heroes/enchantress.py
@@ -9,7 +9,7 @@ import functools
 
 from .. import action
 from .. import dice
-from .. import error
+from ..error import DrollError
 from .. import struct
 from ..world import defeated_monsters
 from ..player import Default
@@ -46,12 +46,12 @@ def _beguiler_ability(
     dungeon = world.dungeon
     dungeon = action.decrement_dungeon(dungeon, target)
     if len(extra_targets) > 1:
-        raise error.DrollError("At most 2 targets can be changed.")
+        raise DrollError("At most 2 targets can be changed.")
     elif len(extra_targets) == 1:
         dungeon = action.decrement_dungeon(dungeon, extra_targets[0])
     elif not defeated_monsters(dungeon):
         assert len(extra_targets) == 0
-        raise error.DrollError("2 targets required when 2+ available.")
+        raise DrollError("2 targets required when 2+ available.")
     dungeon = action.increment_dungeon(dungeon, "potion")
     return action.consume_ability(replace(world, dungeon=dungeon))
 

--- a/droll/heroes/halfgoblin.py
+++ b/droll/heroes/halfgoblin.py
@@ -9,7 +9,7 @@ import functools
 
 from .. import action
 from .. import dice
-from .. import error
+from ..error import DrollError
 from .. import struct
 from .. import world
 from ..player import Default
@@ -28,7 +28,7 @@ def _halfgoblin_ability(
 ) -> struct.World:
     """Transform 1 goblin into 1 thief, discarding it at next regroup."""
     if target and target != "goblin":
-        raise error.DrollError("Ability can only target 1 goblin.")
+        raise DrollError("Ability can only target 1 goblin.")
     world = action.convert_dungeon_to_party(
         world, source="goblin", destination="thief", max_count=1
     )
@@ -44,11 +44,11 @@ def _chieftain_ability(
 ) -> struct.World:
     """Transform 2 goblins into thieves, discarding them at next regroup."""
     if target and target != "goblin":
-        raise error.DrollError("Ability can only target goblins.")
+        raise DrollError("Ability can only target goblins.")
     if extra_targets and extra_targets[0] != "goblin":
-        raise error.DrollError("Ability can only target goblins.")
+        raise DrollError("Ability can only target goblins.")
     if len(extra_targets) > 1:
-        raise error.DrollError("At most 2 targets can be changed.")
+        raise DrollError("At most 2 targets can be changed.")
     world = action.convert_dungeon_to_party(
         world, source="goblin", destination="thief", max_count=2
     )

--- a/droll/heroes/mercenary.py
+++ b/droll/heroes/mercenary.py
@@ -9,7 +9,7 @@ import functools
 
 from .. import action
 from .. import dice
-from .. import error
+from ..error import DrollError
 from .. import struct
 from ..player import Default
 
@@ -39,7 +39,7 @@ def _mercenary_ability(
 ) -> struct.World:
     """Defeat any 2 monsters."""
     if target is None:
-        raise error.DrollError(f"At least 1 target required for {noun}.")
+        raise DrollError(f"At least 1 target required for {noun}.")
     # Temporarily add a champion to be consumed by defeat_one_plus_additional
     world = replace(
         world, party=action.increment_party(world.party, "champion")
@@ -59,7 +59,7 @@ def _commander_ability(
 ) -> struct.World:
     """Rerolls any number of Party and Dungeon dice."""
     if target is None:
-        raise error.DrollError(
+        raise DrollError(
             f"At least 1 reroll target required for {noun}."
         )
     # Temporarily add a scroll to be consumed by reroll

--- a/droll/heroes/minstrel.py
+++ b/droll/heroes/minstrel.py
@@ -9,7 +9,7 @@ import functools
 
 from .. import action
 from .. import dice
-from .. import error
+from ..error import DrollError
 from .. import struct
 from ..player import Default
 
@@ -28,7 +28,7 @@ def _minstrel_ability(
     """Discard all dragon dice."""
     target = "dragon" if target is None else target
     if target != "dragon":
-        raise error.DrollError(f"Can only discard dragon dice, not {target}.")
+        raise DrollError(f"Can only discard dragon dice, not {target}.")
     return action.consume_ability(
         replace(world, dungeon=action.eliminate_dungeon(world.dungeon, target))
     )

--- a/droll/heroes/occultist.py
+++ b/droll/heroes/occultist.py
@@ -9,7 +9,7 @@ import functools
 
 from .. import action
 from .. import dice
-from .. import error
+from ..error import DrollError
 from .. import struct
 from ..player import Default
 
@@ -27,7 +27,7 @@ def _occultist_ability(
 ) -> struct.World:
     """Transform 1 skeleton into 1 fighter, discarding it at next regroup."""
     if target and target != "skeleton":
-        raise error.DrollError("Ability can only target 1 skeleton.")
+        raise DrollError("Ability can only target 1 skeleton.")
     world = action.convert_dungeon_to_party(
         world, source="skeleton", destination="fighter", max_count=1
     )
@@ -43,11 +43,11 @@ def _necromancer_ability(
 ) -> struct.World:
     """Transform 2 skeletons into fighters, discarding them at next regroup."""
     if target and target != "skeleton":
-        raise error.DrollError("Ability can only target skeletons.")
+        raise DrollError("Ability can only target skeletons.")
     if extra_targets and extra_targets[0] != "skeleton":
-        raise error.DrollError("Ability can only target skeletons.")
+        raise DrollError("Ability can only target skeletons.")
     if len(extra_targets) > 1:
-        raise error.DrollError("At most 2 targets can be changed.")
+        raise DrollError("At most 2 targets can be changed.")
     world = action.convert_dungeon_to_party(
         world, source="skeleton", destination="fighter", max_count=2
     )

--- a/droll/heroes/spellsword.py
+++ b/droll/heroes/spellsword.py
@@ -9,7 +9,7 @@ import functools
 
 from .. import action
 from .. import dice
-from .. import error
+from ..error import DrollError
 from .. import struct
 from ..player import Default
 
@@ -35,7 +35,7 @@ def _spellsword_ability(
     if target is None:
         target = next(iter(sorted(_acceptable_targets)))
     if target not in _acceptable_targets:
-        raise error.DrollError(
+        raise DrollError(
             f"Target {target} not one of {_acceptable_targets}."
         )
     return action.consume_ability(
@@ -65,7 +65,7 @@ def _battlemage_ability(
 ) -> struct.World:
     """Discard all monsters, chests, potions, and dice in the dragon's lair."""
     if target is not None:
-        raise error.DrollError(f"No targets accepted for {noun}.")
+        raise DrollError(f"No targets accepted for {noun}.")
     return action.consume_ability(replace(world, dungeon=struct.Dungeon()))
 
 

--- a/droll/player.py
+++ b/droll/player.py
@@ -9,7 +9,7 @@ from dataclasses import replace
 
 from . import action
 from . import dice
-from . import error
+from .error import DrollError
 from . import struct
 from .world import replace_treasure
 
@@ -135,9 +135,9 @@ def apply(
 
     # One-off handling of some treasures, with error wrapping to aid usability
     if noun == "portal":
-        raise error.DrollError('To use a portal, directly "retire".')
+        raise DrollError('To use a portal, directly "retire".')
     if noun == "ring":
-        raise error.DrollError(
+        raise DrollError(
             'To use a ring, directly "descend" or "retire".'
         )
     if noun in {"ability", "bait", "elixir"}:
@@ -145,7 +145,7 @@ def apply(
             action_ = getattr(player, noun)
             return action_(world, randrange, noun, target, *additional)
         except AttributeError as cause:
-            raise error.DrollError(str(cause)) from cause
+            raise DrollError(str(cause)) from cause
 
     # Temporarily inflate party with treasure-as-hero counts
     prior_treasure = world.treasure
@@ -158,11 +158,11 @@ def apply(
         try:
             action_ = getattr(player.party, noun)
             if target is None:
-                raise error.DrollError(f'"{noun}" requires a target.')
+                raise DrollError(f'"{noun}" requires a target.')
             action_ = getattr(action_, target)
             world = action_(world, randrange, noun, target, *additional)
         except (AttributeError, TypeError) as cause:
-            raise error.DrollError(str(cause)) from cause
+            raise DrollError(str(cause)) from cause
 
     # Undo phantom inflation, then consume treasure for any artifacts spent
     world = _adjust_phantom_treasures(world, player.artifacts, prior_treasure, -1)

--- a/droll/world.py
+++ b/droll/world.py
@@ -6,7 +6,7 @@
 from dataclasses import replace
 
 from . import dice
-from . import error
+from .error import DrollError
 from . import struct
 
 __all__ = (
@@ -90,7 +90,7 @@ def delve(
 
     Argument roll_party can be dice.roll_party but other choices okay."""
     if world.delve >= 3:
-        raise error.DrollError("At most 3 delves permitted.")
+        raise DrollError("At most 3 delves permitted.")
     party, regroup = roll_party(_party_dice, randrange)
     return replace(
         world,
@@ -135,13 +135,13 @@ def descend(
     Argument roll_dungeon can be dice.roll_dungeon but other choices okay
     Adheres to the specified number of dice available in the world."""
     if not defeated_monsters(world.dungeon):
-        raise error.DrollError("Monsters must be defeated before descending.")
+        raise DrollError("Monsters must be defeated before descending.")
 
     if not defeated_dungeon(world.dungeon):
         try:
             world = _apply_ring(world)
-        except error.DrollError:
-            raise error.DrollError(
+        except DrollError:
+            raise DrollError(
                 "Dragon remains but no ring in hand."
             )
 
@@ -151,7 +151,7 @@ def descend(
     # Update the world in anticipation of the next dungeon
     next_depth = (world.depth if world.depth else 0) + 1
     if next_depth > _max_depth:
-        raise error.DrollError(f"Maximum depth is {_max_depth}.")
+        raise DrollError(f"Maximum depth is {_max_depth}.")
     prior_dragons = 0 if world.dungeon is None else world.dungeon.dragon
     new_dice = max(1, min(_dungeon_dice - prior_dragons, next_depth))
     rolled = roll_dungeon(new_dice, randrange)
@@ -166,11 +166,11 @@ def _escape_dragon(world: struct.World) -> struct.World:
     """Attempt to escape a blocking dragon using a ring first, then a portal."""
     try:
         return _apply_ring(world)
-    except error.DrollError:
+    except DrollError:
         try:
             return _apply_portal(world)
-        except error.DrollError:
-            raise error.DrollError(
+        except DrollError:
+            raise DrollError(
                 "Dragon remains but no ring or portal in hand."
             )
 
@@ -181,13 +181,13 @@ def retire(world: struct.World) -> struct.World:
     If monsters or a dragon remains, either ring of invisibility or
     a town portal will be used when available."""
     if world.depth == 0:
-        raise error.DrollError("Descend at least once prior to retiring.")
+        raise DrollError("Descend at least once prior to retiring.")
 
     if not defeated_monsters(world.dungeon):
         try:
             world = _apply_portal(world)
-        except error.DrollError:
-            raise error.DrollError("Monsters remain but no portal in hand.")
+        except DrollError:
+            raise DrollError("Monsters remain but no portal in hand.")
     elif _blocking_dragon(world.dungeon):
         world = _escape_dragon(world)
 
@@ -203,9 +203,9 @@ def retire(world: struct.World) -> struct.World:
 def retreat(world: struct.World) -> struct.World:
     """Retreat to the tavern without completing the present dungeon."""
     if world.depth < 1:
-        raise error.DrollError("Descend at least once prior to retreating.")
+        raise DrollError("Descend at least once prior to retreating.")
     if defeated_dungeon(world.dungeon):
-        raise error.DrollError("Dungeon is clear; retire instead of retreating.")
+        raise DrollError("Dungeon is clear; retire instead of retreating.")
 
     # Regroup just prior to retreating
     world = _regroup(world)
@@ -259,7 +259,7 @@ def replace_treasure(world: struct.World, item: str) -> struct.World:
     """Replace a single item from the player's treasures into the reserve."""
     prior_count = getattr(world.treasure, item)
     if not prior_count:
-        raise error.DrollError(f"'{item}' not in player's treasure.")
+        raise DrollError(f"'{item}' not in player's treasure.")
     return replace(
         world,
         treasure=replace(world.treasure, **{item: prior_count - 1}),
@@ -272,7 +272,7 @@ def replace_treasure(world: struct.World, item: str) -> struct.World:
 def _apply_ring(world: struct.World, *, noun: str = "ring") -> struct.World:
     """Attempt to use a ring of invisibility towards sneaking past a dragon."""
     if not _blocking_dragon(world.dungeon):
-        raise error.DrollError(
+        raise DrollError(
             f"A dragon must be present to use a {noun}."
         )
     world = replace_treasure(world, noun)
@@ -285,7 +285,7 @@ def _apply_portal(
     """Attempt to use a town portal towards retiring to town."""
     # No need to reset monsters/dragon as dungeon will be wholly replaced
     if defeated_dungeon(world.dungeon):
-        raise error.DrollError(
+        raise DrollError(
             f"No need to apply {noun} when dungeon clear."
         )
     return replace(replace_treasure(world, "portal"), dungeon=struct.Dungeon())


### PR DESCRIPTION
Replace `from . import error` / `raise error.DrollError(...)` with
`from .error import DrollError` / `raise DrollError(...)` across all
modules. Hero modules use `from ..error import DrollError` accordingly.

https://claude.ai/code/session_01CR8n1qT4jerj7tASFUd2fu