### PR TITLE
Add __repr__ method to Game class for better debugging

### DIFF
--- a/droll/game.py
+++ b/droll/game.py
@@ -56,6 +56,15 @@ class Game:
         new._random = copy.copy(self._random)  # Mutable, needs state copy
         return new
 
+    def __repr__(self) -> str:
+        """Provide a meaningful representation of the game state."""
+        return (
+            f"Game(player={self._player.name}"
+            f", score={self.score}"
+            f", delve={self._world.delve}"
+            f", depth={self._world.depth})"
+        )
+
     def randhash(self) -> int:
         """Hash of the current random state."""
         return hash(self._random.getstate())

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -20,6 +20,17 @@ def test_game_construction():
     Game(random=random.Random(4))
 
 
+def test_game_repr():
+    """Game has a meaningful repr showing player, score, delve, and depth."""
+    g = Game(random=random.Random(4), player=Default)
+    r = repr(g)
+    assert r.startswith("Game(")
+    assert "player=Default" in r
+    assert "score=" in r
+    assert "delve=" in r
+    assert "depth=" in r
+
+
 def test_gamestate_identity():
     """GameState enum members are distinct and comparable."""
     assert GameState.STOP is not GameState.PLAY


### PR DESCRIPTION
## Summary
Added a `__repr__` method to the `Game` class to provide meaningful string representations of game instances, improving debuggability and REPL experience.

## Changes
- **Game.__repr__()**: Implemented a new method that returns a formatted string showing:
  - Player name
  - Current score
  - World delve status
  - Current depth
  
- **test_game_repr()**: Added comprehensive test to verify the repr output includes all expected components and follows the expected format

## Implementation Details
The repr format follows the pattern `Game(player=..., score=..., delve=..., depth=...)`, making it easy to inspect game state at a glance. This is particularly useful during debugging and interactive development sessions.

https://claude.ai/code/session_0159AegcPXSjpQZSpQjKN4rg