### PR TITLE
Flatten test classes that serve only to group tests into free functions

### DIFF
--- a/tests/heroes/test_crusader.py
+++ b/tests/heroes/test_crusader.py
@@ -19,114 +19,119 @@ from droll.heroes.crusader import (
 _UNUSED = object()
 
 
-class TestCrusader:
+def test_crusader_ability_adds_fighter():
+    """Crusader ability adds a fighter to party."""
+    world = droll.struct.World(
+        ability=True,
+        party=droll.struct.Party(fighter=1, cleric=1),
+    )
+    result = _crusader_ability(world, _UNUSED, "ability", "fighter")
+    assert result.party.fighter == 2
+    assert not result.ability
 
-    def test_crusader_ability_adds_fighter(self):
-        """Crusader ability adds a fighter to party."""
-        world = droll.struct.World(
-            ability=True,
-            party=droll.struct.Party(fighter=1, cleric=1),
-        )
-        result = _crusader_ability(world, _UNUSED, "ability", "fighter")
-        assert result.party.fighter == 2
-        assert not result.ability
 
-    def test_crusader_ability_adds_cleric(self):
-        """Crusader ability adds a cleric to party."""
-        world = droll.struct.World(
-            ability=True,
-            party=droll.struct.Party(fighter=1, cleric=1),
-        )
-        result = _crusader_ability(world, _UNUSED, "ability", "cleric")
-        assert result.party.cleric == 2
+def test_crusader_ability_adds_cleric():
+    """Crusader ability adds a cleric to party."""
+    world = droll.struct.World(
+        ability=True,
+        party=droll.struct.Party(fighter=1, cleric=1),
+    )
+    result = _crusader_ability(world, _UNUSED, "ability", "cleric")
+    assert result.party.cleric == 2
 
-    def test_crusader_ability_rejects_invalid_target(self):
-        """Crusader ability rejects invalid targets like mage."""
-        world = droll.struct.World(
-            ability=True,
-            party=droll.struct.Party(fighter=1, cleric=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _crusader_ability(world, _UNUSED, "ability", "mage")
 
-    def test_crusader_advances_to_paladin(self):
-        """Crusader advances to Paladin at 5+ experience."""
-        low_xp = droll.struct.World(experience=4)
-        high_xp = droll.struct.World(experience=5)
-        assert Crusader.advance(low_xp) == Crusader
-        assert Crusader.advance(high_xp) == Paladin
+def test_crusader_ability_rejects_invalid_target():
+    """Crusader ability rejects invalid targets like mage."""
+    world = droll.struct.World(
+        ability=True,
+        party=droll.struct.Party(fighter=1, cleric=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _crusader_ability(world, _UNUSED, "ability", "mage")
 
-    def test_paladin_ability_clears_dungeon(self):
-        """Paladin ability consumes treasure and clears dungeon."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1, dragon=1),
-            party=droll.struct.Party(fighter=1, cleric=1),
-            treasure=droll.struct.Treasure(elixir=1),
-            reserve=droll.struct.Treasure(sword=1, talisman=1),
-        )
-        result = _paladin_ability(world, _UNUSED, "ability", "elixir")
-        assert sum(droll.struct.field_values(result.dungeon)) == 0
-        assert result.treasure.elixir == 0
-        assert not result.ability
 
-    def test_paladin_ability_opens_chests(self):
-        """Paladin ability draws treasure for each chest."""
-        randrange = random.Random(4).randrange
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(chest=2),
-            party=droll.struct.Party(fighter=1),
-            treasure=droll.struct.Treasure(bait=1),
-            reserve=droll.struct.Treasure(sword=1, talisman=1, sceptre=1),
-        )
-        pre_treasure = sum(droll.struct.field_values(world.treasure))
-        result = _paladin_ability(world, randrange, "ability", "bait")
-        post_treasure = sum(droll.struct.field_values(result.treasure))
-        assert (
-            post_treasure == pre_treasure - 1 + 2
-        )  # -1 consumed, +2 from chests
+def test_crusader_advances_to_paladin():
+    """Crusader advances to Paladin at 5+ experience."""
+    low_xp = droll.struct.World(experience=4)
+    high_xp = droll.struct.World(experience=5)
+    assert Crusader.advance(low_xp) == Crusader
+    assert Crusader.advance(high_xp) == Paladin
 
-    def test_paladin_ability_revives_from_potions(self):
-        """Paladin ability revives heroes from potions."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(potion=2),
-            party=droll.struct.Party(fighter=1),
-            treasure=droll.struct.Treasure(elixir=1),
-        )
-        result = _paladin_ability(
-            world, _UNUSED, "ability", "elixir", "mage", "thief"
-        )
-        assert result.party.mage == 1
-        assert result.party.thief == 1
 
-    def test_crusader_ability_default_target(self):
-        """Crusader ability defaults to 'cleric' (first sorted) when no target."""
-        world = droll.struct.World(
-            ability=True,
-            party=droll.struct.Party(fighter=1, cleric=1),
-        )
-        result = _crusader_ability(world, _UNUSED, "ability")
-        assert result.party.cleric == 2
+def test_paladin_ability_clears_dungeon():
+    """Paladin ability consumes treasure and clears dungeon."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1, dragon=1),
+        party=droll.struct.Party(fighter=1, cleric=1),
+        treasure=droll.struct.Treasure(elixir=1),
+        reserve=droll.struct.Treasure(sword=1, talisman=1),
+    )
+    result = _paladin_ability(world, _UNUSED, "ability", "elixir")
+    assert sum(droll.struct.field_values(result.dungeon)) == 0
+    assert result.treasure.elixir == 0
+    assert not result.ability
 
-    def test_paladin_ability_wrong_revivable_count(self):
-        """Paladin ability rejects wrong number of heroes for potions."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(potion=2),
-            party=droll.struct.Party(fighter=1),
-            treasure=droll.struct.Treasure(elixir=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _paladin_ability(world, _UNUSED, "ability", "elixir", "mage")
 
-    def test_paladin_ability_requires_treasure(self):
-        """Paladin ability fails without specifying treasure."""
-        world = droll.struct.World(
-            ability=True,
-            party=droll.struct.Party(fighter=1),
-            treasure=droll.struct.Treasure(elixir=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _paladin_ability(world, _UNUSED, "ability")
+def test_paladin_ability_opens_chests():
+    """Paladin ability draws treasure for each chest."""
+    randrange = random.Random(4).randrange
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(chest=2),
+        party=droll.struct.Party(fighter=1),
+        treasure=droll.struct.Treasure(bait=1),
+        reserve=droll.struct.Treasure(sword=1, talisman=1, sceptre=1),
+    )
+    pre_treasure = sum(droll.struct.field_values(world.treasure))
+    result = _paladin_ability(world, randrange, "ability", "bait")
+    post_treasure = sum(droll.struct.field_values(result.treasure))
+    assert post_treasure == pre_treasure - 1 + 2  # -1 consumed, +2 from chests
+
+
+def test_paladin_ability_revives_from_potions():
+    """Paladin ability revives heroes from potions."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(potion=2),
+        party=droll.struct.Party(fighter=1),
+        treasure=droll.struct.Treasure(elixir=1),
+    )
+    result = _paladin_ability(
+        world, _UNUSED, "ability", "elixir", "mage", "thief"
+    )
+    assert result.party.mage == 1
+    assert result.party.thief == 1
+
+
+def test_crusader_ability_default_target():
+    """Crusader ability defaults to 'cleric' (first sorted) when no target."""
+    world = droll.struct.World(
+        ability=True,
+        party=droll.struct.Party(fighter=1, cleric=1),
+    )
+    result = _crusader_ability(world, _UNUSED, "ability")
+    assert result.party.cleric == 2
+
+
+def test_paladin_ability_wrong_revivable_count():
+    """Paladin ability rejects wrong number of heroes for potions."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(potion=2),
+        party=droll.struct.Party(fighter=1),
+        treasure=droll.struct.Treasure(elixir=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _paladin_ability(world, _UNUSED, "ability", "elixir", "mage")
+
+
+def test_paladin_ability_requires_treasure():
+    """Paladin ability fails without specifying treasure."""
+    world = droll.struct.World(
+        ability=True,
+        party=droll.struct.Party(fighter=1),
+        treasure=droll.struct.Treasure(elixir=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _paladin_ability(world, _UNUSED, "ability")

--- a/tests/heroes/test_enchantress.py
+++ b/tests/heroes/test_enchantress.py
@@ -18,59 +18,59 @@ from droll.heroes.enchantress import (
 _UNUSED = object()
 
 
-class TestEnchantress:
+def test_enchantress_transforms_monster_to_potion():
+    """Enchantress transforms 1 monster into 1 potion."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    result = _enchantress_ability(world, _UNUSED, "ability", "goblin")
+    assert result.dungeon.goblin == 1
+    assert result.dungeon.potion == 1
+    assert not result.ability
 
-    def test_enchantress_transforms_monster_to_potion(self):
-        """Enchantress transforms 1 monster into 1 potion."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        result = _enchantress_ability(world, _UNUSED, "ability", "goblin")
-        assert result.dungeon.goblin == 1
-        assert result.dungeon.potion == 1
-        assert not result.ability
 
-    def test_beguiler_transforms_two_monsters(self):
-        """Beguiler transforms 2 monsters into 1 potion when available."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        result = _beguiler_ability(
-            world, _UNUSED, "ability", "goblin", "skeleton"
-        )
-        assert result.dungeon.goblin == 1
-        assert result.dungeon.skeleton == 0
-        assert result.dungeon.potion == 1
+def test_beguiler_transforms_two_monsters():
+    """Beguiler transforms 2 monsters into 1 potion when available."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    result = _beguiler_ability(world, _UNUSED, "ability", "goblin", "skeleton")
+    assert result.dungeon.goblin == 1
+    assert result.dungeon.skeleton == 0
+    assert result.dungeon.potion == 1
 
-    def test_beguiler_requires_two_when_available(self):
-        """Beguiler must transform 2 monsters when 2+ available."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _beguiler_ability(world, _UNUSED, "ability", "goblin")
 
-    def test_beguiler_rejects_too_many_targets(self):
-        """Beguiler rejects more than 2 targets."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _beguiler_ability(
-                world, _UNUSED, "ability", "goblin", "skeleton", "goblin"
-            )
+def test_beguiler_requires_two_when_available():
+    """Beguiler must transform 2 monsters when 2+ available."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _beguiler_ability(world, _UNUSED, "ability", "goblin")
 
-    def test_enchantress_advances_to_beguiler(self):
-        """Enchantress advances to Beguiler at 5+ experience."""
-        low_xp = droll.struct.World(experience=4)
-        high_xp = droll.struct.World(experience=5)
-        assert Enchantress.advance(low_xp) == Enchantress
-        assert Enchantress.advance(high_xp) == Beguiler
+
+def test_beguiler_rejects_too_many_targets():
+    """Beguiler rejects more than 2 targets."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _beguiler_ability(
+            world, _UNUSED, "ability", "goblin", "skeleton", "goblin"
+        )
+
+
+def test_enchantress_advances_to_beguiler():
+    """Enchantress advances to Beguiler at 5+ experience."""
+    low_xp = droll.struct.World(experience=4)
+    high_xp = droll.struct.World(experience=5)
+    assert Enchantress.advance(low_xp) == Enchantress
+    assert Enchantress.advance(high_xp) == Beguiler

--- a/tests/heroes/test_halfgoblin.py
+++ b/tests/heroes/test_halfgoblin.py
@@ -19,114 +19,114 @@ from droll.heroes.halfgoblin import (
 _UNUSED = object()
 
 
-class TestHalfGoblin:
+def test_halfgoblin_transforms_goblin_to_thief():
+    """HalfGoblin transforms 1 goblin into 1 thief."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    result = _halfgoblin_ability(world, _UNUSED, "ability", "goblin")
+    # Discard during subsequent regroup phase tested elsewhere
+    assert result.dungeon.goblin == 1
+    assert result.party.thief == 1
+    assert not result.ability
 
-    def test_halfgoblin_transforms_goblin_to_thief(self):
-        """HalfGoblin transforms 1 goblin into 1 thief."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        result = _halfgoblin_ability(world, _UNUSED, "ability", "goblin")
-        # Discard during subsequent regroup phase tested elsewhere
-        assert result.dungeon.goblin == 1
-        assert result.party.thief == 1
-        assert not result.ability
 
-    def test_chieftain_transforms_two_monsters(self):
-        """Chieftain transforms 2 goblins into 2 thieves when available."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        result = _chieftain_ability(
-            world, _UNUSED, "ability", "goblin", "goblin"
-        )
-        # Discard during subsequent regroup phase tested elsewhere
-        assert result.dungeon.goblin == 0
-        assert result.dungeon.skeleton == 1
-        assert result.party.thief == 2
+def test_chieftain_transforms_two_monsters():
+    """Chieftain transforms 2 goblins into 2 thieves when available."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    result = _chieftain_ability(world, _UNUSED, "ability", "goblin", "goblin")
+    # Discard during subsequent regroup phase tested elsewhere
+    assert result.dungeon.goblin == 0
+    assert result.dungeon.skeleton == 1
+    assert result.party.thief == 2
 
-    def test_chieftain_transforms_one_monster(self):
-        """Chieftain transforms 1 goblin into 1 thief when 1 available."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        result = _chieftain_ability(
-            world,
-            _UNUSED,
-            "ability",
-            "goblin",
-        )
-        # Discard during subsequent regroup phase tested elsewhere
-        assert result.dungeon.goblin == 0
-        assert result.dungeon.skeleton == 1
-        assert result.party.thief == 1
 
-    def test_halfgoblin_rejects_non_goblin(self):
-        """HalfGoblin ability rejects non-goblin targets."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _halfgoblin_ability(world, _UNUSED, "ability", "skeleton")
+def test_chieftain_transforms_one_monster():
+    """Chieftain transforms 1 goblin into 1 thief when 1 available."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    result = _chieftain_ability(
+        world,
+        _UNUSED,
+        "ability",
+        "goblin",
+    )
+    # Discard during subsequent regroup phase tested elsewhere
+    assert result.dungeon.goblin == 0
+    assert result.dungeon.skeleton == 1
+    assert result.party.thief == 1
 
-    def test_chieftain_rejects_non_goblin_targets(self):
-        """Chieftain rejects non-goblin target, extra target, and excess targets."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _chieftain_ability(world, _UNUSED, "ability", "skeleton")
-        with pytest.raises(droll.error.DrollError):
-            _chieftain_ability(
-                world, _UNUSED, "ability", "goblin", "skeleton"
-            )
-        with pytest.raises(droll.error.DrollError):
-            _chieftain_ability(
-                world, _UNUSED, "ability", "goblin", "goblin", "goblin"
-            )
 
-    def test_halfgoblin_advances_to_chieftain(self):
-        """HalfGoblin advances to Chieftain at 5+ experience."""
-        low_xp = droll.struct.World(experience=4)
-        high_xp = droll.struct.World(experience=5)
-        assert HalfGoblin.advance(low_xp) == HalfGoblin
-        assert HalfGoblin.advance(high_xp) == Chieftain
+def test_halfgoblin_rejects_non_goblin():
+    """HalfGoblin ability rejects non-goblin targets."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _halfgoblin_ability(world, _UNUSED, "ability", "skeleton")
 
-    def test_halfgoblin_fighter_chests_potions(self):
-        """HalfGoblin opens chests and quaff portions when monsters present."""
-        randrange = random.Random(4).randrange
-        world = droll.struct.World(
-            delve=1,
-            depth=1,
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, chest=1, potion=1),
-            party=droll.struct.Party(fighter=5),
-            treasure=droll.struct.Treasure(),
-            reserve=droll.struct.Treasure(scale=1),
+
+def test_chieftain_rejects_non_goblin_targets():
+    """Chieftain rejects non-goblin target, extra target, and excess targets."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _chieftain_ability(world, _UNUSED, "ability", "skeleton")
+    with pytest.raises(droll.error.DrollError):
+        _chieftain_ability(world, _UNUSED, "ability", "goblin", "skeleton")
+    with pytest.raises(droll.error.DrollError):
+        _chieftain_ability(
+            world, _UNUSED, "ability", "goblin", "goblin", "goblin"
         )
 
-        result1 = HalfGoblin.party.fighter.chest(
-            world, randrange, "fighter", "chest"
-        )
-        assert result1.dungeon.chest == 0
-        assert result1.dungeon.goblin == 1
-        assert result1.party.fighter == 4
-        assert result1.treasure.scale == 1
 
-        result2 = HalfGoblin.party.fighter.potion(
-            world, randrange, "fighter", "potion", "mage"
-        )
-        assert result2.dungeon.goblin == 1
-        assert result2.dungeon.potion == 0
-        assert result2.party.fighter == 4
-        assert result2.party.mage == 1
+def test_halfgoblin_advances_to_chieftain():
+    """HalfGoblin advances to Chieftain at 5+ experience."""
+    low_xp = droll.struct.World(experience=4)
+    high_xp = droll.struct.World(experience=5)
+    assert HalfGoblin.advance(low_xp) == HalfGoblin
+    assert HalfGoblin.advance(high_xp) == Chieftain
+
+
+def test_halfgoblin_fighter_chests_potions():
+    """HalfGoblin opens chests and quaff portions when monsters present."""
+    randrange = random.Random(4).randrange
+    world = droll.struct.World(
+        delve=1,
+        depth=1,
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, chest=1, potion=1),
+        party=droll.struct.Party(fighter=5),
+        treasure=droll.struct.Treasure(),
+        reserve=droll.struct.Treasure(scale=1),
+    )
+
+    result1 = HalfGoblin.party.fighter.chest(
+        world, randrange, "fighter", "chest"
+    )
+    assert result1.dungeon.chest == 0
+    assert result1.dungeon.goblin == 1
+    assert result1.party.fighter == 4
+    assert result1.treasure.scale == 1
+
+    result2 = HalfGoblin.party.fighter.potion(
+        world, randrange, "fighter", "potion", "mage"
+    )
+    assert result2.dungeon.goblin == 1
+    assert result2.dungeon.potion == 0
+    assert result2.party.fighter == 4
+    assert result2.party.mage == 1

--- a/tests/heroes/test_knight.py
+++ b/tests/heroes/test_knight.py
@@ -13,51 +13,52 @@ from droll.heroes.knight import Knight, DragonSlayer, _knight_roll_party
 _UNUSED = object()
 
 
-class TestKnight:
+def test_knight_roll_party_converts_scrolls():
+    """Knight converts scrolls to champions when rolling party."""
+    randrange = random.Random(4).randrange
+    party, regroup = _knight_roll_party(7, randrange)
+    assert party.scroll == 0
+    assert sum(droll.struct.field_values(party)) == 7
+    assert regroup == droll.struct.Regroup()
 
-    def test_knight_roll_party_converts_scrolls(self):
-        """Knight converts scrolls to champions when rolling party."""
-        randrange = random.Random(4).randrange
-        party, regroup = _knight_roll_party(7, randrange)
-        assert party.scroll == 0
-        assert sum(droll.struct.field_values(party)) == 7
-        assert regroup == droll.struct.Regroup()
 
-    def test_knight_ability_baits_dragon(self):
-        """Knight ability converts monsters to dragons without treasure."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=2, champion=1),
-        )
-        result = Knight.ability(world, _UNUSED, "ability")
-        assert result.dungeon.dragon == 3
-        assert result.dungeon.goblin == 0
-        assert result.dungeon.skeleton == 0
-        assert not result.ability
+def test_knight_ability_baits_dragon():
+    """Knight ability converts monsters to dragons without treasure."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=2, champion=1),
+    )
+    result = Knight.ability(world, _UNUSED, "ability")
+    assert result.dungeon.dragon == 3
+    assert result.dungeon.goblin == 0
+    assert result.dungeon.skeleton == 0
+    assert not result.ability
 
-    def test_dragonslayer_defeats_dragon_with_two_heroes(self):
-        """DragonSlayer defeats a dragon with only 2 distinct heroes."""
-        randrange = random.Random(4).randrange
-        world = droll.struct.World(
-            delve=1,
-            depth=1,
-            dungeon=droll.struct.Dungeon(dragon=3),
-            party=droll.struct.Party(fighter=1, mage=1),
-            treasure=droll.struct.Treasure(),
-            reserve=droll.struct.Treasure(scale=6),
-        )
-        result = DragonSlayer.party.fighter.dragon(
-            world, randrange, "fighter", "dragon", "mage"
-        )
-        assert result.dungeon.dragon == 0
-        assert result.experience == 1
 
-    def test_dragonslayer_advance(self):
-        """Knight advances to DragonSlayer advances to DragonSlayer."""
-        low_xp = droll.struct.World(experience=2)
-        mid_xp = droll.struct.World(experience=7)
-        high_xp = droll.struct.World(experience=15)
-        assert Knight.advance(low_xp) == Knight
-        assert Knight.advance(mid_xp) == DragonSlayer
-        assert DragonSlayer.advance(high_xp) == DragonSlayer
+def test_dragonslayer_defeats_dragon_with_two_heroes():
+    """DragonSlayer defeats a dragon with only 2 distinct heroes."""
+    randrange = random.Random(4).randrange
+    world = droll.struct.World(
+        delve=1,
+        depth=1,
+        dungeon=droll.struct.Dungeon(dragon=3),
+        party=droll.struct.Party(fighter=1, mage=1),
+        treasure=droll.struct.Treasure(),
+        reserve=droll.struct.Treasure(scale=6),
+    )
+    result = DragonSlayer.party.fighter.dragon(
+        world, randrange, "fighter", "dragon", "mage"
+    )
+    assert result.dungeon.dragon == 0
+    assert result.experience == 1
+
+
+def test_dragonslayer_advance():
+    """Knight advances to DragonSlayer advances to DragonSlayer."""
+    low_xp = droll.struct.World(experience=2)
+    mid_xp = droll.struct.World(experience=7)
+    high_xp = droll.struct.World(experience=15)
+    assert Knight.advance(low_xp) == Knight
+    assert Knight.advance(mid_xp) == DragonSlayer
+    assert DragonSlayer.advance(high_xp) == DragonSlayer

--- a/tests/heroes/test_mercenary.py
+++ b/tests/heroes/test_mercenary.py
@@ -20,120 +20,127 @@ from droll.heroes.mercenary import (
 _UNUSED = object()
 
 
-class TestMercenary:
+def test_mercenary_roll_party_adds_bonus_scroll():
+    """Mercenary roll adds one bonus scroll with regroup discard."""
+    randrange = random.Random(4).randrange
+    party, regroup = _mercenary_roll_party(7, randrange)
+    assert sum(droll.struct.field_values(party)) == 8
+    assert regroup.discard.scroll == 1
 
-    def test_mercenary_roll_party_adds_bonus_scroll(self):
-        """Mercenary roll adds one bonus scroll with regroup discard."""
-        randrange = random.Random(4).randrange
-        party, regroup = _mercenary_roll_party(7, randrange)
-        assert sum(droll.struct.field_values(party)) == 8
-        assert regroup.discard.scroll == 1
 
-    def test_mercenary_ability_defeats_two_monsters(self):
-        """Mercenary ability defeats 2 different monsters."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
-            party=droll.struct.Party(fighter=2),
-        )
-        result = _mercenary_ability(
-            world, _UNUSED, "ability", "goblin", "skeleton"
-        )
-        assert result.dungeon.goblin == 0
-        assert result.dungeon.skeleton == 0
-        assert result.party.fighter == 2
-        assert not result.ability
+def test_mercenary_ability_defeats_two_monsters():
+    """Mercenary ability defeats 2 different monsters."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
+        party=droll.struct.Party(fighter=2),
+    )
+    result = _mercenary_ability(
+        world, _UNUSED, "ability", "goblin", "skeleton"
+    )
+    assert result.dungeon.goblin == 0
+    assert result.dungeon.skeleton == 0
+    assert result.party.fighter == 2
+    assert not result.ability
 
-    def test_mercenary_ability_defeats_one_when_only_one(self):
-        """Mercenary ability defeats 1 monster when only 1 exists."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1),
-            party=droll.struct.Party(fighter=2),
-        )
-        result = _mercenary_ability(world, _UNUSED, "ability", "goblin")
-        assert result.dungeon.goblin == 0
-        assert not result.ability
 
-    def test_mercenary_ability_requires_target(self):
-        """Mercenary ability requires at least one target."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1),
-            party=droll.struct.Party(fighter=2),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _mercenary_ability(world, _UNUSED, "ability")
+def test_mercenary_ability_defeats_one_when_only_one():
+    """Mercenary ability defeats 1 monster when only 1 exists."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1),
+        party=droll.struct.Party(fighter=2),
+    )
+    result = _mercenary_ability(world, _UNUSED, "ability", "goblin")
+    assert result.dungeon.goblin == 0
+    assert not result.ability
 
-    def test_commander_ability_rerolls_dungeon_dice(self):
-        """Commander ability rerolls dungeon dice."""
-        randrange = random.Random(7).randrange
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=2),
-        )
-        result = _commander_ability(
-            world, randrange, "ability", "goblin", "goblin"
-        )
-        assert not result.ability
-        assert result.party.fighter == 2
 
-    def test_commander_ability_rerolls_dragon(self):
-        """Commander ability can reroll dragon dice."""
-        randrange = random.Random(7).randrange
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(dragon=3),
-            party=droll.struct.Party(fighter=2),
-        )
-        result = _commander_ability(
-            world, randrange, "ability", "dragon", "dragon", "dragon"
-        )
-        assert not result.ability
+def test_mercenary_ability_requires_target():
+    """Mercenary ability requires at least one target."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1),
+        party=droll.struct.Party(fighter=2),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _mercenary_ability(world, _UNUSED, "ability")
 
-    def test_commander_ability_requires_target(self):
-        """Commander ability requires at least one target."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1),
-            party=droll.struct.Party(fighter=2),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _commander_ability(world, _UNUSED, "ability")
 
-    def test_commander_fighter_defeats_goblin_plus_additional(self):
-        """Commander fighters defeat all goblins plus one additional."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(fighter=2),
-        )
-        result = Commander.party.fighter.goblin(
-            world, _UNUSED, "fighter", "goblin", "skeleton"
-        )
-        assert result.dungeon.goblin == 0
-        assert result.dungeon.skeleton == 0
-        assert result.party.fighter == 1
+def test_commander_ability_rerolls_dungeon_dice():
+    """Commander ability rerolls dungeon dice."""
+    randrange = random.Random(7).randrange
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=2),
+    )
+    result = _commander_ability(
+        world, randrange, "ability", "goblin", "goblin"
+    )
+    assert not result.ability
+    assert result.party.fighter == 2
 
-    def test_commander_fighter_defeats_skeleton_plus_additional(self):
-        """Commander fighters defeat one skeleton plus one additional."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(skeleton=2, ooze=1),
-            party=droll.struct.Party(fighter=2),
-        )
-        result = Commander.party.fighter.skeleton(
-            world, _UNUSED, "fighter", "skeleton", "ooze"
-        )
-        assert result.dungeon.skeleton == 1
-        assert result.dungeon.ooze == 0
-        assert result.party.fighter == 1
 
-    def test_mercenary_advances_to_commander(self):
-        """Mercenary advances to Commander at 5+ experience."""
-        low_xp = droll.struct.World(experience=4)
-        high_xp = droll.struct.World(experience=5)
-        assert Mercenary.advance(low_xp) == Mercenary
-        assert Mercenary.advance(high_xp) == Commander
-        assert Commander.advance(high_xp) == Commander
+def test_commander_ability_rerolls_dragon():
+    """Commander ability can reroll dragon dice."""
+    randrange = random.Random(7).randrange
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(dragon=3),
+        party=droll.struct.Party(fighter=2),
+    )
+    result = _commander_ability(
+        world, randrange, "ability", "dragon", "dragon", "dragon"
+    )
+    assert not result.ability
+
+
+def test_commander_ability_requires_target():
+    """Commander ability requires at least one target."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1),
+        party=droll.struct.Party(fighter=2),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _commander_ability(world, _UNUSED, "ability")
+
+
+def test_commander_fighter_defeats_goblin_plus_additional():
+    """Commander fighters defeat all goblins plus one additional."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(fighter=2),
+    )
+    result = Commander.party.fighter.goblin(
+        world, _UNUSED, "fighter", "goblin", "skeleton"
+    )
+    assert result.dungeon.goblin == 0
+    assert result.dungeon.skeleton == 0
+    assert result.party.fighter == 1
+
+
+def test_commander_fighter_defeats_skeleton_plus_additional():
+    """Commander fighters defeat one skeleton plus one additional."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(skeleton=2, ooze=1),
+        party=droll.struct.Party(fighter=2),
+    )
+    result = Commander.party.fighter.skeleton(
+        world, _UNUSED, "fighter", "skeleton", "ooze"
+    )
+    assert result.dungeon.skeleton == 1
+    assert result.dungeon.ooze == 0
+    assert result.party.fighter == 1
+
+
+def test_mercenary_advances_to_commander():
+    """Mercenary advances to Commander at 5+ experience."""
+    low_xp = droll.struct.World(experience=4)
+    high_xp = droll.struct.World(experience=5)
+    assert Mercenary.advance(low_xp) == Mercenary
+    assert Mercenary.advance(high_xp) == Commander
+    assert Commander.advance(high_xp) == Commander

--- a/tests/heroes/test_minstrel.py
+++ b/tests/heroes/test_minstrel.py
@@ -13,47 +13,48 @@ from droll.heroes.minstrel import Minstrel, Bard, _minstrel_ability
 _UNUSED = object()
 
 
-class TestMinstrel:
+def test_minstrel_ability_discards_dragons():
+    """Minstrel/Bard ability discards all dragon dice."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, dragon=3),
+        party=droll.struct.Party(fighter=1),
+    )
+    result = _minstrel_ability(world, _UNUSED, "ability")
+    assert result.dungeon.dragon == 0
+    assert result.dungeon.goblin == 1
+    assert not result.ability
 
-    def test_minstrel_ability_discards_dragons(self):
-        """Minstrel/Bard ability discards all dragon dice."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, dragon=3),
-            party=droll.struct.Party(fighter=1),
-        )
-        result = _minstrel_ability(world, _UNUSED, "ability")
-        assert result.dungeon.dragon == 0
-        assert result.dungeon.goblin == 1
-        assert not result.ability
 
-    def test_minstrel_ability_rejects_non_dragon(self):
-        """Minstrel/Bard ability only works on dragons."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, dragon=3),
-            party=droll.struct.Party(fighter=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _minstrel_ability(world, _UNUSED, "ability", "goblin")
+def test_minstrel_ability_rejects_non_dragon():
+    """Minstrel/Bard ability only works on dragons."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, dragon=3),
+        party=droll.struct.Party(fighter=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _minstrel_ability(world, _UNUSED, "ability", "goblin")
 
-    def test_bard_champion_defeats_all_plus_additional(self):
-        """Bard champion defeats all of one type plus one additional."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
-            party=droll.struct.Party(champion=1),
-        )
-        result = Bard.party.champion.goblin(
-            world, _UNUSED, "champion", "goblin", "skeleton"
-        )
-        assert result.dungeon.goblin == 0
-        assert result.dungeon.skeleton == 0
-        assert result.party.champion == 0
 
-    def test_minstrel_advances_to_bard(self):
-        """Minstrel advances to Bard at 5+ experience."""
-        low_xp = droll.struct.World(experience=4)
-        high_xp = droll.struct.World(experience=5)
-        assert Minstrel.advance(low_xp) == Minstrel
-        assert Minstrel.advance(high_xp) == Bard
+def test_bard_champion_defeats_all_plus_additional():
+    """Bard champion defeats all of one type plus one additional."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, skeleton=1),
+        party=droll.struct.Party(champion=1),
+    )
+    result = Bard.party.champion.goblin(
+        world, _UNUSED, "champion", "goblin", "skeleton"
+    )
+    assert result.dungeon.goblin == 0
+    assert result.dungeon.skeleton == 0
+    assert result.party.champion == 0
+
+
+def test_minstrel_advances_to_bard():
+    """Minstrel advances to Bard at 5+ experience."""
+    low_xp = droll.struct.World(experience=4)
+    high_xp = droll.struct.World(experience=5)
+    assert Minstrel.advance(low_xp) == Minstrel
+    assert Minstrel.advance(high_xp) == Bard

--- a/tests/heroes/test_occultist.py
+++ b/tests/heroes/test_occultist.py
@@ -18,128 +18,134 @@ from droll.heroes.occultist import (
 _UNUSED = object()
 
 
-class TestOccultist:
+def test_occultist_transforms_skeleton_to_fighter():
+    """Occultist transforms 1 skeleton into 1 fighter."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=2),
+        party=droll.struct.Party(cleric=1),
+    )
+    result = _occultist_ability(world, _UNUSED, "ability", "skeleton")
+    # Discard during subsequent regroup phase tested elsewhere
+    assert result.dungeon.skeleton == 1
+    assert result.party.fighter == 1
+    assert not result.ability
 
-    def test_occultist_transforms_skeleton_to_fighter(self):
-        """Occultist transforms 1 skeleton into 1 fighter."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=2),
-            party=droll.struct.Party(cleric=1),
-        )
-        result = _occultist_ability(world, _UNUSED, "ability", "skeleton")
-        # Discard during subsequent regroup phase tested elsewhere
-        assert result.dungeon.skeleton == 1
-        assert result.party.fighter == 1
-        assert not result.ability
 
-    def test_occultist_rejects_non_skeleton_target(self):
-        """Occultist ability rejects non-skeleton targets."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
-            party=droll.struct.Party(cleric=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _occultist_ability(world, _UNUSED, "ability", "goblin")
+def test_occultist_rejects_non_skeleton_target():
+    """Occultist ability rejects non-skeleton targets."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
+        party=droll.struct.Party(cleric=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _occultist_ability(world, _UNUSED, "ability", "goblin")
 
-    def test_occultist_sets_regroup_discard(self):
-        """Occultist marks the created fighter for regroup discard."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(skeleton=1),
-            party=droll.struct.Party(cleric=1),
-        )
-        result = _occultist_ability(world, _UNUSED, "ability", "skeleton")
-        assert result.regroup.discard.fighter == 1
 
-    def test_necromancer_transforms_two_skeletons(self):
-        """Necromancer transforms 2 skeletons into 2 fighters when available."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=2),
-            party=droll.struct.Party(cleric=1),
-        )
-        result = _necromancer_ability(
-            world, _UNUSED, "ability", "skeleton", "skeleton"
-        )
-        # Discard during subsequent regroup phase tested elsewhere
-        assert result.dungeon.skeleton == 0
-        assert result.dungeon.goblin == 1
-        assert result.party.fighter == 2
+def test_occultist_sets_regroup_discard():
+    """Occultist marks the created fighter for regroup discard."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(skeleton=1),
+        party=droll.struct.Party(cleric=1),
+    )
+    result = _occultist_ability(world, _UNUSED, "ability", "skeleton")
+    assert result.regroup.discard.fighter == 1
 
-    def test_necromancer_transforms_one_skeleton(self):
-        """Necromancer transforms 1 skeleton into 1 fighter when 1 available."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
-            party=droll.struct.Party(cleric=1),
-        )
-        result = _necromancer_ability(
-            world,
-            _UNUSED,
-            "ability",
-            "skeleton",
-        )
-        # Discard during subsequent regroup phase tested elsewhere
-        assert result.dungeon.skeleton == 0
-        assert result.dungeon.goblin == 1
-        assert result.party.fighter == 1
 
-    def test_necromancer_sets_regroup_discard(self):
-        """Necromancer marks created fighters for regroup discard."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(skeleton=2),
-            party=droll.struct.Party(cleric=1),
-        )
-        result = _necromancer_ability(
-            world, _UNUSED, "ability", "skeleton", "skeleton"
-        )
-        assert result.regroup.discard.fighter == 2
+def test_necromancer_transforms_two_skeletons():
+    """Necromancer transforms 2 skeletons into 2 fighters when available."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=2),
+        party=droll.struct.Party(cleric=1),
+    )
+    result = _necromancer_ability(
+        world, _UNUSED, "ability", "skeleton", "skeleton"
+    )
+    # Discard during subsequent regroup phase tested elsewhere
+    assert result.dungeon.skeleton == 0
+    assert result.dungeon.goblin == 1
+    assert result.party.fighter == 2
 
