### PR TITLE
Add orange color formatting to help command output

### DIFF
--- a/droll/shell.py
+++ b/droll/shell.py
@@ -19,7 +19,7 @@ __all__ = ("Shell",)
 _RESET = "\033[0m"
 _GREEN = "\033[92m"
 _RED = "\033[91m"
-_ORANGE = "\033[93m"  # TODO Make output between commands, e.g. help, orange
+_ORANGE = "\033[93m"
 
 
 class Shell(cmd.Cmd):
@@ -239,6 +239,16 @@ class Shell(cmd.Cmd):
     #################
     # HELP BELOW HERE
     #################
+
+    def do_help(self, arg):
+        """List available commands or show help for a specific command."""
+        if self._color:
+            print(_ORANGE, end="")
+        try:
+            super().do_help(arg)
+        finally:
+            if self._color:
+                print(_RESET, end="")
 
     doc_header = "Feasible commands (help <command>):"
     doc_hero_template = (


### PR DESCRIPTION
## Summary
This change implements the TODO item to colorize help command output in orange, improving visual consistency with the shell's color scheme.

## Key Changes
- Removed the TODO comment from the `_ORANGE` color constant definition
- Implemented a new `do_help()` method that wraps the parent class help functionality with orange color formatting
- The help output is wrapped with `_ORANGE` color code at the start and `_RESET` at the end when colors are enabled
- Used try/finally block to ensure color reset is always applied, even if an exception occurs during help execution

## Implementation Details
- The method respects the existing `self._color` flag to only apply coloring when enabled
- Delegates to `super().do_help(arg)` to maintain all existing help functionality
- Follows the same color management pattern used elsewhere in the codebase

https://claude.ai/code/session_01FbRoZceZ4WkVVb4imZgSnX