### PR TITLE
Clarify combat mechanics in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,8 +255,8 @@ as follows:
 Undo: you can `undo` a command so long as nothing was rolled or
 drawn since—the game prevents undoing randomized actions.
 
-Combat: each party member can target any monster, but specialists
-defeat all of their favored type while non-specialists defeat one:
+Combat: each party member can target any monster type.  Against
+a favored type they defeat all at once; otherwise they defeat one:
 
 | Hero     | Defeats all | Defeats one each       | Special          |
 |----------|-------------|------------------------|------------------|


### PR DESCRIPTION
This PR improves the clarity of the combat mechanics documentation in the README.

**Summary**
Updated the combat section to better explain how party members target and defeat monsters, making the distinction between specialist and non-specialist behavior clearer.

**Changes**
- Restructured the combat explanation to clarify that all party members can target any monster type
- Separated the targeting mechanic from the defeat mechanic for improved readability
- Emphasized that specialists defeat all monsters of their favored type at once, while non-specialists defeat one at a time

**Details**
The original phrasing could be misinterpreted as specialists having exclusive targeting abilities. The revised text makes it explicit that targeting is universal, while the actual difference lies in the defeat behavior (all vs. one) based on whether the monster is the specialist's favored type.

https://claude.ai/code/session_01F1fUndPNs7cxwVCfamRnnj