-    def test_necromancer_rejects_non_skeleton_target(self):
-        """Necromancer ability rejects non-skeleton targets."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=2),
-            party=droll.struct.Party(cleric=1),
+
+def test_necromancer_transforms_one_skeleton():
+    """Necromancer transforms 1 skeleton into 1 fighter when 1 available."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=1),
+        party=droll.struct.Party(cleric=1),
+    )
+    result = _necromancer_ability(
+        world,
+        _UNUSED,
+        "ability",
+        "skeleton",
+    )
+    # Discard during subsequent regroup phase tested elsewhere
+    assert result.dungeon.skeleton == 0
+    assert result.dungeon.goblin == 1
+    assert result.party.fighter == 1
+
+
+def test_necromancer_sets_regroup_discard():
+    """Necromancer marks created fighters for regroup discard."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(skeleton=2),
+        party=droll.struct.Party(cleric=1),
+    )
+    result = _necromancer_ability(
+        world, _UNUSED, "ability", "skeleton", "skeleton"
+    )
+    assert result.regroup.discard.fighter == 2
+
+
+def test_necromancer_rejects_non_skeleton_target():
+    """Necromancer ability rejects non-skeleton targets."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=2),
+        party=droll.struct.Party(cleric=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _necromancer_ability(world, _UNUSED, "ability", "goblin")
+
+
+def test_necromancer_rejects_non_skeleton_extra_target():
+    """Necromancer ability rejects non-skeleton extra targets."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1, skeleton=2),
+        party=droll.struct.Party(cleric=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _necromancer_ability(world, _UNUSED, "ability", "skeleton", "goblin")
+
+
+def test_necromancer_rejects_too_many_targets():
+    """Necromancer rejects more than 2 targets."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(skeleton=3),
+        party=droll.struct.Party(cleric=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _necromancer_ability(
+            world, _UNUSED, "ability", "skeleton", "skeleton", "skeleton"
         )
-        with pytest.raises(droll.error.DrollError):
-            _necromancer_ability(world, _UNUSED, "ability", "goblin")
 
-    def test_necromancer_rejects_non_skeleton_extra_target(self):
-        """Necromancer ability rejects non-skeleton extra targets."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1, skeleton=2),
-            party=droll.struct.Party(cleric=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _necromancer_ability(
-                world, _UNUSED, "ability", "skeleton", "goblin"
-            )
 
-    def test_necromancer_rejects_too_many_targets(self):
-        """Necromancer rejects more than 2 targets."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(skeleton=3),
-            party=droll.struct.Party(cleric=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _necromancer_ability(
-                world, _UNUSED, "ability", "skeleton", "skeleton", "skeleton"
-            )
+def test_occultist_advances_to_necromancer():
+    """Occultist advances to Necromancer at 5+ experience."""
+    low_xp = droll.struct.World(experience=4)
+    high_xp = droll.struct.World(experience=5)
+    assert Occultist.advance(low_xp) == Occultist
+    assert Occultist.advance(high_xp) == Necromancer
 
-    def test_occultist_advances_to_necromancer(self):
-        """Occultist advances to Necromancer at 5+ experience."""
-        low_xp = droll.struct.World(experience=4)
-        high_xp = droll.struct.World(experience=5)
-        assert Occultist.advance(low_xp) == Occultist
-        assert Occultist.advance(high_xp) == Necromancer
 
-    def test_necromancer_does_not_advance(self):
-        """Necromancer does not advance further."""
-        high_xp = droll.struct.World(experience=10)
-        assert Necromancer.advance(high_xp) == Necromancer
+def test_necromancer_does_not_advance():
+    """Necromancer does not advance further."""
+    high_xp = droll.struct.World(experience=10)
+    assert Necromancer.advance(high_xp) == Necromancer

--- a/tests/heroes/test_spellsword.py
+++ b/tests/heroes/test_spellsword.py
@@ -18,72 +18,74 @@ from droll.heroes.spellsword import (
 _UNUSED = object()
 
 
-class TestSpellsword:
+def test_spellsword_ability_adds_fighter():
+    """Spellsword ability adds a fighter to party."""
+    world = droll.struct.World(
+        ability=True,
+        party=droll.struct.Party(fighter=1, mage=1),
+    )
+    result = _spellsword_ability(world, _UNUSED, "ability", "fighter")
+    assert result.party.fighter == 2
+    assert not result.ability
 
-    def test_spellsword_ability_adds_fighter(self):
-        """Spellsword ability adds a fighter to party."""
-        world = droll.struct.World(
-            ability=True,
-            party=droll.struct.Party(fighter=1, mage=1),
-        )
-        result = _spellsword_ability(world, _UNUSED, "ability", "fighter")
-        assert result.party.fighter == 2
-        assert not result.ability
 
-    def test_spellsword_ability_adds_mage(self):
-        """Spellsword ability adds a mage to party."""
-        world = droll.struct.World(
-            ability=True,
-            party=droll.struct.Party(fighter=1, mage=1),
-        )
-        result = _spellsword_ability(world, _UNUSED, "ability", "mage")
-        assert result.party.mage == 2
+def test_spellsword_ability_adds_mage():
+    """Spellsword ability adds a mage to party."""
+    world = droll.struct.World(
+        ability=True,
+        party=droll.struct.Party(fighter=1, mage=1),
+    )
+    result = _spellsword_ability(world, _UNUSED, "ability", "mage")
+    assert result.party.mage == 2
 
-    def test_spellsword_ability_rejects_invalid_target(self):
-        """Spellsword ability rejects invalid targets like cleric."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(),
-            party=droll.struct.Party(fighter=1, mage=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _spellsword_ability(world, _UNUSED, "ability", "cleric")
 
-    def test_battlemage_ability_clears_dungeon(self):
-        """Battlemage ability clears entire dungeon."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(
-                goblin=2, chest=1, potion=1, dragon=2
-            ),
-            party=droll.struct.Party(fighter=1, mage=1),
-        )
-        result = _battlemage_ability(world, _UNUSED, "ability")
-        assert sum(droll.struct.field_values(result.dungeon)) == 0
-        assert not result.ability
+def test_spellsword_ability_rejects_invalid_target():
+    """Spellsword ability rejects invalid targets like cleric."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(),
+        party=droll.struct.Party(fighter=1, mage=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _spellsword_ability(world, _UNUSED, "ability", "cleric")
 
-    def test_spellsword_ability_default_target(self):
-        """Spellsword ability defaults to 'fighter' (first sorted) when no target."""
-        world = droll.struct.World(
-            ability=True,
-            party=droll.struct.Party(fighter=1, mage=1),
-        )
-        result = _spellsword_ability(world, _UNUSED, "ability")
-        assert result.party.fighter == 2
 
-    def test_battlemage_ability_rejects_target(self):
-        """Battlemage ability rejects any target argument."""
-        world = droll.struct.World(
-            ability=True,
-            dungeon=droll.struct.Dungeon(goblin=1),
-            party=droll.struct.Party(fighter=1, mage=1),
-        )
-        with pytest.raises(droll.error.DrollError):
-            _battlemage_ability(world, _UNUSED, "ability", "goblin")
+def test_battlemage_ability_clears_dungeon():
+    """Battlemage ability clears entire dungeon."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=2, chest=1, potion=1, dragon=2),
+        party=droll.struct.Party(fighter=1, mage=1),
+    )
+    result = _battlemage_ability(world, _UNUSED, "ability")
+    assert sum(droll.struct.field_values(result.dungeon)) == 0
+    assert not result.ability
 
-    def test_spellsword_advances_to_battlemage(self):
-        """Spellsword advances to Battlemage at 5+ experience."""
-        low_xp = droll.struct.World(experience=4)
-        high_xp = droll.struct.World(experience=5)
-        assert Spellsword.advance(low_xp) == Spellsword
-        assert Spellsword.advance(high_xp) == Battlemage
+
+def test_spellsword_ability_default_target():
+    """Spellsword ability defaults to 'fighter' (first sorted) when no target."""
+    world = droll.struct.World(
+        ability=True,
+        party=droll.struct.Party(fighter=1, mage=1),
+    )
+    result = _spellsword_ability(world, _UNUSED, "ability")
+    assert result.party.fighter == 2
+
+
+def test_battlemage_ability_rejects_target():
+    """Battlemage ability rejects any target argument."""
+    world = droll.struct.World(
+        ability=True,
+        dungeon=droll.struct.Dungeon(goblin=1),
+        party=droll.struct.Party(fighter=1, mage=1),
+    )
+    with pytest.raises(droll.error.DrollError):
+        _battlemage_ability(world, _UNUSED, "ability", "goblin")
+
+
+def test_spellsword_advances_to_battlemage():
+    """Spellsword advances to Battlemage at 5+ experience."""
+    low_xp = droll.struct.World(experience=4)
+    high_xp = droll.struct.World(experience=5)
+    assert Spellsword.advance(low_xp) == Spellsword
+    assert Spellsword.advance(high_xp) == Battlemage

--- a/tests/test_action.py
+++ b/tests/test_action.py
@@ -14,140 +14,140 @@ from droll.error import DrollError
 _UNUSED = object()
 
 
-class TestDefeatAllPlusAdditional:
-
-    def test_defeats_all_plus_one_additional(self):
-        """Defeats all of one type plus one additional."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=2, skeleton=1),
-            party=struct.Party(champion=1),
-        )
-        result = action.defeat_all_plus_additional(
-            w, _UNUSED, "champion", "goblin", "skeleton"
-        )
-        assert result.dungeon.goblin == 0
-        assert result.dungeon.skeleton == 0
-        assert result.party.champion == 0
-
-    def test_no_additional_when_cleared(self):
-        """No additional needed when monsters cleared."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=2),
-            party=struct.Party(champion=1),
-        )
-        result = action.defeat_all_plus_additional(
-            w, _UNUSED, "champion", "goblin"
-        )
-        assert result.dungeon.goblin == 0
-
-    def test_rejects_extra_additional(self):
-        """Rejects more than one additional target."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1, skeleton=2),
-            party=struct.Party(champion=1),
-        )
-        with pytest.raises(DrollError):
-            action.defeat_all_plus_additional(
-                w,
-                _UNUSED,
-                "champion",
-                "goblin",
-                "skeleton",
-                "skeleton",
-            )
-
-    def test_requires_additional_when_monsters_remain(self):
-        """Requires additional target when monsters remain."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1, skeleton=1),
-            party=struct.Party(champion=1),
-        )
-        with pytest.raises(DrollError):
-            action.defeat_all_plus_additional(
-                w,
-                _UNUSED,
-                "champion",
-                "goblin",
-            )
+def test_defeats_all_plus_one_additional():
+    """Defeats all of one type plus one additional."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=2, skeleton=1),
+        party=struct.Party(champion=1),
+    )
+    result = action.defeat_all_plus_additional(
+        w, _UNUSED, "champion", "goblin", "skeleton"
+    )
+    assert result.dungeon.goblin == 0
+    assert result.dungeon.skeleton == 0
+    assert result.party.champion == 0
 
 
-class TestDefeatOnePlusAdditional:
+def test_defeat_all_no_additional_when_cleared():
+    """No additional needed when monsters cleared."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=2),
+        party=struct.Party(champion=1),
+    )
+    result = action.defeat_all_plus_additional(
+        w, _UNUSED, "champion", "goblin"
+    )
+    assert result.dungeon.goblin == 0
 
