### PR TITLE
Relax World.party and World.ability from Optional to concrete types

### DIFF
--- a/droll/party.py
+++ b/droll/party.py
@@ -4,7 +4,6 @@
 """Functionality associated with party state and party mechanics."""
 
 from dataclasses import replace
-from typing import Optional
 
 from .struct import DrollError, Party, Regroup
 
@@ -15,10 +14,8 @@ __all__ = (
 )
 
 
-def decrement_party(party: Optional[Party], hero: str) -> Party:
+def decrement_party(party: Party, hero: str) -> Party:
     """Decrease the count of the specified hero type by one."""
-    if party is None:
-        raise DrollError("No party currently active.")
     prior_heroes = getattr(party, hero)
     if not prior_heroes:
         raise DrollError(f"At least 1 {hero} required in party.")
@@ -33,8 +30,6 @@ def decrement_regroup(regroup: Regroup, hero: str) -> Regroup:
     )
 
 
-def increment_party(party: Optional[Party], hero: str) -> Party:
+def increment_party(party: Party, hero: str) -> Party:
     """Increase the count of the specified hero type by one."""
-    if party is None:
-        raise DrollError("No party currently active.")
     return replace(party, **{hero: getattr(party, hero) + 1})

--- a/droll/struct.py
+++ b/droll/struct.py
@@ -117,8 +117,8 @@ class World:
     depth: int = 0
     experience: int = 0
     dungeon: Optional[Dungeon] = None
-    party: Optional[Party] = None
-    ability: Optional[bool] = None
+    party: Party = Party()
+    ability: bool = False
     regroup: Regroup = Regroup()
     treasure: Treasure = Treasure()
 

--- a/droll/world.py
+++ b/droll/world.py
@@ -27,8 +27,8 @@ def new_world() -> struct.World:
         depth=0,
         experience=0,
         dungeon=None,
-        party=None,
-        ability=None,
+        party=struct.Party(),
+        ability=False,
         regroup=struct.Regroup(),
         treasure=struct.Treasure(
             own=struct.Artifacts(),

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -23,23 +23,11 @@ def test_decrement_party_zero_target():
         decrement_party(party, "fighter")
 
 
-def test_decrement_party_none():
-    """Cannot decrement when no party is active."""
-    with pytest.raises(DrollError):
-        decrement_party(None, "fighter")
-
-
 def test_increment_party():
     """Incrementing a hero count yields one more."""
     party = Party(fighter=1)
     result = increment_party(party, "fighter")
     assert result.fighter == 2
-
-
-def test_increment_party_none():
-    """Cannot increment when no party is active."""
-    with pytest.raises(DrollError):
-        increment_party(None, "fighter")
 
 
 def test_decrement_regroup_positive():

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -427,9 +427,8 @@ class TestWorld:
             delve=3,
             depth=1,
             experience=15,
-            ability=None,
+            ability=False,
             dungeon=None,
-            party=None,
             treasure=struct.Treasure(
                 own=struct.Artifacts(
                     sword=0,


### PR DESCRIPTION
World.ability was Optional[bool] defaulting to None, but None was
never semantically distinct from False -- both mean "ability not
available." Changed to bool = False.

World.party was Optional[Party] defaulting to None, but None only
occurred before the first delve and behaved identically to Party()
(all-zero counts). Changed to Party = Party(), removing the None
guards from decrement_party and increment_party.

World.dungeon remains Optional[Dungeon] because None ("not in a
dungeon") is semantically distinct from Dungeon() ("active level,
cleared").

https://claude.ai/code/session_013c3S7U2yMrizF9A8xsSgmM