### PR TITLE
Initialize world depth to 0 instead of None

### DIFF
--- a/droll/struct.py
+++ b/droll/struct.py
@@ -130,7 +130,7 @@ class Treasure:
 @dataclass(frozen=True)
 class World:
     delve: int = 0
-    depth: Optional[int] = None
+    depth: int = 0
     experience: int = 0
     dungeon: Optional[Dungeon] = None
     party: Optional[Party] = None

--- a/droll/world.py
+++ b/droll/world.py
@@ -24,7 +24,7 @@ def new_world() -> struct.World:
     """Establish a new world independent of a delve/dungeon."""
     return struct.World(
         delve=0,
-        depth=None,
+        depth=0,
         experience=0,
         dungeon=None,
         party=None,
@@ -116,7 +116,7 @@ def descend(
     world = _regroup(world)
 
     # Update the world in anticipation of the next dungeon
-    next_depth = (world.depth if world.depth else 0) + 1
+    next_depth = world.depth + 1
     if next_depth > _max_depth:
         raise DrollError(f"Maximum depth is {_max_depth}.")
     prior_dragons = 0 if world.dungeon is None else world.dungeon.dragon


### PR DESCRIPTION
## Summary
Changed the `World.depth` field from an optional integer (defaulting to `None`) to a required integer (defaulting to `0`). This eliminates the need for null-checking when calculating the next depth level.

## Key Changes
- Updated `World` dataclass in `struct.py` to initialize `depth` as `int = 0` instead of `Optional[int] = None`
- Updated `new_world()` function in `world.py` to set `depth=0` instead of `depth=None`
- Simplified the `descend()` function by removing the conditional check `(world.depth if world.depth else 0)` and replacing it with direct arithmetic `world.depth + 1`

## Implementation Details
This change removes unnecessary null-handling logic by establishing that a world always has a defined depth value, starting at 0. The depth is incremented when descending into dungeons, making the type system more accurate and the code cleaner.

https://claude.ai/code/session_016DCk39Qb9jy16cRHxLUdk3