-    def test_defeats_one_plus_one_additional(self):
-        """Defeats one of primary target plus one additional."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=2, skeleton=1),
-            party=struct.Party(champion=1),
-        )
-        result = action.defeat_one_plus_additional(
-            w, _UNUSED, "champion", "goblin", "skeleton"
-        )
-        assert result.dungeon.goblin == 1
-        assert result.dungeon.skeleton == 0
-        assert result.party.champion == 0
 
-    def test_no_additional_when_cleared(self):
-        """No additional needed when all monsters cleared after defeating one."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1),
-            party=struct.Party(fighter=1),
+def test_defeat_all_rejects_extra_additional():
+    """Rejects more than one additional target."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1, skeleton=2),
+        party=struct.Party(champion=1),
+    )
+    with pytest.raises(DrollError):
+        action.defeat_all_plus_additional(
+            w,
+            _UNUSED,
+            "champion",
+            "goblin",
+            "skeleton",
+            "skeleton",
         )
-        result = action.defeat_one_plus_additional(
-            w, _UNUSED, "fighter", "goblin"
-        )
-        assert result.dungeon.goblin == 0
-        assert result.party.fighter == 0
 
-    def test_rejects_additional_when_cleared(self):
-        """Rejects additional target when all monsters already cleared."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1),
-            party=struct.Party(fighter=1),
-        )
-        with pytest.raises(DrollError):
-            action.defeat_one_plus_additional(
-                w, _UNUSED, "fighter", "goblin", "skeleton"
-            )
 
