### PR TITLE
Add color highlighting for dragon and None in game summary

### DIFF
--- a/droll/shell.py
+++ b/droll/shell.py
@@ -20,6 +20,7 @@ _RESET = "\033[0m"
 _GREEN = "\033[92m"
 _RED = "\033[91m"
 _ORANGE = "\033[93m"
+_GREY = "\033[90m"
 
 
 class Shell(cmd.Cmd):
@@ -64,14 +65,17 @@ class Shell(cmd.Cmd):
         print()
         if line != "EOF":
             available = [] if stop else self._available_commands()
-            print(
-                display.compact_summary(
-                    self._game.current_world,
-                    self._game.player_name,
-                    self._game.score(),
-                    available,
-                )
+            summary = display.compact_summary(
+                self._game.current_world,
+                self._game.player_name,
+                self._game.score(),
+                available,
             )
+            if self._color:
+                summary = summary.replace(
+                    "dragon", _RED + "dragon" + _RESET
+                ).replace("None", _GREY + "None" + _RESET)
+            print(summary)
             if stop:
                 print(self.prompt)
 


### PR DESCRIPTION
## Summary
Enhanced the game shell output to add color highlighting for specific keywords in the game summary display when color mode is enabled.

## Key Changes
- Added `_GREY` color constant (`\033[90m`) to the color palette
- Refactored the summary display logic to capture the summary text before printing
- Added conditional color replacement for "dragon" (red) and "None" (grey) keywords when `self._color` is enabled
- Improved code readability by separating summary generation from printing

## Implementation Details
The change extracts the `compact_summary()` result into a variable, allowing post-processing of the summary text. When color mode is active, the summary is enhanced with ANSI color codes:
- "dragon" is highlighted in red (`_RED`)
- "None" is highlighted in grey (`_GREY`)
- Both use `_RESET` to restore default formatting

This provides better visual distinction of important game elements in the terminal output.

https://claude.ai/code/session_01XC1VL6kuFvEK64UtQMN2fD