### PR TITLE
Separate scroll quaff from reroll command (issue #133)

### DIFF
--- a/droll/player.py
+++ b/droll/player.py
@@ -82,13 +82,13 @@ Default = struct.Player(
             potion=regular.quaff,
             dragon=regular.defeat_dragon,
         ),
-        # Scrolls can re-roll chests and potions though doing so feels odd.
-        # Scrolls can also, less oddly, quaff potions so always assume quaff.
+        # Scrolls re-roll via the 'reroll' command (see issue #133).
+        # Using 'scroll' as a noun targets only quaff and dragon.
         scroll=struct.Dungeon(
-            goblin=regular.reroll,
-            skeleton=regular.reroll,
-            ooze=regular.reroll,
-            chest=regular.reroll,
+            goblin=regular.not_reroll,
+            skeleton=regular.not_reroll,
+            ooze=regular.not_reroll,
+            chest=regular.not_reroll,
             potion=regular.quaff,
             dragon=regular.defeat_dragon,
         ),

--- a/droll/regular.py
+++ b/droll/regular.py
@@ -34,6 +34,7 @@ __all__ = (
     "defeat_one",
     "distinct_heroes",
     "elixir",
+    "not_reroll",
     "open_all",
     "open_one",
     "quaff",
@@ -42,6 +43,13 @@ __all__ = (
 
 _DUNGEON_NAMES = frozenset(field_names(Dungeon))
 _PARTY_NAMES = frozenset(field_names(Party))
+
+
+def not_reroll(
+    world: World, randrange: RandRange, hero: str, target: str, *additional
+) -> World:
+    """Scrolls cannot target dungeon dice directly; use 'reroll' instead."""
+    raise DrollError(f'Use "reroll {target}" to re-roll with a scroll.')
 
 
 def defeat_one(

--- a/droll/shell.py
+++ b/droll/shell.py
@@ -299,18 +299,17 @@ class Shell(cmd.Cmd):
 
     def help_scroll(self):
         """Display help for using scroll treasures."""
-        print("Scrolls may quaff potions and re-roll dungeon dice like so:")
+        print("Scrolls quaff potions or re-roll dice via 'reroll':")
         print(
             """
             scroll potion mage thief    # Drink 2 potions obtaining mage, thief
-            scroll skeleton goblin      # Re-roll all skeletons and goblins
+            reroll skeleton goblin      # Re-roll a skeleton and a goblin
             """
         )
-        print("Heroes like the Enchantress instead kill enemies with 'scroll'")
+        print("Heroes like the Enchantress instead kill enemies with 'scroll':")
         print(
             """
-            scroll skeleton             # Enchantress would kill skeleton...
-            reroll skeleton goblin      # ...but 'reroll' forces re-rolling"""
+            scroll skeleton             # Enchantress kills all skeletons"""
         )
 
     def help_reroll(self):

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -140,7 +140,7 @@ class TestPlayer:
             player.apply(player.Default, self.game, None, "fighter")
 
     def test_scroll_reroll(self):
-        """Test scroll used to reroll dungeon dice."""
+        """Test reroll command to reroll dungeon dice (issue #133)."""
         # Consumed by canned_sequence just below
         sequence = [0, 1, 2]
 
@@ -148,12 +148,12 @@ class TestPlayer:
             """Predetermined sequence values for deterministic testing."""
             return start + sequence.pop(0)
 
-        # Notice scroll causes chests to be re-rolled
+        # 'reroll' re-rolls chests via the scroll mechanic
         game = player.apply(
             player.Default,
             self.game,
             canned_sequence,
-            "scroll",
+            "reroll",
             "chest",
             "ooze",
             "chest",
@@ -162,6 +162,13 @@ class TestPlayer:
         assert game.dungeon == struct.Dungeon(
             goblin=3, skeleton=3, ooze=2, chest=0, potion=2, dragon=2
         )
+
+    def test_scroll_not_reroll(self):
+        """Using 'scroll' as a noun for rerolling raises DrollError (#133)."""
+        with pytest.raises(struct.DrollError, match="reroll"):
+            player.apply(
+                player.Default, self.game, None, "scroll", "goblin"
+            )
 
 
 # Shorthand for testing completions given that method returns unsorted generator


### PR DESCRIPTION
## Summary
This PR clarifies the distinction between using scrolls to quaff potions and using the `reroll` command to re-roll dungeon dice. Previously, scrolls could be used for both actions, which was confusing. Now scrolls are limited to quaffing potions and defeating dragons, while re-rolling is exclusively handled by the `reroll` command.

## Key Changes
- **Command separation**: Scrolls no longer accept dungeon dice as targets for re-rolling. Attempting to use `scroll` with dice now raises a `DrollError` directing users to use `reroll` instead.
- **New `not_reroll` function**: Added a handler function that raises an informative error when users try to re-roll with a scroll, guiding them to use the `reroll` command.
- **Updated scroll behavior**: Modified the scroll dungeon mapping to use `not_reroll` for all dice targets (goblin, skeleton, ooze, chest) instead of `reroll`.
- **Improved documentation**: Updated help text in `shell.py` to clarify that scrolls quaff potions or work with heroes, while `reroll` is the dedicated command for re-rolling dice.
- **Test coverage**: Added `test_scroll_not_reroll` to verify that using `scroll` with dungeon dice raises the appropriate error, and updated `test_scroll_reroll` to use the `reroll` command instead.

## Implementation Details
- The `not_reroll` function provides a user-friendly error message that suggests the correct command syntax.
- Help text now clearly distinguishes between scroll usage (quaffing potions, hero abilities) and the reroll command (re-rolling dice).
- This change maintains backward compatibility for valid scroll usage while preventing the confusing dual-purpose behavior.

https://claude.ai/code/session_01HdgBs7aaCjDK9fY724y9dL