-    def test_requires_additional_when_monsters_remain(self):
-        """Requires additional target when monsters remain after defeating one."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1, skeleton=1),
-            party=struct.Party(fighter=1),
+def test_defeat_all_requires_additional_when_monsters_remain():
+    """Requires additional target when monsters remain."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1, skeleton=1),
+        party=struct.Party(champion=1),
+    )
+    with pytest.raises(DrollError):
+        action.defeat_all_plus_additional(
+            w,
+            _UNUSED,
+            "champion",
+            "goblin",
         )
-        with pytest.raises(DrollError):
-            action.defeat_one_plus_additional(
-                w, _UNUSED, "fighter", "goblin"
-            )
 
-    def test_rejects_extra_additional(self):
-        """Rejects more than one additional target."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1, skeleton=1, ooze=1),
-            party=struct.Party(champion=1),
-        )
-        with pytest.raises(DrollError):
-            action.defeat_one_plus_additional(
-                w,
-                _UNUSED,
-                "champion",
-                "goblin",
-                "skeleton",
-                "ooze",
-            )
 
-    def test_only_decrements_one_of_primary(self):
-        """Defeats only one of the primary target, not all."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=3, skeleton=1),
-            party=struct.Party(champion=1),
+def test_defeats_one_plus_one_additional():
+    """Defeats one of primary target plus one additional."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=2, skeleton=1),
+        party=struct.Party(champion=1),
+    )
+    result = action.defeat_one_plus_additional(
+        w, _UNUSED, "champion", "goblin", "skeleton"
+    )
+    assert result.dungeon.goblin == 1
+    assert result.dungeon.skeleton == 0
+    assert result.party.champion == 0
+
+
+def test_defeat_one_no_additional_when_cleared():
+    """No additional needed when all monsters cleared after defeating one."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1),
+        party=struct.Party(fighter=1),
+    )
+    result = action.defeat_one_plus_additional(w, _UNUSED, "fighter", "goblin")
+    assert result.dungeon.goblin == 0
+    assert result.party.fighter == 0
+
+
+def test_defeat_one_rejects_additional_when_cleared():
+    """Rejects additional target when all monsters already cleared."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1),
+        party=struct.Party(fighter=1),
+    )
+    with pytest.raises(DrollError):
+        action.defeat_one_plus_additional(
+            w, _UNUSED, "fighter", "goblin", "skeleton"
         )
-        result = action.defeat_one_plus_additional(
-            w, _UNUSED, "champion", "goblin", "skeleton"
+
+
+def test_defeat_one_requires_additional_when_monsters_remain():
+    """Requires additional target when monsters remain after defeating one."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1, skeleton=1),
+        party=struct.Party(fighter=1),
+    )
+    with pytest.raises(DrollError):
+        action.defeat_one_plus_additional(w, _UNUSED, "fighter", "goblin")
+
+
+def test_defeat_one_rejects_extra_additional():
+    """Rejects more than one additional target."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1, skeleton=1, ooze=1),
+        party=struct.Party(champion=1),
+    )
+    with pytest.raises(DrollError):
+        action.defeat_one_plus_additional(
+            w,
+            _UNUSED,
+            "champion",
+            "goblin",
+            "skeleton",
+            "ooze",
         )
-        assert result.dungeon.goblin == 2
-        assert result.dungeon.skeleton == 0
-        assert result.party.champion == 0
+
+
+def test_defeat_one_only_decrements_one_of_primary():
+    """Defeats only one of the primary target, not all."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=3, skeleton=1),
+        party=struct.Party(champion=1),
+    )
+    result = action.defeat_one_plus_additional(
+        w, _UNUSED, "champion", "goblin", "skeleton"
+    )
+    assert result.dungeon.goblin == 2
+    assert result.dungeon.skeleton == 0
+    assert result.party.champion == 0
 
 
 class TestRerollParty:
@@ -174,9 +174,7 @@ class TestRerollParty:
         """Rerolling a single party die removes it and re-rolls one party die."""
         # Roll value 0 => fighter
         randrange = self._canned_randrange([0])
-        result = action.reroll(
-            self.world, randrange, "scroll", "fighter"
-        )
+        result = action.reroll(self.world, randrange, "scroll", "fighter")
         # One scroll consumed for the hero cost
         assert result.party.scroll == 1
         # Fighter was removed (2-1=1) then re-rolled as fighter (+1=2)
@@ -218,134 +216,130 @@ class TestRerollParty:
         """Rerolling a party die that is not present raises DrollError."""
         randrange = self._canned_randrange([])
         with pytest.raises(DrollError):
-            action.reroll(
-                self.world, randrange, "scroll", "mage"
-            )
+            action.reroll(self.world, randrange, "scroll", "mage")
 
     def test_reroll_unknown_target_raises(self):
         """Rerolling a target that is neither dungeon nor party raises DrollError."""
         randrange = self._canned_randrange([])
         with pytest.raises(DrollError):
-            action.reroll(
-                self.world, randrange, "scroll", "nonexistent"
-            )
+            action.reroll(self.world, randrange, "scroll", "nonexistent")
 
 
-class TestDefeatDragonHeroesWildcard:
+def test_dragon_wildcard_less_interesting_successful_cases():
+    """Test valid dragon defeats with wildcard heroes."""
+    assert action.defeat_dragon_heroes_wildcard(
+        "cleric",
+        "thief",
+        "mage",
+    )
+    assert action.defeat_dragon_heroes_wildcard(
+        "cleric", "thief", "fighter", _wildcard={"scroll"}
+    )
 
