### PR TITLE
Simplify World initialization by removing default fields

### DIFF
--- a/droll/world.py
+++ b/droll/world.py
@@ -23,15 +23,7 @@ __all__ = (
 def new_world() -> struct.World:
     """Establish a new world independent of a delve/dungeon."""
     return struct.World(
-        delve=0,
-        depth=0,
-        experience=0,
-        dungeon=None,
-        party=struct.Party(),
-        ability=False,
-        regroup=struct.Regroup(),
         treasure=struct.Treasure(
-            own=struct.Artifacts(),
             box=struct.Artifacts(
                 sword=3,
                 talisman=3,


### PR DESCRIPTION
## Summary
Refactored the `new_world()` function to remove redundant field initializations that are already handled by default values in the `struct.World` and `struct.Treasure` constructors.

## Key Changes
- Removed explicit initialization of fields with default/zero values: `delve`, `depth`, `experience`, `dungeon`, `party`, `ability`, and `regroup`
- Removed redundant `own` field initialization from `struct.Treasure`
- Retained only the non-default `box` artifact initialization with specific sword and talisman counts

## Implementation Details
This change assumes that the struct definitions for `World` and `Treasure` have appropriate default values defined for the removed fields. The refactoring reduces boilerplate code while maintaining the same functional behavior, making the initialization logic more concise and easier to maintain.

https://claude.ai/code/session_016edkWzpMjVVLL6BA3ExrkV