### PR TITLE
Raise DrollError instead of RuntimeError when treasure box is empty

### DIFF
--- a/droll/treasure.py
+++ b/droll/treasure.py
@@ -24,7 +24,7 @@ def _draw(box: Artifacts, randrange: RandRange) -> str:
     """Draw a random treasure from the box, weighted by counts."""
     total = sum(field_values(box))
     if not total:
-        raise RuntimeError("No items remaining in the box")
+        raise DrollError("No items remaining in the box")
     choice = randrange(0, total)
     cumulative = 0
     for name, count in field_items(box):

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -57,6 +57,16 @@ class TestWorld:
             == 1
         )
 
+    def test_draw_treasure_empty_box(self):
+        """Test drawing from an empty box raises DrollError."""
+        pre = world.new_world()
+        pre = replace(
+            pre,
+            treasure=replace(pre.treasure, box=struct.Artifacts()),
+        )
+        with pytest.raises(struct.DrollError):
+            treasure.draw_treasure(pre.treasure, self.state.randrange)
+
     def test_replace_treasure(self):
         """Test replacing treasure moves one item from own to box."""
         pre = world.new_world()


### PR DESCRIPTION
## Summary
Changed the exception type raised when attempting to draw treasure from an empty box from `RuntimeError` to `DrollError` for more consistent error handling across the codebase.

## Key Changes
- Updated `droll/treasure.py` to raise `DrollError` instead of `RuntimeError` when no items remain in the treasure box
- Added test case `test_draw_treasure_empty_box()` to verify that `DrollError` is properly raised when drawing from an empty box

## Implementation Details
The change ensures that treasure-related errors use the domain-specific `DrollError` exception class rather than the generic `RuntimeError`. This allows callers to more specifically catch and handle treasure drawing failures. The test validates this behavior by creating a world with an empty treasure box and confirming the expected exception is raised.

https://claude.ai/code/session_01Fv9kGnCZPf2AuG2jEizaBd