-    def test_less_interesting_successful_cases(self):
-        """Test valid dragon defeats with wildcard heroes."""
-        assert action.defeat_dragon_heroes_wildcard(
+
+def test_dragon_wildcard_less_interesting_failure_cases():
+    """Test invalid dragon defeats with wildcard heroes."""
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_wildcard(
+            "cleric", "thief", _wildcard={"scroll"}
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_wildcard(
+            "cleric", "fighter", _wildcard={"fighter"}
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_wildcard(
+            "cleric", "thief", "champion", "mage", _wildcard={"fighter"}
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_wildcard(
             "cleric",
             "thief",
+            "champion",
+            "fighter",
+            _wildcard={"fighter"},
+        )
+
+
+def test_dragon_wildcard_more_interesting_failure_cases():
+    """Test invalid dragon defeats with multiple wildcard heroes."""
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_wildcard(
             "mage",
+            "mage",
+            "scroll",
         )
-        assert action.defeat_dragon_heroes_wildcard(
-            "cleric", "thief", "fighter", _wildcard={"scroll"}
-        )
-
-    def test_less_interesting_failure_cases(self):
-        """Test invalid dragon defeats with wildcard heroes."""
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_wildcard(
-                "cleric", "thief", _wildcard={"scroll"}
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_wildcard(
-                "cleric", "fighter", _wildcard={"fighter"}
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_wildcard(
-                "cleric", "thief", "champion", "mage", _wildcard={"fighter"}
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_wildcard(
-                "cleric",
-                "thief",
-                "champion",
-                "fighter",
-                _wildcard={"fighter"},
-            )
-
-    def test_more_interesting_failure_cases(self):
-        """Test invalid dragon defeats with multiple wildcard heroes."""
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_wildcard(
-                "mage",
-                "mage",
-                "scroll",
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_wildcard(
-                "fighter",
-                "fighter",
-                "fighter",
-                _wildcard={"mage"},
-            )
-
-
-class TestDefeatDragonHeroesInterchangeable:
-
-    def test_less_interesting_successful_cases(self):
-        """Test valid dragon defeats with interchangeable heroes."""
-        assert action.defeat_dragon_heroes_interchangeable(
-            "cleric", "thief", "mage", _interchangeable={"fighter"}
-        )
-        assert action.defeat_dragon_heroes_interchangeable(
-            "cleric", "thief", "fighter", _interchangeable={"fighter"}
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_wildcard(
+            "fighter",
+            "fighter",
+            "fighter",
+            _wildcard={"mage"},
         )
 
-    def test_less_interesting_failure_cases(self):
-        """Test invalid dragon defeats with interchangeable heroes."""
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "cleric", "thief", _interchangeable={"fighter"}
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "cleric", "fighter", _interchangeable={"fighter"}
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "cleric",
-                "thief",
-                "champion",
-                "mage",
-                _interchangeable={"fighter"},
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "cleric",
-                "thief",
-                "champion",
-                "fighter",
-                _interchangeable={"fighter"},
-            )
 
-    def test_more_interesting_failure_cases(self):
-        """Invalid dragon defeats with multiple interchangeable hero types."""
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "mage", "mage", "mage", _interchangeable={"mage", "fighter"}
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "fighter",
-                "fighter",
-                "fighter",
-                _interchangeable={"mage", "fighter"},
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "fighter", "mage", "mage", _interchangeable={"mage", "fighter"}
-            )
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "mage",
-                "fighter",
-                "fighter",
-                _interchangeable={"mage", "fighter"},
-            )
+def test_dragon_interchangeable_less_interesting_successful_cases():
+    """Test valid dragon defeats with interchangeable heroes."""
+    assert action.defeat_dragon_heroes_interchangeable(
+        "cleric", "thief", "mage", _interchangeable={"fighter"}
+    )
+    assert action.defeat_dragon_heroes_interchangeable(
+        "cleric", "thief", "fighter", _interchangeable={"fighter"}
+    )
+
+
+def test_dragon_interchangeable_less_interesting_failure_cases():
+    """Test invalid dragon defeats with interchangeable heroes."""
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "cleric", "thief", _interchangeable={"fighter"}
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "cleric", "fighter", _interchangeable={"fighter"}
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "cleric",
+            "thief",
+            "champion",
+            "mage",
+            _interchangeable={"fighter"},
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "cleric",
+            "thief",
+            "champion",
+            "fighter",
+            _interchangeable={"fighter"},
+        )
+
+
+def test_dragon_interchangeable_more_interesting_failure_cases():
+    """Invalid dragon defeats with multiple interchangeable hero types."""
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "mage", "mage", "mage", _interchangeable={"mage", "fighter"}
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "fighter",
+            "fighter",
+            "fighter",
+            _interchangeable={"mage", "fighter"},
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "fighter", "mage", "mage", _interchangeable={"mage", "fighter"}
+        )
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "mage",
+            "fighter",
+            "fighter",
+            _interchangeable={"mage", "fighter"},
+        )
 
 
 class TestDragon:
@@ -430,7 +424,11 @@ class TestDragon:
 
         with pytest.raises(error.DrollError):
             player.apply(
-                player.Default, self.game, self.randrange, "fighter", "dragon"
+                player.Default,
+                self.game,
+                self.randrange,
+                "fighter",
+                "dragon",
             )
 
         # Dragon Slayer requires only two
@@ -494,219 +492,227 @@ class TestDragon:
             )
 
 
-class TestConvertDungeonToParty:
-
-    def test_converts_up_to_max_count(self):
-        """Converts min(available, max_count) dungeon dice to party dice."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=3),
-            party=struct.Party(fighter=1),
-        )
-        result = action.convert_dungeon_to_party(
-            w, source="goblin", destination="thief", max_count=2
-        )
-        assert result.dungeon.goblin == 1
-        assert result.party.thief == 2
-        assert result.regroup.discard.thief == 2
-
-    def test_converts_fewer_when_limited(self):
-        """Converts only available count when fewer than max_count."""
-        w = struct.World(
-            dungeon=struct.Dungeon(skeleton=1),
-            party=struct.Party(),
-        )
-        result = action.convert_dungeon_to_party(
-            w, source="skeleton", destination="fighter", max_count=2
-        )
-        assert result.dungeon.skeleton == 0
-        assert result.party.fighter == 1
-        assert result.regroup.discard.fighter == 1
+def test_convert_dungeon_to_party_up_to_max_count():
+    """Converts min(available, max_count) dungeon dice to party dice."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=3),
+        party=struct.Party(fighter=1),
+    )
+    result = action.convert_dungeon_to_party(
+        w, source="goblin", destination="thief", max_count=2
+    )
+    assert result.dungeon.goblin == 1
+    assert result.party.thief == 2
+    assert result.regroup.discard.thief == 2
 
 
-class TestActionErrorPaths:
-    """Tests for game-rule error paths in the action module."""
-
-    def test_decrement_dungeon_zero_target(self):
-        """Cannot decrement a dungeon target that is already zero."""
-        dungeon = struct.Dungeon(goblin=0, skeleton=1)
-        with pytest.raises(DrollError):
-            action.decrement_dungeon(dungeon, "goblin")
-
-    def test_eliminate_dungeon_zero_target(self):
-        """Cannot eliminate a dungeon target that is already zero."""
-        dungeon = struct.Dungeon(goblin=0, skeleton=1)
-        with pytest.raises(DrollError):
-            action.eliminate_dungeon(dungeon, "goblin")
-
-    def test_open_one_before_monsters_defeated(self):
-        """Cannot open chests while monsters remain."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1, chest=1),
-            party=struct.Party(thief=1),
-        )
-        with pytest.raises(DrollError):
-            action.open_one(w, _UNUSED, "thief", "chest")
-
-    def test_open_all_before_monsters_defeated(self):
-        """Cannot open all chests while monsters remain."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1, chest=2),
-            party=struct.Party(thief=1),
-        )
-        with pytest.raises(DrollError):
-            action.open_all(w, _UNUSED, "thief", "chest")
-
-    def test_quaff_no_potions(self):
-        """Cannot quaff when no potions are available."""
-        w = struct.World(
-            dungeon=struct.Dungeon(potion=0),
-            party=struct.Party(fighter=1),
-        )
-        with pytest.raises(DrollError):
-            action.quaff(w, _UNUSED, "fighter", "potion")
-
-    def test_reroll_no_targets(self):
-        """Reroll requires at least one target."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1),
-            party=struct.Party(scroll=1),
-        )
-        with pytest.raises(DrollError):
-            action.reroll(w, _UNUSED, "scroll")
-
-    def test_reroll_dragon_disallowed(self):
-        """Cannot reroll dragon dice by default."""
-        w = struct.World(
-            dungeon=struct.Dungeon(dragon=3),
-            party=struct.Party(scroll=1),
-        )
-        with pytest.raises(DrollError):
-            action.reroll(w, _UNUSED, "scroll", "dragon")
-
-    def test_interchangeable_disallowed_hero(self):
-        """Scrolls cannot defeat a dragon via interchangeable heroes."""
-        with pytest.raises(DrollError):
-            action.defeat_dragon_heroes_interchangeable(
-                "scroll", "fighter", "thief",
-                _interchangeable={"fighter", "mage"},
-            )
-
-    def test_bait_non_dragon_target(self):
-        """Bait can only target dragons."""
-        w = struct.World(
-            dungeon=struct.Dungeon(goblin=1),
-            party=struct.Party(fighter=1),
-            treasure=struct.Treasure(bait=1),
-        )
-        with pytest.raises(DrollError):
-            action.bait_dragon(w, _UNUSED, "bait", "goblin")
-
-    def test_consume_ability_when_unavailable(self):
-        """Cannot consume ability that is already used."""
-        w = struct.World(ability=False)
-        with pytest.raises(DrollError):
-            action.consume_ability(w)
-
-    def test_nop_ability_rejects_target(self):
-        """Default nop ability rejects any target."""
-        w = struct.World(ability=True)
-        with pytest.raises(DrollError):
-            action.nop_ability(w, _UNUSED, "ability", "fighter")
+def test_convert_dungeon_to_party_fewer_when_limited():
+    """Converts only available count when fewer than max_count."""
+    w = struct.World(
+        dungeon=struct.Dungeon(skeleton=1),
+        party=struct.Party(),
+    )
+    result = action.convert_dungeon_to_party(
+        w, source="skeleton", destination="fighter", max_count=2
+    )
+    assert result.dungeon.skeleton == 0
+    assert result.party.fighter == 1
+    assert result.regroup.discard.fighter == 1
 
 
-class TestRegroupDiscard:
+def test_decrement_dungeon_zero_target():
+    """Cannot decrement a dungeon target that is already zero."""
+    dungeon = struct.Dungeon(goblin=0, skeleton=1)
+    with pytest.raises(DrollError):
+        action.decrement_dungeon(dungeon, "goblin")
 
-    def test_regroup_discard_after_quaff(self):
-        """
-        Quaffing a new thief with a force-discard thief clears discarding.
 
-        A thief gained via Half-Goblin ability (marked for discard) quaffs a
-        potion to revive another thief.  The revived thief survives regroup.
-        """
-        # Setup: thief from ability (marked for discard), 1 potion available
-        pre = struct.World(
-            delve=1,
-            depth=1,
-            experience=0,
-            ability=False,
-            dungeon=struct.Dungeon(potion=1),
-            party=struct.Party(thief=1),
-            regroup=struct.Regroup(discard=struct.Party(thief=1)),
-        )
-        # Thief quaffs potion, reviving another thief
-        post = action.quaff(pre, None, "thief", "potion", "thief")
-        # The marked thief was consumed so the discard counter must drop
-        assert post.regroup.discard.thief == 0
-        assert post.party.thief == 1
+def test_eliminate_dungeon_zero_target():
+    """Cannot eliminate a dungeon target that is already zero."""
+    dungeon = struct.Dungeon(goblin=0, skeleton=1)
+    with pytest.raises(DrollError):
+        action.eliminate_dungeon(dungeon, "goblin")
 
-        # After descending the revived thief must survive regroup
-        descended = world.descend(
-            post,
-            dice.roll_dungeon,
-            random.Random(4).randrange,
-        )
-        assert descended.party.thief == 1
 
-    def test_regroup_discard_after_elixir1(self):
-        """Accounting of revived vs force-discard thieves via elixirs."""
-        # Setup: thief from ability (marked for discard), 1 ooze present
-        pre = struct.World(
-            delve=1,
-            depth=1,
-            experience=0,
-            ability=False,
-            dungeon=struct.Dungeon(ooze=1),
-            party=struct.Party(thief=1),
-            regroup=struct.Regroup(discard=struct.Party(thief=1)),
-            treasure=struct.Treasure(elixir=1),
+def test_open_one_before_monsters_defeated():
+    """Cannot open chests while monsters remain."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1, chest=1),
+        party=struct.Party(thief=1),
+    )
+    with pytest.raises(DrollError):
+        action.open_one(w, _UNUSED, "thief", "chest")
+
+
+def test_open_all_before_monsters_defeated():
+    """Cannot open all chests while monsters remain."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1, chest=2),
+        party=struct.Party(thief=1),
+    )
+    with pytest.raises(DrollError):
+        action.open_all(w, _UNUSED, "thief", "chest")
+
+
+def test_quaff_no_potions():
+    """Cannot quaff when no potions are available."""
+    w = struct.World(
+        dungeon=struct.Dungeon(potion=0),
+        party=struct.Party(fighter=1),
+    )
+    with pytest.raises(DrollError):
+        action.quaff(w, _UNUSED, "fighter", "potion")
+
+
+def test_reroll_no_targets():
+    """Reroll requires at least one target."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1),
+        party=struct.Party(scroll=1),
+    )
+    with pytest.raises(DrollError):
+        action.reroll(w, _UNUSED, "scroll")
+
+
+def test_reroll_dragon_disallowed():
+    """Cannot reroll dragon dice by default."""
+    w = struct.World(
+        dungeon=struct.Dungeon(dragon=3),
+        party=struct.Party(scroll=1),
+    )
+    with pytest.raises(DrollError):
+        action.reroll(w, _UNUSED, "scroll", "dragon")
+
+
+def test_interchangeable_disallowed_hero():
+    """Scrolls cannot defeat a dragon via interchangeable heroes."""
+    with pytest.raises(DrollError):
+        action.defeat_dragon_heroes_interchangeable(
+            "scroll",
+            "fighter",
+            "thief",
+            _interchangeable={"fighter", "mage"},
         )
 
