### PR TITLE
Rename exhausted_dungeon to finished_dungeon for clarity

### DIFF
--- a/droll/dungeon.py
+++ b/droll/dungeon.py
@@ -14,7 +14,7 @@ __all__ = (
     "defeated_dungeon",
     "defeated_monsters",
     "eliminate_dungeon",
-    "exhausted_dungeon",
+    "finished_dungeon",
     "increment_dungeon",
 )
 
@@ -34,7 +34,7 @@ def blocking_dragon(dungeon: Dungeon) -> bool:
     return defeated_monsters(dungeon) and not defeated_dungeon(dungeon)
 
 
-def exhausted_dungeon(dungeon: Dungeon) -> bool:
+def finished_dungeon(dungeon: Dungeon) -> bool:
     """Has the player exhausted all possible actions for this dungeon?
 
     In contrast to defeated_dungeon(...), returns True if chests/etc remain."""

--- a/droll/game.py
+++ b/droll/game.py
@@ -183,7 +183,7 @@ class Game:
     ) -> Sequence[str]:
         """Complete possible command names based upon context."""
         results = [x for x in self._possible_world_actions() if x.startswith(text)]
-        if not dungeon.exhausted_dungeon(self._world.dungeon):
+        if not dungeon.finished_dungeon(self._world.dungeon):
             results += self.completedefault(text, head, tail)
         return results
 

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -316,24 +316,24 @@ class TestWorld:
             fighter=0, cleric=0, mage=0, thief=0, champion=0, scroll=0
         )
 
-    def test_exhausted_dungeon(self):
-        """Test exhausted_dungeon detects when no actions remain."""
+    def test_finished_dungeon(self):
+        """Test finished_dungeon detects when no actions remain."""
         # None dungeon is exhausted
-        assert dungeon.exhausted_dungeon(None)
+        assert dungeon.finished_dungeon(None)
 
         # Empty dungeon is exhausted
-        assert dungeon.exhausted_dungeon(struct.Dungeon())
+        assert dungeon.finished_dungeon(struct.Dungeon())
 
         # Dungeon with only dragons (blocking) is not exhausted
-        assert not dungeon.exhausted_dungeon(struct.Dungeon(dragon=3))
+        assert not dungeon.finished_dungeon(struct.Dungeon(dragon=3))
 
         # Dungeon with monsters is not exhausted
-        assert not dungeon.exhausted_dungeon(struct.Dungeon(goblin=1))
-        assert not dungeon.exhausted_dungeon(struct.Dungeon(skeleton=2))
-        assert not dungeon.exhausted_dungeon(struct.Dungeon(ooze=1))
+        assert not dungeon.finished_dungeon(struct.Dungeon(goblin=1))
+        assert not dungeon.finished_dungeon(struct.Dungeon(skeleton=2))
+        assert not dungeon.finished_dungeon(struct.Dungeon(ooze=1))
 
         # Dungeon with chests/potions still has actions (not exhausted)
-        assert not dungeon.exhausted_dungeon(struct.Dungeon(chest=2, potion=3))
+        assert not dungeon.finished_dungeon(struct.Dungeon(chest=2, potion=3))
 
     def test_retreat_valid(self):
         """Test valid retreat scenarios."""


### PR DESCRIPTION
## Summary
Rename the `exhausted_dungeon` function to `finished_dungeon` throughout the codebase to better reflect its purpose and improve code clarity.

## Key Changes
- Renamed `exhausted_dungeon()` function to `finished_dungeon()` in `droll/dungeon.py`
- Updated the function export in `__all__` in `droll/dungeon.py`
- Updated all call sites in `droll/game.py` to use the new function name
- Updated all test cases in `tests/test_world.py` to reference the renamed function

## Implementation Details
The function logic remains unchanged—it still detects when no actions remain in a dungeon by returning `True` for `None` or empty dungeons, and `False` when monsters, chests, or potions are present. The rename improves semantic clarity by using "finished" instead of "exhausted," which better communicates that the function checks if all possible dungeon actions have been completed.

https://claude.ai/code/session_01U3uKQQ59ZVAjAmQcSndL5N