### PR TITLE
Change DrollError to inherit from Exception instead of RuntimeError

### DIFF
--- a/droll/struct.py
+++ b/droll/struct.py
@@ -27,7 +27,7 @@ __all__ = (
 )
 
 
-class DrollError(RuntimeError):
+class DrollError(Exception):
     """Indicates attempts to take impossible actions."""
 
 


### PR DESCRIPTION
## Summary
Updated the `DrollError` exception class to inherit directly from `Exception` rather than `RuntimeError`.

## Changes
- Changed `DrollError` base class from `RuntimeError` to `Exception` in `droll/struct.py`

## Details
This change makes `DrollError` a more general exception type. By inheriting from `Exception` instead of `RuntimeError`, the exception is no longer categorized as a runtime error specifically, allowing for more flexible exception handling and better semantic accuracy for the types of errors this exception represents (impossible actions within the droll system).

https://claude.ai/code/session_015zMPJmc6BhMDVKTZW8bcqi