-        # Force-discard thief kills the ooze
-        post1 = action.defeat_one(pre, None, "thief", "ooze")
-        assert post1.regroup.discard.thief == 0
-        assert post1.party.thief == 0
 
-        # Elixir revives a new thief
-        post2 = action.elixir(post1, None, "elixir", "thief")
-        assert post2.regroup.discard.thief == 0
-        assert post2.party.thief == 1
+def test_bait_non_dragon_target():
+    """Bait can only target dragons."""
+    w = struct.World(
+        dungeon=struct.Dungeon(goblin=1),
+        party=struct.Party(fighter=1),
+        treasure=struct.Treasure(bait=1),
+    )
+    with pytest.raises(DrollError):
+        action.bait_dragon(w, _UNUSED, "bait", "goblin")
 
-        # After descending the revived thief must survive regroup
-        descended = world.descend(
-            post2,
-            dice.roll_dungeon,
-            random.Random(4).randrange,
-        )
-        assert descended.party.thief == 1
 
-    def test_regroup_discard_after_elixir2(self):
-        """Accounting of revived vs force-discard thieves via elixirs."""
-        # Setup: thief from ability (marked for discard), 1 ooze present
-        pre = struct.World(
-            delve=1,
-            depth=1,
-            experience=0,
-            ability=False,
-            dungeon=struct.Dungeon(ooze=1),
-            party=struct.Party(thief=1),
-            regroup=struct.Regroup(discard=struct.Party(thief=1)),
-            treasure=struct.Treasure(elixir=1),
-        )
+def test_consume_ability_when_unavailable():
+    """Cannot consume ability that is already used."""
+    w = struct.World(ability=False)
+    with pytest.raises(DrollError):
+        action.consume_ability(w)
 
-        # Elixir revives a new thief
-        post1 = action.elixir(pre, None, "elixir", "thief")
-        assert post1.regroup.discard.thief == 1
-        assert post1.party.thief == 2
 
-        # Force-discard thief kills the ooze
-        post2 = action.defeat_one(post1, None, "thief", "ooze")
-        assert post2.regroup.discard.thief == 0
-        assert post2.party.thief == 1
+def test_nop_ability_rejects_target():
+    """Default nop ability rejects any target."""
+    w = struct.World(ability=True)
+    with pytest.raises(DrollError):
+        action.nop_ability(w, _UNUSED, "ability", "fighter")
 
-        # After descending the revived thief must survive regroup
-        descended = world.descend(
-            post2,
-            dice.roll_dungeon,
-            random.Random(4).randrange,
-        )
-        assert descended.party.thief == 1
+
+def test_regroup_discard_after_quaff():
+    """
+    Quaffing a new thief with a force-discard thief clears discarding.
+
+    A thief gained via Half-Goblin ability (marked for discard) quaffs a
+    potion to revive another thief.  The revived thief survives regroup.
+    """
+    # Setup: thief from ability (marked for discard), 1 potion available
+    pre = struct.World(
+        delve=1,
+        depth=1,
+        experience=0,
+        ability=False,
+        dungeon=struct.Dungeon(potion=1),
+        party=struct.Party(thief=1),
+        regroup=struct.Regroup(discard=struct.Party(thief=1)),
+    )
+    # Thief quaffs potion, reviving another thief
+    post = action.quaff(pre, None, "thief", "potion", "thief")
+    # The marked thief was consumed so the discard counter must drop
+    assert post.regroup.discard.thief == 0
+    assert post.party.thief == 1
+
+    # After descending the revived thief must survive regroup
+    descended = world.descend(
+        post,
+        dice.roll_dungeon,
+        random.Random(4).randrange,
+    )
+    assert descended.party.thief == 1
+
+
+def test_regroup_discard_after_elixir1():
+    """Accounting of revived vs force-discard thieves via elixirs."""
+    # Setup: thief from ability (marked for discard), 1 ooze present
+    pre = struct.World(
+        delve=1,
+        depth=1,
+        experience=0,
+        ability=False,
+        dungeon=struct.Dungeon(ooze=1),
+        party=struct.Party(thief=1),
+        regroup=struct.Regroup(discard=struct.Party(thief=1)),
+        treasure=struct.Treasure(elixir=1),
+    )
+
+    # Force-discard thief kills the ooze
+    post1 = action.defeat_one(pre, None, "thief", "ooze")
+    assert post1.regroup.discard.thief == 0
+    assert post1.party.thief == 0
+
+    # Elixir revives a new thief
+    post2 = action.elixir(post1, None, "elixir", "thief")
+    assert post2.regroup.discard.thief == 0
+    assert post2.party.thief == 1
+
+    # After descending the revived thief must survive regroup
+    descended = world.descend(
+        post2,
+        dice.roll_dungeon,
+        random.Random(4).randrange,
+    )
+    assert descended.party.thief == 1
+
+
+def test_regroup_discard_after_elixir2():
+    """Accounting of revived vs force-discard thieves via elixirs."""
+    # Setup: thief from ability (marked for discard), 1 ooze present
+    pre = struct.World(
+        delve=1,
+        depth=1,
+        experience=0,
+        ability=False,
+        dungeon=struct.Dungeon(ooze=1),
+        party=struct.Party(thief=1),
+        regroup=struct.Regroup(discard=struct.Party(thief=1)),
+        treasure=struct.Treasure(elixir=1),
+    )
+
+    # Elixir revives a new thief
+    post1 = action.elixir(pre, None, "elixir", "thief")
+    assert post1.regroup.discard.thief == 1
+    assert post1.party.thief == 2
+
+    # Force-discard thief kills the ooze
+    post2 = action.defeat_one(post1, None, "thief", "ooze")
+    assert post2.regroup.discard.thief == 0
+    assert post2.party.thief == 1
+
+    # After descending the revived thief must survive regroup
+    descended = world.descend(
+        post2,
+        dice.roll_dungeon,
+        random.Random(4).randrange,
+    )
+    assert descended.party.thief == 1

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -7,154 +7,149 @@ from droll import display
 from droll import struct
 
 
-class TestFormatItems:
-
-    def test_multiple_items(self):
-        """Test formatting party with multiple quantities uses × notation."""
-        party = struct.Party(fighter=2, cleric=1, mage=3)
-        assert display._format_items(party) == "fighter×2 cleric mage×3"
-
-    def test_dragon_always_shows_count(self):
-        """Test that dragons always display with count, even when singular."""
-        dungeon = struct.Dungeon(dragon=1)
-        assert display._format_items(dungeon) == "dragon×1"
+def test_format_items_multiple_items():
+    """Test formatting party with multiple quantities uses × notation."""
+    party = struct.Party(fighter=2, cleric=1, mage=3)
+    assert display._format_items(party) == "fighter×2 cleric mage×3"
 
 
-class TestFormatTreasure:
-
-    def test_multiple_items_alphabetized(self):
-        """Test multiple treasure items are alphabetized and use × notation."""
-        treasure = struct.Treasure(scale=4, sceptre=1, talisman=1, tools=1)
-        assert (
-            display._format_treasure(treasure)
-            == "scale×4 sceptre talisman tools"
-        )
+def test_format_items_dragon_always_shows_count():
+    """Test that dragons always display with count, even when singular."""
+    dungeon = struct.Dungeon(dragon=1)
+    assert display._format_items(dungeon) == "dragon×1"
 
 
-class TestFormatAvailable:
-
-    def test_alphabetized(self):
-        """Test available commands are displayed in alphabetical order."""
-        available = ["retreat", "ability", "reroll"]
-        assert display._format_available(available) == "ability reroll retreat"
-
-
-class TestFormatDungeon:
-
-    def test_empty_dungeon(self):
-        """Test formatting empty dungeon returns 'None' string."""
-        dungeon = struct.Dungeon()
-        assert display._format_dungeon(dungeon) == "None"
-
-    def test_with_monsters(self):
-        """Test formatting dungeon with monsters."""
-        dungeon = struct.Dungeon(goblin=1, skeleton=2)
-        assert display._format_dungeon(dungeon) == "goblin skeleton×2"
+def test_format_treasure_multiple_items_alphabetized():
+    """Test multiple treasure items are alphabetized and use × notation."""
+    treasure = struct.Treasure(scale=4, sceptre=1, talisman=1, tools=1)
+    assert (
+        display._format_treasure(treasure) == "scale×4 sceptre talisman tools"
+    )
 
 
-class TestCompactSummary:
+def test_format_available_alphabetized():
+    """Test available commands are displayed in alphabetical order."""
+    available = ["retreat", "ability", "reroll"]
+    assert display._format_available(available) == "ability reroll retreat"
 
-    def test_in_dungeon(self):
-        """Test compact summary while in a dungeon with monsters."""
-        world = struct.World(
-            delve=1,
-            depth=3,
-            experience=0,
-            dungeon=struct.Dungeon(goblin=1, skeleton=2, ooze=2),
-            party=struct.Party(fighter=1, champion=1),
-            ability=True,
-            treasure=struct.Treasure(talisman=1),
-        )
-        result = display.compact_summary(
-            world, "Default", 1, ["ability", "retreat"]
-        )
-        lines = result.split("\n")
-        assert len(lines) == 5
-        assert "depth 3 in delve 1 with experience 0" in lines[0]
-        assert "talisman" in lines[1]
-        assert "ability retreat" in lines[2]
-        assert "fighter champion" in lines[3]
-        assert "goblin skeleton×2 ooze×2" in lines[4]
 
-    def test_long_player_name_alignment(self):
-        """Test that long player names maintain proper column alignment."""
-        world = struct.World(
-            delve=2,
-            depth=0,
-            experience=5,
-            dungeon=None,
-            party=struct.Party(fighter=1, cleric=2, mage=3, champion=1),
-            ability=True,
-            treasure=struct.Treasure(talisman=1),
-        )
-        result = display.compact_summary(
-            world, "DragonSlayer", 6, ["ability", "descend"]
-        )
-        lines = result.split("\n")
-        # Check that alignment matches DragonSlayer> width (13 chars)
-        for line in lines:
-            colon_pos = line.index(":")
-            content_start = colon_pos + 1
-            while content_start < len(line) and line[content_start] == " ":
-                content_start += 1
-            # Content should start at same column for all lines
-            assert content_start >= 13
+def test_format_dungeon_empty():
+    """Test formatting empty dungeon returns 'None' string."""
+    dungeon = struct.Dungeon()
+    assert display._format_dungeon(dungeon) == "None"
 
-    def test_dungeon_shown_when_empty(self):
-        """Test that empty dungeons display 'Dungeon: None' in the summary."""
-        world = struct.World(
-            delve=1,
-            depth=1,
-            experience=0,
-            dungeon=struct.Dungeon(),
-            party=struct.Party(fighter=1, cleric=1),
-            ability=True,
-            treasure=struct.Treasure(),
-        )
-        result = display.compact_summary(
-            world, "Knight", 0, ["ability", "descend", "retire"]
-        )
-        lines = result.split("\n")
-        assert len(lines) == 5
-        assert "Dungeon:" in lines[4]
-        assert "None" in lines[4]
 
-    def test_cleared_level_10(self):
-        """Test compact summary after clearing dungeon level 10."""
-        world = struct.World(
-            delve=3,
-            depth=10,
-            experience=16,
-            dungeon=struct.Dungeon(),
-            party=struct.Party(champion=1, scroll=2),
-            ability=False,
-            treasure=struct.Treasure(scale=4, sceptre=1, talisman=1, tools=1),
-        )
-        result = display.compact_summary(world, "Beguiler", 24, ["retire"])
-        lines = result.split("\n")
-        assert "depth 10 in delve 3 with experience 16" in lines[0]
-        assert "scale×4 sceptre talisman tools" in lines[1]
-        assert "retire" in lines[2]
-        assert "champion scroll×2" in lines[3]
-        assert "Dungeon:" in lines[4]
-        assert "None" in lines[4]
-        assert len(lines) == 5
+def test_format_dungeon_with_monsters():
+    """Test formatting dungeon with monsters."""
+    dungeon = struct.Dungeon(goblin=1, skeleton=2)
+    assert display._format_dungeon(dungeon) == "goblin skeleton×2"
 
