### PR TITLE
Add validation to convert_dungeon_to_party for missing source

### DIFF
--- a/droll/special.py
+++ b/droll/special.py
@@ -85,6 +85,8 @@ def convert_dungeon_to_party(
 
     Converts min(available, max_count) of source into destination."""
     count = min(getattr(world.dungeon, source), max_count)
+    if count < 1:
+        raise DrollError(f"No {source} in dungeon to convert.")
     return replace(
         world,
         dungeon=replace(

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -164,6 +164,18 @@ def test_convert_dungeon_to_party_up_to_max_count():
     assert result.regroup.discard.thief == 2
 
 
+def test_convert_dungeon_to_party_zero_source_raises():
+    """Raises DrollError when zero of the requested source exist in dungeon."""
+    w = struct.World(
+        dungeon=struct.Dungeon(skeleton=2),
+        party=struct.Party(),
+    )
+    with pytest.raises(DrollError):
+        special.convert_dungeon_to_party(
+            w, source="goblin", destination="thief", max_count=1
+        )
+
+
 def test_convert_dungeon_to_party_fewer_when_limited():
     """Converts only available count when fewer than max_count."""
     w = struct.World(


### PR DESCRIPTION
## Summary
Added input validation to the `convert_dungeon_to_party` function to raise a `DrollError` when attempting to convert a source creature type that doesn't exist in the dungeon.

## Changes
- **droll/special.py**: Added a check after calculating the conversion count to raise `DrollError` if no source creatures are available in the dungeon
- **tests/test_special.py**: Added `test_convert_dungeon_to_party_zero_source_raises()` test case to verify the error is raised when trying to convert a non-existent source creature type

## Implementation Details
The validation occurs early in the function after determining the count to convert. If the count is less than 1 (meaning the source creature type has zero instances in the dungeon), a descriptive error message is raised before any world state modifications occur.

https://claude.ai/code/session_015isBGgcAdQCZJDs2ZXKva4