-    def test_ending_state(self):
-        """After final delve, Available should show 'None'."""
-        world = struct.World(
-            delve=3,
-            experience=16,
-            dungeon=None,
-            party=struct.Party(champion=1),
-            ability=False,
-            treasure=struct.Treasure(
-                scroll=1, elixir=1, bait=2, portal=1, scale=1
-            ),
-        )
-        result = display.compact_summary(world, "DragonSlayer", 23, [])
-        lines = result.split("\n")
-        assert "delve 3 with experience 16" in lines[0]
-        assert "Available:" in lines[2]
-        assert "None" in lines[2]
-        assert len(lines) == 4  # No Dungeon line
+
+def test_compact_summary_in_dungeon():
+    """Test compact summary while in a dungeon with monsters."""
+    world = struct.World(
+        delve=1,
+        depth=3,
+        experience=0,
+        dungeon=struct.Dungeon(goblin=1, skeleton=2, ooze=2),
+        party=struct.Party(fighter=1, champion=1),
+        ability=True,
+        treasure=struct.Treasure(talisman=1),
+    )
+    result = display.compact_summary(
+        world, "Default", 1, ["ability", "retreat"]
+    )
+    lines = result.split("\n")
+    assert len(lines) == 5
+    assert "depth 3 in delve 1 with experience 0" in lines[0]
+    assert "talisman" in lines[1]
+    assert "ability retreat" in lines[2]
+    assert "fighter champion" in lines[3]
+    assert "goblin skeleton×2 ooze×2" in lines[4]
+
+
+def test_compact_summary_long_player_name_alignment():
+    """Test that long player names maintain proper column alignment."""
+    world = struct.World(
+        delve=2,
+        depth=0,
+        experience=5,
+        dungeon=None,
+        party=struct.Party(fighter=1, cleric=2, mage=3, champion=1),
+        ability=True,
+        treasure=struct.Treasure(talisman=1),
+    )
+    result = display.compact_summary(
+        world, "DragonSlayer", 6, ["ability", "descend"]
+    )
+    lines = result.split("\n")
+    # Check that alignment matches DragonSlayer> width (13 chars)
+    for line in lines:
+        colon_pos = line.index(":")
+        content_start = colon_pos + 1
+        while content_start < len(line) and line[content_start] == " ":
+            content_start += 1
+        # Content should start at same column for all lines
+        assert content_start >= 13
+
+
+def test_compact_summary_dungeon_shown_when_empty():
+    """Test that empty dungeons display 'Dungeon: None' in the summary."""
+    world = struct.World(
+        delve=1,
+        depth=1,
+        experience=0,
+        dungeon=struct.Dungeon(),
+        party=struct.Party(fighter=1, cleric=1),
+        ability=True,
+        treasure=struct.Treasure(),
+    )
+    result = display.compact_summary(
+        world, "Knight", 0, ["ability", "descend", "retire"]
+    )
+    lines = result.split("\n")
+    assert len(lines) == 5
+    assert "Dungeon:" in lines[4]
+    assert "None" in lines[4]
+
+
+def test_compact_summary_cleared_level_10():
+    """Test compact summary after clearing dungeon level 10."""
+    world = struct.World(
+        delve=3,
+        depth=10,
+        experience=16,
+        dungeon=struct.Dungeon(),
+        party=struct.Party(champion=1, scroll=2),
+        ability=False,
+        treasure=struct.Treasure(scale=4, sceptre=1, talisman=1, tools=1),
+    )
+    result = display.compact_summary(world, "Beguiler", 24, ["retire"])
+    lines = result.split("\n")
+    assert "depth 10 in delve 3 with experience 16" in lines[0]
+    assert "scale×4 sceptre talisman tools" in lines[1]
+    assert "retire" in lines[2]
+    assert "champion scroll×2" in lines[3]
+    assert "Dungeon:" in lines[4]
+    assert "None" in lines[4]
+    assert len(lines) == 5
+
+
+def test_compact_summary_ending_state():
+    """After final delve, Available should show 'None'."""
+    world = struct.World(
+        delve=3,
+        experience=16,
+        dungeon=None,
+        party=struct.Party(champion=1),
+        ability=False,
+        treasure=struct.Treasure(
+            scroll=1, elixir=1, bait=2, portal=1, scale=1
+        ),
+    )
+    result = display.compact_summary(world, "DragonSlayer", 23, [])
+    lines = result.split("\n")
+    assert "delve 3 with experience 16" in lines[0]
+    assert "Available:" in lines[2]
+    assert "None" in lines[2]
+    assert len(lines) == 4  # No Dungeon line

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -13,142 +13,150 @@ from droll.game import Game, GameState
 from droll.player import Default
 
 
-class TestGame:
+def test_game_construction():
+    """Game can be constructed with various parameter combinations."""
+    Game()
+    Game(player=Default)
+    Game(random=random.Random(4))
 
-    def test_game_construction(self):
-        """Game can be constructed with various parameter combinations."""
-        Game()
-        Game(player=Default)
-        Game(random=random.Random(4))
 
-    def test_gamestate_truthiness(self):
-        """GameState values coerce to boolean correctly for control flow."""
-        assert GameState.STOP, "STOP must coerce to True."
-        assert not GameState.PLAY, "PLAY must coerce to False."
+def test_gamestate_truthiness():
+    """GameState values coerce to boolean correctly for control flow."""
+    assert GameState.STOP, "STOP must coerce to True."
+    assert not GameState.PLAY, "PLAY must coerce to False."
 
-    def test_reroll_dungeon_dice(self):
-        """Test rerolling dungeon dice using a scroll."""
-        g = Game(random=random.Random(4), player=Default)
-        g.descend()  # Start delve
-        # Set up dungeon with goblin and party with scroll
-        g._world = replace(
-            g._world,
-            depth=1,
-            party=replace(g._world.party, scroll=1),
-            dungeon=struct.Dungeon(goblin=2),
-        )
-        pre_scroll = g._world.party.scroll
-        g.reroll("goblin")
-        # Scroll consumed, dungeon rerolled
-        assert g._world.party.scroll == pre_scroll - 1
 
-    def test_reroll_portion(self):
-        """Test rerolling potion using a scroll."""
-        g = Game(random=random.Random(4), player=Default)
-        g.descend()  # Start delve
-        # Set up dungeon with goblin and party with scroll
-        g._world = replace(
-            g._world,
-            depth=1,
-            party=replace(g._world.party, scroll=1),
-            dungeon=struct.Dungeon(potion=2),
-        )
-        pre_scroll = g._world.party.scroll
-        g.reroll("potion")
-        # Scroll consumed, dungeon rerolled
-        assert g._world.party.scroll == pre_scroll - 1
+def test_reroll_dungeon_dice():
+    """Test rerolling dungeon dice using a scroll."""
+    g = Game(random=random.Random(4), player=Default)
+    g.descend()  # Start delve
+    # Set up dungeon with goblin and party with scroll
+    g._world = replace(
+        g._world,
+        depth=1,
+        party=replace(g._world.party, scroll=1),
+        dungeon=struct.Dungeon(goblin=2),
+    )
+    pre_scroll = g._world.party.scroll
+    g.reroll("goblin")
+    # Scroll consumed, dungeon rerolled
+    assert g._world.party.scroll == pre_scroll - 1
 
-    def test_reroll_multiple_targets(self):
-        """Test rerolling multiple dungeon dice."""
-        g = Game(random=random.Random(4), player=Default)
-        g.descend()
-        g._world = replace(
-            g._world,
-            depth=1,
-            party=replace(g._world.party, scroll=1),
-            dungeon=struct.Dungeon(goblin=1, skeleton=1),
-        )
-        g.reroll("goblin", "skeleton")
-        assert g._world.party.scroll == 0
 
-    def test_apply_portal_directly_fails(self):
-        """Test that using portal directly gives helpful error."""
-        g = Game(random=random.Random(4), player=Default)
-        g.descend()
-        g._world = replace(
-            g._world,
-            treasure=replace(g._world.treasure, portal=1),
-        )
-        with pytest.raises(DrollError):
-            g.apply("portal")
+def test_reroll_portion():
+    """Test rerolling potion using a scroll."""
+    g = Game(random=random.Random(4), player=Default)
+    g.descend()  # Start delve
+    # Set up dungeon with goblin and party with scroll
+    g._world = replace(
+        g._world,
+        depth=1,
+        party=replace(g._world.party, scroll=1),
+        dungeon=struct.Dungeon(potion=2),
+    )
+    pre_scroll = g._world.party.scroll
+    g.reroll("potion")
+    # Scroll consumed, dungeon rerolled
+    assert g._world.party.scroll == pre_scroll - 1
 
-    def test_apply_ring_directly_fails(self):
-        """Test that using ring directly gives helpful error."""
-        g = Game(random=random.Random(4), player=Default)
-        g.descend()
-        g._world = replace(
-            g._world,
-            treasure=replace(g._world.treasure, ring=1),
-        )
-        with pytest.raises(DrollError):
-            g.apply("ring")
 
-    def test_retreat(self):
-        """Game.retreat() retreats from dungeon and starts next delve."""
-        g = Game(random=random.Random(4), player=Default)
-        g.descend()
-        # Place a monster so retreat is valid (can't retreat from cleared dungeon)
-        g._world = replace(
-            g._world, dungeon=struct.Dungeon(goblin=1)
-        )
-        result = g.retreat()
-        assert result == GameState.PLAY
-        # After retreat, a new delve should have started
-        assert g._world.depth == 0
-        assert g._world.party is not None
+def test_reroll_multiple_targets():
+    """Test rerolling multiple dungeon dice."""
+    g = Game(random=random.Random(4), player=Default)
+    g.descend()
+    g._world = replace(
+        g._world,
+        depth=1,
+        party=replace(g._world.party, scroll=1),
+        dungeon=struct.Dungeon(goblin=1, skeleton=1),
+    )
+    g.reroll("goblin", "skeleton")
+    assert g._world.party.scroll == 0
 
-    def test_completenames(self):
-        """completenames returns contextual completions including retire/retreat."""
-        g = Game(random=random.Random(4), player=Default)
-        g.descend()
 
-        # With monsters: retreat is possible, retire is not
-        g._world = replace(g._world, dungeon=struct.Dungeon(goblin=1))
-        names = g.completenames(text="", head=[], tail=[])
-        assert "ability" in names
-        assert "retreat" in names
-        assert "retire" not in names
-        # Hero-related completions appear (dungeon not exhausted)
-        assert any(n not in ("ability", "descend", "retire", "retreat") for n in names)
+def test_apply_portal_directly_fails():
+    """Test that using portal directly gives helpful error."""
+    g = Game(random=random.Random(4), player=Default)
+    g.descend()
+    g._world = replace(
+        g._world,
+        treasure=replace(g._world.treasure, portal=1),
+    )
+    with pytest.raises(DrollError):
+        g.apply("portal")
 
-        # With cleared dungeon: retire is possible
-        g._world = replace(g._world, dungeon=struct.Dungeon())
-        names = g.completenames(text="", head=[], tail=[])
-        assert "retire" in names
 
-    def test_completedefault(self):
-        """completedefault delegates to player.complete."""
-        g = Game(random=random.Random(4), player=Default)
-        g.descend()
-        g._world = replace(
-            g._world,
-            dungeon=struct.Dungeon(goblin=1),
-            party=struct.Party(fighter=1),
-        )
-        results = g.completedefault(text="fi", head=[], tail=[])
-        assert "fighter" in results
+def test_apply_ring_directly_fails():
+    """Test that using ring directly gives helpful error."""
+    g = Game(random=random.Random(4), player=Default)
+    g.descend()
+    g._world = replace(
+        g._world,
+        treasure=replace(g._world.treasure, ring=1),
+    )
+    with pytest.raises(DrollError):
+        g.apply("ring")
 
-    def test_next_delve_returns_stop_after_three(self):
-        """Game returns STOP when no more delves remain."""
-        g = Game(random=random.Random(4), player=Default)
-        # Play through 3 delves by retiring from each
-        for _ in range(2):
-            g.descend()
-            g._world = replace(g._world, dungeon=struct.Dungeon())
-            result = g.retire()
-            assert result == GameState.PLAY
-        # Third delve: retire should trigger STOP
+
+def test_retreat():
+    """Game.retreat() retreats from dungeon and starts next delve."""
+    g = Game(random=random.Random(4), player=Default)
+    g.descend()
+    # Place a monster so retreat is valid (can't retreat from cleared dungeon)
+    g._world = replace(g._world, dungeon=struct.Dungeon(goblin=1))
+    result = g.retreat()
+    assert result == GameState.PLAY
+    # After retreat, a new delve should have started
+    assert g._world.depth == 0
+    assert g._world.party is not None
+
+
+def test_completenames():
+    """completenames returns contextual completions including retire/retreat."""
+    g = Game(random=random.Random(4), player=Default)
+    g.descend()
+
+    # With monsters: retreat is possible, retire is not
+    g._world = replace(g._world, dungeon=struct.Dungeon(goblin=1))
+    names = g.completenames(text="", head=[], tail=[])
+    assert "ability" in names
+    assert "retreat" in names
+    assert "retire" not in names
+    # Hero-related completions appear (dungeon not exhausted)
+    assert any(
+        n not in ("ability", "descend", "retire", "retreat") for n in names
+    )
+
+    # With cleared dungeon: retire is possible
+    g._world = replace(g._world, dungeon=struct.Dungeon())
+    names = g.completenames(text="", head=[], tail=[])
+    assert "retire" in names
+
+
+def test_completedefault():
+    """completedefault delegates to player.complete."""
+    g = Game(random=random.Random(4), player=Default)
+    g.descend()
+    g._world = replace(
+        g._world,
+        dungeon=struct.Dungeon(goblin=1),
+        party=struct.Party(fighter=1),
+    )
+    results = g.completedefault(text="fi", head=[], tail=[])
+    assert "fighter" in results
+
+
+def test_next_delve_returns_stop_after_three():
+    """Game returns STOP when no more delves remain."""
+    g = Game(random=random.Random(4), player=Default)
+    # Play through 3 delves by retiring from each
+    for _ in range(2):
         g.descend()
         g._world = replace(g._world, dungeon=struct.Dungeon())
         result = g.retire()
-        assert result == GameState.STOP
+        assert result == GameState.PLAY
+    # Third delve: retire should trigger STOP
+    g.descend()
+    g._world = replace(g._world, dungeon=struct.Dungeon())
+    result = g.retire()
+    assert result == GameState.STOP

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -223,9 +223,8 @@ class TestComplete:
         # Special case associated with 'elixir'
         game = replace(game, party=struct.Party())
         game = replace(game, treasure=struct.Treasure())
-        assert (
-            complete(game, ("elixir", ""), "", 1)
-            == list(sorted(struct.field_names(struct.Party)))
+        assert complete(game, ("elixir", ""), "", 1) == list(
+            sorted(struct.field_names(struct.Party))
         )
 
     def test_complete2(self):
@@ -235,5 +234,6 @@ class TestComplete:
         assert complete(game, ("X", "Y", "fig"), "fig", 2) == ["fighter"]
         assert complete(game, ("X", "Y", "gob"), "gob", 2) == ["goblin"]
         assert complete(game, ("X", "Y", "ch"), "ch", 2) == [
-            "champion", "chest"
+            "champion",
+            "chest",
         ]

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -22,73 +22,71 @@ def _mechanical_shell(game: Game) -> Shell:
     return Shell(game, display_mode=DisplayMode.MECHANICAL)
 
 
-class TestPrecmd:
-
-    def test_precmd_emits_reset_when_color_enabled(self):
-        with patch("sys.stdout.isatty", return_value=True):
-            s = Shell(Game(), display_mode=DisplayMode.CURRENT)
-        s.preloop()
-        with patch("sys.stdout", new_callable=io.StringIO) as fake_out:
-            result = s.precmd("fighter goblin")
-        assert result == "fighter goblin"
-        assert fake_out.getvalue() == _RESET
-
-    def test_precmd_emits_nothing_when_color_disabled(self):
-        s = _mechanical_shell(Game())
-        s.preloop()
-        with patch("sys.stdout", new_callable=io.StringIO) as fake_out:
-            result = s.precmd("fighter goblin")
-        assert result == "fighter goblin"
-        assert fake_out.getvalue() == ""
+def test_precmd_emits_reset_when_color_enabled():
+    with patch("sys.stdout.isatty", return_value=True):
+        s = Shell(Game(), display_mode=DisplayMode.CURRENT)
+    s.preloop()
+    with patch("sys.stdout", new_callable=io.StringIO) as fake_out:
+        result = s.precmd("fighter goblin")
+    assert result == "fighter goblin"
+    assert fake_out.getvalue() == _RESET
 
 
-class TestShell:
+def test_precmd_emits_nothing_when_color_disabled():
+    s = _mechanical_shell(Game())
+    s.preloop()
+    with patch("sys.stdout", new_callable=io.StringIO) as fake_out:
+        result = s.precmd("fighter goblin")
+    assert result == "fighter goblin"
+    assert fake_out.getvalue() == ""
 
-    def test_EOF(self):
-        """Confirm providing EOF exits cmdloop(...)."""
-        s = _mechanical_shell(Game())
-        assert not s.cmdqueue
-        s.cmdqueue.append("EOF")
-        s.cmdloop()
-        assert s.prompt == "(Default  0) "
-        assert s.lastcmd == ""
 
-    def test_reroll(self):
-        """Confirm reroll command forwards to game."""
-        s = _mechanical_shell(Game(random=random.Random(4), player=Default))
-        s.preloop()
-        s.onecmd("descend")
-        # Depth 1 with seed 4 has a single goblin; reroll it
-        s.onecmd("reroll goblin")
+def test_shell_EOF():
+    """Confirm providing EOF exits cmdloop(...)."""
+    s = _mechanical_shell(Game())
+    assert not s.cmdqueue
+    s.cmdqueue.append("EOF")
+    s.cmdloop()
+    assert s.prompt == "(Default  0) "
+    assert s.lastcmd == ""
 
-    def test_retreat(self):
-        """Confirm retreat command forwards to game."""
-        s = _mechanical_shell(Game(random=random.Random(4), player=Default))
-        s.preloop()
-        s.onecmd("descend")
-        # Need a monster present so retreat is valid
-        s._game._world = replace(
-            s._game._world, dungeon=struct.Dungeon(goblin=1)
-        )
-        s.onecmd("retreat")
 
-    def test_help(self):
-        """Confirm help invocations do not throw exceptions."""
-        s = _mechanical_shell(Game())
-        s.help_ability()
-        s.help_bait()
-        s.help_champion()
-        s.help_cleric()
-        s.help_elixir()
-        s.help_fighter()
-        s.help_mage()
-        s.help_ring()
-        s.help_sceptre()
-        s.help_scroll()
-        s.help_sword()
-        s.help_talisman()
-        s.help_thief()
-        s.help_tools()
+def test_shell_reroll():
+    """Confirm reroll command forwards to game."""
+    s = _mechanical_shell(Game(random=random.Random(4), player=Default))
+    s.preloop()
+    s.onecmd("descend")
+    # Depth 1 with seed 4 has a single goblin; reroll it
+    s.onecmd("reroll goblin")
+
+
+def test_shell_retreat():
+    """Confirm retreat command forwards to game."""
+    s = _mechanical_shell(Game(random=random.Random(4), player=Default))
+    s.preloop()
+    s.onecmd("descend")
+    # Need a monster present so retreat is valid
+    s._game._world = replace(s._game._world, dungeon=struct.Dungeon(goblin=1))
+    s.onecmd("retreat")
+
+
+def test_shell_help():
+    """Confirm help invocations do not throw exceptions."""
+    s = _mechanical_shell(Game())
+    s.help_ability()
+    s.help_bait()
+    s.help_champion()
+    s.help_cleric()
+    s.help_elixir()
+    s.help_fighter()
+    s.help_mage()
+    s.help_ring()
+    s.help_sceptre()
+    s.help_scroll()
+    s.help_sword()
+    s.help_talisman()
+    s.help_thief()
+    s.help_tools()
 
 
 # Strategy for testing, further below, will turn docstrings into assertions
@@ -111,116 +109,114 @@ def parse_summary_command(text) -> typing.Iterable[typing.Tuple[str, str]]:
     return zip(summaries, commands)
 
 
-class TestUndo:
+def test_undo():
+    """Based upon test_simple(...), verify undo behaving as expected."""
+    s = _mechanical_shell(Game(random=random.Random(4), player=Default))
 
-    def test_undo(self):
-        """Based upon test_simple(...), verify undo behaving as expected."""
-        s = _mechanical_shell(Game(random=random.Random(4), player=Default))
+    # Supplies a private flag so that DrollErrors percolate to this level
+    def onecmd(line):
+        """Execute shell command with errors raised instead of printed."""
+        s.onecmd(line, _raises=True)
 
-        # Supplies a private flag so that DrollErrors percolate to this level
-        def onecmd(line):
-            """Execute shell command with errors raised instead of printed."""
-            s.onecmd(line, _raises=True)
+    s.preloop()
 
-        s.preloop()
-
-        # (delve=1, party=(fighter=1, cleric=2, mage=1, thief=2, scroll=1), ...)
-        with pytest.raises(DrollError):
-            onecmd("undo")
-        with pytest.raises(DrollError):
-            onecmd("undo")
-        onecmd("descend")
-
-        # (delve=1, depth=1, dungeon=(goblin=1),
-        #  party=(fighter=1, cleric=2, mage=1, thief=2, scroll=1), ...)
-        with pytest.raises(DrollError):
-            onecmd("undo")
-        onecmd("fighter goblin")
+    # (delve=1, party=(fighter=1, cleric=2, mage=1, thief=2, scroll=1), ...)
+    with pytest.raises(DrollError):
         onecmd("undo")
-        with pytest.raises(DrollError):
-            onecmd("undo")
-        onecmd("cleric goblin")
+    with pytest.raises(DrollError):
         onecmd("undo")
-        with pytest.raises(DrollError):
-            onecmd("undo")
-        onecmd("mage goblin")
-        onecmd("descend")
+    onecmd("descend")
 
-        # (delve=1, depth=2, dungeon=(goblin=2), ...)
-        assert s._game._world.dungeon.goblin == 2
-        with pytest.raises(DrollError):
-            onecmd("undo")
-        onecmd("thief goblin")
-        onecmd("fighter goblin")
+    # (delve=1, depth=1, dungeon=(goblin=1),
+    #  party=(fighter=1, cleric=2, mage=1, thief=2, scroll=1), ...)
+    with pytest.raises(DrollError):
         onecmd("undo")
+    onecmd("fighter goblin")
+    onecmd("undo")
+    with pytest.raises(DrollError):
         onecmd("undo")
-        onecmd("fighter goblin")
-        onecmd("descend")
-
-        # (delve=1, depth=3, dungeon=(ooze=1, chest=1, potion=1), ...)
-        assert s._game._world.dungeon.ooze == 1
-        assert s._game._world.dungeon.chest == 1
-        assert s._game._world.dungeon.potion == 1
-        with pytest.raises(DrollError):
-            onecmd("undo")
-        onecmd("cleric ooze")
+    onecmd("cleric goblin")
+    onecmd("undo")
+    with pytest.raises(DrollError):
         onecmd("undo")
-        onecmd("cleric ooze")
-        onecmd("thief chest")
-        with pytest.raises(DrollError):
-            onecmd("undo")
-        onecmd("scroll potion champion")
+    onecmd("mage goblin")
+    onecmd("descend")
+
+    # (delve=1, depth=2, dungeon=(goblin=2), ...)
+    assert s._game._world.dungeon.goblin == 2
+    with pytest.raises(DrollError):
         onecmd("undo")
-        onecmd("scroll potion thief")
-        onecmd("descend")
+    onecmd("thief goblin")
+    onecmd("fighter goblin")
+    onecmd("undo")
+    onecmd("undo")
+    onecmd("fighter goblin")
+    onecmd("descend")
 
-    def test_undo_in_available_commands(self):
-        """Verify undo appears in available commands only when undo stack is not empty."""
-        s = _mechanical_shell(Game(random=random.Random(42), player=Default))
-        s.preloop()
-
-        # Initially, undo stack is empty, so "undo" should not be available
-        available = s._available_commands()
-        assert "undo" not in available
-
-        # Execute a command that can be undone (ability doesn't change random state)
-        s.onecmd("ability")
-
-        # Now undo stack has one item, so "undo" should be available
-        available = s._available_commands()
-        assert "undo" in available
-
-        # Execute undo to restore previous state
-        s.onecmd("undo")
-
-        # Undo stack is empty again, so "undo" should not be available
-        available = s._available_commands()
-        assert "undo" not in available
+    # (delve=1, depth=3, dungeon=(ooze=1, chest=1, potion=1), ...)
+    assert s._game._world.dungeon.ooze == 1
+    assert s._game._world.dungeon.chest == 1
+    assert s._game._world.dungeon.potion == 1
+    with pytest.raises(DrollError):
+        onecmd("undo")
+    onecmd("cleric ooze")
+    onecmd("undo")
+    onecmd("cleric ooze")
+    onecmd("thief chest")
+    with pytest.raises(DrollError):
+        onecmd("undo")
+    onecmd("scroll potion champion")
+    onecmd("undo")
+    onecmd("scroll potion thief")
+    onecmd("descend")
 
 
-class TestRetireAndQuaffError:
+def test_undo_in_available_commands():
+    """Verify undo appears in available commands only when undo stack is not empty."""
+    s = _mechanical_shell(Game(random=random.Random(42), player=Default))
+    s.preloop()
 
-    def test_retire(self):
-        """Shell.do_retire exercises the retire command path."""
-        s = _mechanical_shell(Game(random=random.Random(4), player=Default))
-        s.preloop()
-        s.onecmd("descend")
-        # Seed 4 at depth 1 produces goblin=1; defeat it
-        s.onecmd("fighter goblin")
-        # Dungeon cleared: retire covers shell.py do_retire
-        s.onecmd("retire")
+    # Initially, undo stack is empty, so "undo" should not be available
+    available = s._available_commands()
+    assert "undo" not in available
 
-    def test_quaff_wrong_revive_count_prints_error(self):
-        """Quaffing with wrong revive count prints DrollError via onecmd."""
-        s = _mechanical_shell(Game(random=random.Random(4), player=Default))
-        s.preloop()
-        s.onecmd("descend")
-        # Replace dungeon with a single potion and no monsters
-        s._game._world = replace(
-            s._game._world,
-            dungeon=struct.Dungeon(potion=1),
-        )
-        # Quaff 1 potion providing 0 revive targets:
-        # - action.py quaff raises "Exactly 1 heroes to revive required."
-        # - onecmd catches and prints the DrollError
-        s.onecmd("fighter potion")
+    # Execute a command that can be undone (ability doesn't change random state)
+    s.onecmd("ability")
+
+    # Now undo stack has one item, so "undo" should be available
+    available = s._available_commands()
+    assert "undo" in available
+
+    # Execute undo to restore previous state
+    s.onecmd("undo")
+
+    # Undo stack is empty again, so "undo" should not be available
+    available = s._available_commands()
+    assert "undo" not in available
+
+
+def test_retire():
+    """Shell.do_retire exercises the retire command path."""
+    s = _mechanical_shell(Game(random=random.Random(4), player=Default))
+    s.preloop()
+    s.onecmd("descend")
+    # Seed 4 at depth 1 produces goblin=1; defeat it
+    s.onecmd("fighter goblin")
+    # Dungeon cleared: retire covers shell.py do_retire
+    s.onecmd("retire")
+
+
+def test_quaff_wrong_revive_count_prints_error():
+    """Quaffing with wrong revive count prints DrollError via onecmd."""
+    s = _mechanical_shell(Game(random=random.Random(4), player=Default))
+    s.preloop()
+    s.onecmd("descend")
+    # Replace dungeon with a single potion and no monsters
+    s._game._world = replace(
+        s._game._world,
+        dungeon=struct.Dungeon(potion=1),
+    )
+    # Quaff 1 potion providing 0 revive targets:
+    # - action.py quaff raises "Exactly 1 heroes to revive required."
+    # - onecmd catches and prints the DrollError
+    s.onecmd("fighter potion")

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -289,9 +289,7 @@ class TestWorld:
         assert not world.exhausted_dungeon(struct.Dungeon(ooze=1))
 
         # Dungeon with chests/potions still has actions (not exhausted)
-        assert not world.exhausted_dungeon(
-            struct.Dungeon(chest=2, potion=3)
-        )
+        assert not world.exhausted_dungeon(struct.Dungeon(chest=2, potion=3))
 
     def test_retreat_valid(self):
         """Test valid retreat scenarios."""


### PR DESCRIPTION
Classes without setup_method (i.e. those that solely namespace tests)
are converted to module-level functions.  Classes with setup_method
(TestDragon, TestRerollParty, TestPlayer, TestComplete, TestWorld,
TestTreasure) retain their class form since they provide shared
fixtures.

Formatted with black --line-length 79.

https://claude.ai/code/session_01FGo3GDZprsmRYiwRgojQxA