### PR TITLE
WIP: Replace string literals with enums and dataclasses with frozen mappings

### DIFF
--- a/PLAN.md
+++ b/PLAN.md
@@ -15,10 +15,10 @@ static analysis nearly useless and hide semantic errors.
 
 ## Proposed Enums
 
-### `DungeonFace` — the six dungeon die faces
+### `DungeonDie` — the six dungeon die faces
 
 ```python
-class DungeonFace(enum.Enum):
+class DungeonDie(enum.Enum):
     GOBLIN = "goblin"
     SKELETON = "skeleton"
     OOZE = "ooze"
@@ -39,10 +39,10 @@ class PartyDie(enum.Enum):
     SCROLL = "scroll"
 ```
 
-### `ArtifactKind` — the ten treasure/artifact types
+### `Artifact` — the ten treasure/artifact types
 
 ```python
-class ArtifactKind(enum.Enum):
+class Artifact(enum.Enum):
     SWORD = "sword"
     TALISMAN = "talisman"
     SCEPTRE = "sceptre"
@@ -55,10 +55,10 @@ class ArtifactKind(enum.Enum):
     SCALE = "scale"
 ```
 
-### `ActionVerb` — the special command verbs that aren't heroes
+### `Action` — the special command verbs that aren't heroes
 
 ```python
-class ActionVerb(enum.Enum):
+class Action(enum.Enum):
     ABILITY = "ability"
     BAIT = "bait"
     ELIXIR = "elixir"
@@ -74,48 +74,72 @@ keys, each role becomes a distinct, precisely-typed dict:
 
 | Current Type | Role / Context | Current Field Annotation | New Type Alias | Used In |
 |---|---|---|---|---|
-| `Dungeon` | Die counts on a dungeon level | `Union[int, Command]` (only `int` at runtime) | `DungeonState = dict[DungeonFace, int]` | `World.dungeon`, `dice.roll_dungeon()`, `dungeon.py` functions |
-| `Dungeon` | Per-hero dispatch: what action does this hero take against each dungeon face? | `Union[int, Command]` (only `Command` at runtime) | `HeroActions = dict[DungeonFace, Command]` | Nested inside `Player.party` values (e.g. `Default.party[PartyDie.FIGHTER]`) |
+| `Dungeon` | Die counts on a dungeon level | `Union[int, Command]` (only `int` at runtime) | `DungeonState = dict[DungeonDie, int]` | `World.dungeon`, `dice.roll_dungeon()`, `dungeon.py` functions |
+| `Dungeon` | Per-hero dispatch: what action does this hero take against each dungeon face? | `Union[int, Command]` (only `Command` at runtime) | `HeroActions = dict[DungeonDie, Command]` | Nested inside `Player.party` values (e.g. `Default.party[PartyDie.FIGHTER]`) |
 | `Party` | Die counts of heroes in the current party | `Union[int, Command, str, None]` (only `int` at runtime) | `PartyState = dict[PartyDie, int]` | `World.party`, `Regroup.discard`, `dice.roll_party()`, `party.py` functions |
 | `Party` | Full dispatch table: for each hero, what does it do to each dungeon face? | `Union[int, Command, str, None]` (only `HeroActions`/`Dungeon` at runtime) | `PartyActions = dict[PartyDie, HeroActions]` | `Player.party` — the two-level dispatch table |
-| `Party` | Which artifact corresponds to each hero? | `Union[int, Command, str, None]` (only `Optional[str]` at runtime) | `ArtifactMapping = dict[PartyDie, Optional[ArtifactKind]]` | `Player.artifacts` |
-| `Artifacts` | Counts of each treasure type (in hand or in box) | `int` | `ArtifactCounts = dict[ArtifactKind, int]` | `Treasure.own`, `Treasure.box`, `world.py` scoring |
+| `Party` | Which artifact corresponds to each hero? | `Union[int, Command, str, None]` (only `Optional[str]` at runtime) | `ArtifactMapping = dict[PartyDie, Optional[Artifact]]` | `Player.artifacts` |
+| `Artifacts` | Counts of each treasure type (in hand or in box) | `int` | `ArtifactCounts = dict[Artifact, int]` | `Treasure.own`, `Treasure.box`, `world.py` scoring |
 
 ### What the type aliases look like in `struct.py`
 
+Runtime containers use `types.MappingProxyType` to preserve the frozen
+semantics of the dataclasses they replace.  Type annotations use
+`Mapping[K, V]` from `collections.abc` (read-only interface).
+
 ```python
+from collections.abc import Mapping
+from types import MappingProxyType
+
 # State containers (runtime values are always int)
-DungeonState  = dict[DungeonFace, int]
-PartyState    = dict[PartyDie, int]
-ArtifactCounts = dict[ArtifactKind, int]
+DungeonState   = Mapping[DungeonDie, int]
+PartyState     = Mapping[PartyDie, int]
+ArtifactCounts = Mapping[Artifact, int]
 
 # Dispatch containers (runtime values are always Command)
-HeroActions   = dict[DungeonFace, Command]
-PartyActions  = dict[PartyDie, HeroActions]
+HeroActions    = Mapping[DungeonDie, Command]
+PartyActions   = Mapping[PartyDie, HeroActions]
 
 # Mapping container
-ArtifactMapping = dict[PartyDie, Optional[ArtifactKind]]
+ArtifactMapping = Mapping[PartyDie, Optional[Artifact]]
+```
+
+Annotations say `Mapping` (read-only contract); factories return
+`MappingProxyType` (enforced at runtime).  A thin `frozen()` helper
+wraps construction:
+
+```python
+def frozen(d: dict) -> MappingProxyType:
+    """Wrap a dict as an immutable MappingProxyType."""
+    return MappingProxyType(d)
 ```
 
 ### Updated `Player`, `World`, `Treasure`, `Regroup`
 
+Note: `frozen=True` on the dataclasses prevents reassignment of the fields
+themselves (e.g. `world.party = ...` raises `FrozenInstanceError`).
+`MappingProxyType` on the mapping values prevents mutation of the
+containers (e.g. `world.party[PartyDie.FIGHTER] = 99` raises `TypeError`).
+Together they provide the same depth of immutability as the old frozen
+dataclasses.
+
 ```python
 @dataclass(frozen=True)
 class Treasure:
-    own: ArtifactCounts    # was Artifacts
-    box: ArtifactCounts    # was Artifacts
+    own: ArtifactCounts    # was Artifacts; runtime: MappingProxyType
+    box: ArtifactCounts    # was Artifacts; runtime: MappingProxyType
 
 @dataclass(frozen=True)
 class Regroup:
-    discard: PartyState    # was Party
+    discard: PartyState    # was Party; runtime: MappingProxyType
 
 @dataclass(frozen=True)
 class World:
     delve: int = 0
     depth: int = 0
     experience: int = 0
-    dungeon: Optional[DungeonState] = None   # was Optional[Dungeon]
-    party: PartyState = ...                   # was Party
+    dungeon: Optional[DungeonState] = None   # runtime: MappingProxyType | None
+    party: PartyState = ...                   # runtime: MappingProxyType
     ability: bool = False
     regroup: Regroup = ...
     treasure: Treasure = ...
@@ -128,8 +152,8 @@ class Player:
     bait: Command
     elixir: Command
     roll: Roll
-    artifacts: ArtifactMapping    # was Party(fighter="sword", ...)
-    party: PartyActions           # was Party(fighter=Dungeon(goblin=defeat_all, ...))
+    artifacts: ArtifactMapping    # runtime: MappingProxyType
+    party: PartyActions           # runtime: MappingProxyType of MappingProxyType
 ```
 
 ### Updated `Command` Signature
@@ -139,11 +163,11 @@ class Player:
 Command = Callable[[World, RandRange, str, tuple[str, ...]], World]
 
 # After
-Command = Callable[[World, RandRange, PartyDie, tuple[DungeonFace | PartyDie, ...]], World]
+Command = Callable[[World, RandRange, PartyDie, tuple[DungeonDie | PartyDie, ...]], World]
 ```
 
 The `str` that was `hero` becomes `PartyDie`.  The `tuple[str, ...]` that was
-`targets` becomes `tuple[DungeonFace | PartyDie, ...]` (targets can be
+`targets` becomes `tuple[DungeonDie | PartyDie, ...]` (targets can be
 dungeon faces to attack, or party die names for reroll/quaff).
 
 ## What Changes in the Access Patterns
@@ -161,11 +185,11 @@ def decrement_dungeon(dungeon: Dungeon, target: str) -> Dungeon:
     return replace(dungeon, **{target: prior - 1})
 
 # After
-def decrement_dungeon(dungeon: DungeonState, target: DungeonFace) -> DungeonState:
+def decrement_dungeon(dungeon: DungeonState, target: DungeonDie) -> DungeonState:
     prior = dungeon[target]
     if not prior:
         raise DrollError(f"At least 1 {target.value} required in dungeon.")
-    return {**dungeon, target: prior - 1}
+    return frozen({**dungeon, target: prior - 1})
 ```
 
 ```python
@@ -176,7 +200,7 @@ def increment_party(party: Party, hero: str) -> Party:
 
 # After
 def increment_party(party: PartyState, hero: PartyDie) -> PartyState:
-    return {**party, hero: party[hero] + 1}
+    return frozen({**party, hero: party[hero] + 1})
 ```
 
 ### `field_names`/`field_values`/`field_items` → dict methods
@@ -208,22 +232,21 @@ DragonSlayer = replace(Default, ...,
 
 # After
 DragonSlayer = replace(Default, ...,
-    party={
-        PartyDie.FIGHTER: {**Default.party[PartyDie.FIGHTER],
-                           DungeonFace.DRAGON: _dragonslayer_defeat_dragon},
+    party=frozen({
+        PartyDie.FIGHTER: frozen({**Default.party[PartyDie.FIGHTER],
+                                  DungeonDie.DRAGON: _dragonslayer_defeat_dragon}),
         ...
-    })
+    }))
 ```
 
-### `Dungeon()` as empty → dict comprehension or factory
+### `Dungeon()` as empty → factory helper
 
 ```python
 # Before
 struct.Dungeon()  # all zeros
 
 # After
-{face: 0 for face in DungeonFace}
-# or a helper: empty_dungeon()
+empty_dungeon()   # returns frozen({face: 0 for face in DungeonDie})
 ```
 
 ### Constructor patterns with `*list` unpacking
@@ -233,16 +256,19 @@ struct.Dungeon()  # all zeros
 Dungeon(*_roll(dice, 0, 6, randrange))
 
 # After
-dict(zip(DungeonFace, _roll(dice, 0, 6, randrange)))
+frozen(dict(zip(DungeonDie, _roll(dice, 0, 6, randrange))))
 ```
 
 ## Detailed Per-File Impact
 
 ### `struct.py`
-- Add four enums and six type aliases
+- Add `from types import MappingProxyType` and `from collections.abc import Mapping`
+- Add `frozen()` helper wrapping `MappingProxyType`
+- Add four enums and six type aliases (using `Mapping[K, V]`)
 - Remove `Dungeon`, `Party`, `Artifacts` dataclasses
 - Add factory helpers: `empty_dungeon() -> DungeonState`,
   `empty_party() -> PartyState`, `empty_artifacts() -> ArtifactCounts`
+  (each returns `frozen({...})`)
 - Update `Treasure` fields: `own: ArtifactCounts`, `box: ArtifactCounts`
 - Update `Regroup.discard: PartyState`
 - Update `World.dungeon: Optional[DungeonState]`, `World.party: PartyState`
@@ -253,70 +279,70 @@ dict(zip(DungeonFace, _roll(dice, 0, 6, randrange)))
 - Keep `brief()` working via duck typing on dict `.items()`
 
 ### `dungeon.py`
-- Param `target: str` → `target: DungeonFace` in all functions
-- Return `Dungeon` → `DungeonState` (i.e. `dict[DungeonFace, int]`)
+- Param `target: str` → `target: DungeonDie` in all functions
+- Return `Dungeon` → `DungeonState` (i.e. `dict[DungeonDie, int]`)
 - Delete `_DUNGEON_FIELDS`, `_check_dungeon_target`
 - `getattr(dungeon, target)` → `dungeon[target]`
-- `replace(dungeon, **{target: v})` → `{**dungeon, target: v}`
-- Direct access `dungeon.goblin` → `dungeon[DungeonFace.GOBLIN]`
+- `replace(dungeon, **{target: v})` → `frozen({**dungeon, target: v})`
+- Direct access `dungeon.goblin` → `dungeon[DungeonDie.GOBLIN]`
 - `field_values(dungeon)` → `dungeon.values()`
 
 ### `party.py`
 - Param `hero: str` → `hero: PartyDie` in all functions
 - Return `Party` → `PartyState`
 - Delete `_PARTY_FIELDS`, `_check_party_member`
-- Same `getattr`→`[]` and `replace`→`{**d}` migration as `dungeon.py`
+- Same `getattr`→`[]` and `replace`→`frozen({**d})` migration as `dungeon.py`
 
 ### `treasure.py`
-- `_draw` returns `ArtifactKind` instead of `str`
-- `replace_treasure` param `item: str` → `item: ArtifactKind`
+- `_draw` returns `Artifact` instead of `str`
+- `replace_treasure` param `item: str` → `item: Artifact`
 - `field_items(box)` → `box.items()`
 - `field_values(box)` → `box.values()`
 - `getattr(treasure.own, drawn)` → `treasure.own[drawn]`
-- `replace(treasure.own, **{drawn: v})` → `{**treasure.own, drawn: v}`
+- `replace(treasure.own, **{drawn: v})` → `frozen({**treasure.own, drawn: v})`
   (but `Treasure` itself stays a dataclass, so its `replace` stays)
 
 ### `regular.py`
 - All `Command`-signature functions: `hero: str` → `hero: PartyDie`,
-  `targets: tuple[str, ...]` → `tuple[DungeonFace | PartyDie, ...]`
+  `targets: tuple[str, ...]` → `tuple[DungeonDie | PartyDie, ...]`
 - `_DUNGEON_NAMES`, `_PARTY_NAMES` frozensets → deleted (use `isinstance`
   checks or enum type)
-- `_classify_reroll_targets`: check `isinstance(t, DungeonFace)` vs
+- `_classify_reroll_targets`: check `isinstance(t, DungeonDie)` vs
   `isinstance(t, PartyDie)`
-- `bait_dragon`: `_enemies` becomes `tuple[DungeonFace, ...]`
+- `bait_dragon`: `_enemies` becomes `tuple[DungeonDie, ...]`
 - `defeat_dragon_heroes`: `disallowed_heroes` becomes `frozenset[PartyDie]`
 - `elixir`: `targets[0]` is already `PartyDie`
-- String literals like `"potion"` → `DungeonFace.POTION`, `"scroll"` →
+- String literals like `"potion"` → `DungeonDie.POTION`, `"scroll"` →
   `PartyDie.SCROLL`, etc.
 
 ### `special.py`
 - Same `Command` signature updates as `regular.py`
-- `convert_dungeon_to_party`: `source: str` → `source: DungeonFace`,
+- `convert_dungeon_to_party`: `source: str` → `source: DungeonDie`,
   `destination: str` → `destination: PartyDie`
 - `getattr(world.dungeon, source)` → `world.dungeon[source]`
 
 ### `ability.py`
-- All ability functions: `command: str` → `command: ActionVerb`,
+- All ability functions: `command: str` → `command: Action`,
   `targets: tuple[str, ...]` → typed tuple
 - `_choose_and_add_hero`: `acceptable: frozenset[str]` →
   `frozenset[PartyDie]`
-- `_convert_one`/`_convert_two`: `source: str` → `DungeonFace`,
+- `_convert_one`/`_convert_two`: `source: str` → `DungeonDie`,
   `destination: str` → `PartyDie`
 - Literal strings like `increment_dungeon(dungeon, "potion")` →
-  `increment_dungeon(dungeon, DungeonFace.POTION)`
+  `increment_dungeon(dungeon, DungeonDie.POTION)`
 - `increment_party(world.party, "scroll")` →
   `increment_party(world.party, PartyDie.SCROLL)`
 
 ### `player.py`
 - `Default.artifacts` becomes `ArtifactMapping`:
-  `{PartyDie.FIGHTER: ArtifactKind.SWORD, ..., PartyDie.CHAMPION: None, ...}`
+  `{PartyDie.FIGHTER: Artifact.SWORD, ..., PartyDie.CHAMPION: None, ...}`
 - `Default.party` becomes `PartyActions`:
-  `{PartyDie.FIGHTER: {DungeonFace.GOBLIN: defeat_all, ...}, ...}`
+  `{PartyDie.FIGHTER: {DungeonDie.GOBLIN: defeat_all, ...}, ...}`
 - `apply()`: `command: str` becomes a union or is pre-parsed into the
   appropriate enum type by the caller; dispatch uses enum comparisons
-- `_partify_command`: `ArtifactKind` → `PartyDie` reverse lookup
-- `_ARTIFACT_COMMANDS`: `frozenset[ArtifactKind]`
-- `_TREASURE_NO_COMMAND`: `frozenset[ArtifactKind]`
+- `_partify_command`: `Artifact` → `PartyDie` reverse lookup
+- `_ARTIFACT_COMMANDS`: `frozenset[Artifact]`
+- `_TREASURE_NO_COMMAND`: `frozenset[Artifact]`
 - `complete()`: returns `Sequence[str]` (for the shell), but internally
   works with enum `.value` strings
 - `_available_nouns`/`_available_targets`: iterate `.items()` on dicts
@@ -326,37 +352,37 @@ dict(zip(DungeonFace, _roll(dice, 0, 6, randrange)))
 
 ### `world.py`
 - `new_world()`: `Artifacts(sword=3, ...)` →
-  `{ArtifactKind.SWORD: 3, ...}`
+  `{Artifact.SWORD: 3, ...}`
 - `_regroup()`: `Party(**{name: max(...)})` →
   `{die: max(0, world.party[die] - world.regroup.discard[die]) for die in PartyDie}`
-- `descend()`: `replace(rolled, dragon=...)` → `{**rolled, DungeonFace.DRAGON: ...}`
+- `descend()`: `replace(rolled, dragon=...)` → `{**rolled, DungeonDie.DRAGON: ...}`
 - `_apply_ring`/`_apply_portal`: `noun: str = "ring"` →
-  `noun: ArtifactKind = ArtifactKind.RING`
+  `noun: Artifact = Artifact.RING`
 - `score()`: `field_values(world.treasure.own)` → `world.treasure.own.values()`
-- `world.treasure.own.portal` → `world.treasure.own[ArtifactKind.PORTAL]`
-- `world.treasure.own.scale` → `world.treasure.own[ArtifactKind.SCALE]`
+- `world.treasure.own.portal` → `world.treasure.own[Artifact.PORTAL]`
+- `world.treasure.own.scale` → `world.treasure.own[Artifact.SCALE]`
 
 ### `display.py`
 - `_format_items`: `field_items(counts)` → `counts.items()`
 - `_format_treasure`: `field_items(artifacts)` → `artifacts.items()`
 - `field_values(party)` → `party.values()`
 - Item names in output use `face.value` / `die.value` for display strings
-- `_ALWAYS_COUNT = frozenset({DungeonFace.DRAGON})`
+- `_ALWAYS_COUNT = frozenset({DungeonDie.DRAGON})`
 
 ### `dice.py`
 - `roll_dungeon` returns `DungeonState` instead of `Dungeon`
 - `roll_party` returns `PartyState` instead of `Party`
-- `Dungeon(*_roll(...))` → `dict(zip(DungeonFace, _roll(...)))`
+- `Dungeon(*_roll(...))` → `dict(zip(DungeonDie, _roll(...)))`
 - `Party(*_roll(...))` → `dict(zip(PartyDie, _roll(...)))`
-- `len(fields(Dungeon))` → `len(DungeonFace)` (enum length)
+- `len(fields(Dungeon))` → `len(DungeonDie)` (enum length)
 - `len(fields(Party))` → `len(PartyDie)`
 
 ### `game.py`
-- `Game.ability()`: passes `ActionVerb.ABILITY` instead of `"ability"`
-- `Game.reroll()`: passes `ActionVerb.REROLL` instead of `"reroll"`
+- `Game.ability()`: passes `Action.ABILITY` instead of `"ability"`
+- `Game.reroll()`: passes `Action.REROLL` instead of `"reroll"`
 - `Game.apply()`: tokenized strings arrive from shell; parsing happens
   in `player.apply()` or the caller converts first
-- `_possible_world_actions()`: `"ability"` → `ActionVerb.ABILITY` etc.
+- `_possible_world_actions()`: `"ability"` → `Action.ABILITY` etc.
 - `score_deltas()`: no enum changes (returns `dict[str, int]` for display)
 
 ### `shell.py`
@@ -370,34 +396,34 @@ dict(zip(DungeonFace, _roll(dice, 0, 6, randrange)))
 
 ### Hero files (`droll/heroes/*.py`)
 - All `struct.Party(fighter=struct.Dungeon(...), ...)` constructions →
-  `{PartyDie.FIGHTER: {DungeonFace.GOBLIN: defeat_all, ...}, ...}`
+  `{PartyDie.FIGHTER: {DungeonDie.GOBLIN: defeat_all, ...}, ...}`
 - `replace(Default.party.fighter, dragon=...)` →
-  `{**Default.party[PartyDie.FIGHTER], DungeonFace.DRAGON: ...}`
+  `frozen({**Default.party[PartyDie.FIGHTER], DungeonDie.DRAGON: ...})`
 - `replace(Default.party, fighter=..., cleric=...)` →
-  `{**Default.party, PartyDie.FIGHTER: ..., PartyDie.CLERIC: ...}`
-- `Default.party.cleric.skeleton` → `Default.party[PartyDie.CLERIC][DungeonFace.SKELETON]`
+  `frozen({**Default.party, PartyDie.FIGHTER: ..., PartyDie.CLERIC: ...})`
+- `Default.party.cleric.skeleton` → `Default.party[PartyDie.CLERIC][DungeonDie.SKELETON]`
 - `frozenset({"fighter", "cleric"})` → `frozenset({PartyDie.FIGHTER, PartyDie.CLERIC})`
 
 ### Test files
-- Every `struct.Dungeon(goblin=1, ...)` → `{DungeonFace.GOBLIN: 1, ...}`
-  (or use `{**empty_dungeon(), DungeonFace.GOBLIN: 1}`)
+- Every `struct.Dungeon(goblin=1, ...)` → `{DungeonDie.GOBLIN: 1, ...}`
+  (or use `{**empty_dungeon(), DungeonDie.GOBLIN: 1}`)
 - Every `struct.Party(fighter=2, ...)` → same pattern with `PartyDie`
-- Every `struct.Artifacts(sword=1, ...)` → same pattern with `ArtifactKind`
-- Direct field access `game.dungeon.goblin` → `game.dungeon[DungeonFace.GOBLIN]`
+- Every `struct.Artifacts(sword=1, ...)` → same pattern with `Artifact`
+- Direct field access `game.dungeon.goblin` → `game.dungeon[DungeonDie.GOBLIN]`
 - Direct field access `game.party.fighter` → `game.party[PartyDie.FIGHTER]`
 
 ## Implementation Steps
 
 ### Step 1: Define enums and type aliases in `struct.py`
 
-Add `DungeonFace`, `PartyDie`, `ArtifactKind`, `ActionVerb` plus all six
+Add `DungeonDie`, `PartyDie`, `Artifact`, `Action` plus all six
 type aliases.  Add `empty_dungeon()`, `empty_party()`, `empty_artifacts()`
 factory helpers.  Keep the old dataclasses temporarily.  Tests still pass.
 
 ### Step 2: Migrate `Artifacts` → `ArtifactCounts`
 
 This is the simplest migration — `Artifacts` has only one role (`int` fields).
-- Replace `Artifacts` dataclass with `ArtifactCounts = dict[ArtifactKind, int]`
+- Replace `Artifacts` dataclass with `ArtifactCounts = dict[Artifact, int]`
 - Update `Treasure.own` and `Treasure.box` field types
 - Update `treasure.py`: `field_items` → `.items()`, `getattr` → `[]`,
   `replace(own, **{k: v})` → `{**own, k: v}`
@@ -411,7 +437,7 @@ This is the simplest migration — `Artifacts` has only one role (`int` fields).
 ### Step 3: Migrate `Dungeon` state → `DungeonState`
 
 Replace the `Dungeon` dataclass's state role (counting die faces) with
-`DungeonState = dict[DungeonFace, int]`.
+`DungeonState = dict[DungeonDie, int]`.
 - Update `dungeon.py`: all functions take/return `DungeonState`, delete
   `_check_dungeon_target` and `_DUNGEON_FIELDS`
 - Update `World.dungeon: Optional[DungeonState]`
@@ -438,7 +464,7 @@ Replace the `Party` dataclass's counting role with
 ### Step 5: Migrate `Dungeon` dispatch → `HeroActions`, and `Party` dispatch → `PartyActions`
 
 These two are tightly coupled (a `PartyActions` is a dict of `HeroActions`).
-- Define `HeroActions = dict[DungeonFace, Command]`
+- Define `HeroActions = dict[DungeonDie, Command]`
 - Define `PartyActions = dict[PartyDie, HeroActions]`
 - Remove the `Dungeon` and `Party` dataclasses entirely
 - Update `Player.party: PartyActions`
@@ -452,7 +478,7 @@ These two are tightly coupled (a `PartyActions` is a dict of `HeroActions`).
 
 ### Step 6: Migrate `Party` artifact mapping → `ArtifactMapping`
 
-- Define `ArtifactMapping = dict[PartyDie, Optional[ArtifactKind]]`
+- Define `ArtifactMapping = dict[PartyDie, Optional[Artifact]]`
 - Update `Player.artifacts: ArtifactMapping`
 - Update `player.py`: `Default.artifacts` construction,
   `_partify_command`, `_adjust_phantom_treasures`, `_ARTIFACT_COMMANDS`
@@ -471,7 +497,7 @@ These two are tightly coupled (a `PartyActions` is a dict of `HeroActions`).
 
 ### Step 8: Port `game.py`, `shell.py`, and the boundary layer
 
-- `game.py`: pass `ActionVerb.ABILITY` / `ActionVerb.REROLL` instead of
+- `game.py`: pass `Action.ABILITY` / `Action.REROLL` instead of
   string literals
 - `shell.py`: add `_parse_token` to convert user input strings → enum at
   the boundary; or let `player.apply` handle the conversion
@@ -500,8 +526,10 @@ After migration, `World.dungeon` will be a `dict` (or `None`), and
 must detect dicts and use `.items()` instead of `fields()`.
 
 ```python
+from collections.abc import Mapping
+
 def brief(o: Any) -> str:
-    if isinstance(o, dict):
+    if isinstance(o, Mapping):
         keyvalues = [f"{k.value if hasattr(k, 'value') else k}={brief(v)}"
                      for k, v in o.items() if v]
         return f"({', '.join(keyvalues)})"
@@ -513,6 +541,9 @@ def brief(o: Any) -> str:
     keyvalues = [f"{f}={brief(v)}" for f, v in zip(names, values) if v]
     return f"({', '.join(keyvalues)})"
 ```
+
+Note: `isinstance(o, Mapping)` catches both plain `dict` and
+`MappingProxyType`, since `MappingProxyType` implements `Mapping`.
 
 ### `field_names` / `field_values` / `field_items` helpers survive but shrink in scope
 
@@ -526,7 +557,7 @@ Callers that used them on the removed types:
 
 | Caller | Was | Becomes |
 |---|---|---|
-| `dice.py`: `len(fields(Dungeon))` | dataclass field count | `len(DungeonFace)` |
+| `dice.py`: `len(fields(Dungeon))` | dataclass field count | `len(DungeonDie)` |
 | `dice.py`: `len(fields(Party))` | dataclass field count | `len(PartyDie)` |
 | `dungeon.py`: `field_names(Dungeon)` | frozenset of names | deleted (enum membership) |
 | `dungeon.py`: `field_values(dungeon)` | sum of values | `dungeon.values()` |
@@ -538,11 +569,11 @@ Callers that used them on the removed types:
 | `player.py`: `field_items(action_)` | iteration | `.items()` |
 | `player.py`: `field_names(player.party)` | membership check | `in player.party` |
 | `player.py`: `field_names(action_)` | membership check | `in action_` |
-| `player.py`: `field_names(struct.Party)` / `field_names(struct.Dungeon)` | completion | `PartyDie` / `DungeonFace` members |
+| `player.py`: `field_names(struct.Party)` / `field_names(struct.Dungeon)` | completion | `PartyDie` / `DungeonDie` members |
 | `display.py`: `field_items(counts)` / `field_values(party)` | formatting | `.items()` / `.values()` |
 | `world.py`: `field_values(world.treasure.own)` | scoring | `.values()` |
 | `world.py`: `field_items(world.regroup.discard)` | regroup | `.items()` |
-| Tests: `len(fields(struct.Dungeon))` / `len(fields(struct.Party))` | construction | `len(DungeonFace)` / `len(PartyDie)` |
+| Tests: `len(fields(struct.Dungeon))` / `len(fields(struct.Party))` | construction | `len(DungeonDie)` / `len(PartyDie)` |
 
 ### `RollDungeon` and `RollParty` type aliases need updating
 
@@ -561,19 +592,35 @@ RollParty = Callable[[int, RandRange], tuple[PartyState, Regroup]]
 Line 49: `if not hasattr(treasure.own, item):` becomes
 `if item not in treasure.own:` — a natural dict idiom.
 
-### Frozen dict semantics
+### Frozen dict semantics — `MappingProxyType`
 
-`Dungeon` and `Party` are frozen dataclasses today; plain `dict` is mutable.
-Options:
-1. Use `types.MappingProxyType` for immutability (adds complexity)
-2. Use plain `dict` and rely on convention (simpler, matches `dataclasses.replace`
-   already returning new instances)
-3. Use a frozen-dict library
+`Dungeon` and `Party` are frozen dataclasses today.  To preserve the same
+runtime immutability, all six mapping types use `types.MappingProxyType`
+from the stdlib.  This is a zero-dependency read-only view over a `dict`:
 
-Recommend option 2: plain `dict`.  The existing code already treats these
-immutably via `replace()` returning new instances.  The dict spread
-`{**d, key: val}` naturally produces a new dict.  `World` (which holds them)
-remains a frozen dataclass, so you can't accidentally mutate its fields.
+```python
+from types import MappingProxyType
+
+proxy = MappingProxyType({DungeonDie.GOBLIN: 2})
+proxy[DungeonDie.GOBLIN]          # 2 — reads work
+proxy[DungeonDie.GOBLIN] = 99     # TypeError — mutation blocked
+```
+
+The "update" idiom builds a new plain `dict` via spread, then re-wraps:
+
+```python
+frozen({**proxy, DungeonDie.GOBLIN: 0})
+# → MappingProxyType({DungeonDie.GOBLIN: 0, ...})
+```
+
+This pairs with frozen dataclasses: `World(frozen=True)` prevents field
+reassignment, and `MappingProxyType` prevents mutation of the mapping
+values.  Together they provide the same depth of immutability as the
+original nested frozen dataclasses.
+
+Type annotations use `Mapping[K, V]` (the abstract read-only interface
+from `collections.abc`), so function signatures express the read-only
+contract without mentioning `MappingProxyType` directly.
 
 ### All 8 hero files need migration
 
@@ -598,15 +645,15 @@ patterns that must become dict literals / dict spreads.
   files but each `getattr`→`[]` change is mechanical.
 - **Higher risk:** Dispatch table migration (Step 5) changes how hero files
   build their action tables.  The `replace(Default.party.fighter, dragon=...)`
-  pattern becomes `{**Default.party[PartyDie.FIGHTER], DungeonFace.DRAGON: ...}`.
+  pattern becomes `{**Default.party[PartyDie.FIGHTER], DungeonDie.DRAGON: ...}`.
   This is more verbose but precisely typed.  Must test all 8 hero variants.
 - **Medium risk:** `Command` signature (Step 7) touches every action function.
   Doing it late means intermediate steps have a mixed `str`/`enum` period.
 - **`brief()` breakage:** If not handled in Step 1, `brief(world)` will
   produce ugly `str(dict)` output for dungeon/party sub-objects.  Must be
   addressed early (Step 1 or 2).
-- **Frozen semantics:** Moving to plain `dict` loses the frozen guarantee.
-  Mitigated by `World` being a frozen dataclass and the existing code already
-  following an immutable-update pattern.
+- **Frozen semantics:** `MappingProxyType` preserves the same runtime
+  immutability as frozen dataclasses.  The `frozen()` helper adds one
+  function call per construction, which is negligible.
 - **Boundary clarity:** The shell is the only place raw user strings enter.
   Converting there (Step 8) means the engine interior speaks enums throughout.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,25 +1,21 @@
-# Plan: Replace Literal Strings with Enums
+# Plan: Replace Literal Strings with Enums and Overloaded Dataclasses with Typed Dicts
 
 ## Problem Statement
 
 Throughout the codebase, a small number of literal string values—representing
 party members, dungeon faces, artifacts, and special commands—are passed as
-plain `str` from the shell layer all the way into the game engine.  These
-strings are the game's vocabulary: `"fighter"`, `"goblin"`, `"sword"`,
-`"reroll"`, `"ability"`, etc.  They are never arbitrary user text; they always
-belong to one of a few closed sets.  Using bare strings means:
+plain `str` from the shell layer all the way into the game engine.
 
-- No static checking that a value belongs to its intended set.
-- `getattr(obj, name)` / `replace(obj, **{name: ...})` patterns where `name`
-  is a raw string, bypassing type-checker visibility.
-- Validation scattered across ad-hoc `frozenset` lookups and runtime `if`
-  checks (`_DUNGEON_FIELDS`, `_PARTY_FIELDS`, `_check_dungeon_target`, etc.).
-- Easy to accidentally pass a dungeon name where a party name is expected (or
-  vice versa) with no tool-time feedback.
+Compounding this, three dataclasses (`Dungeon`, `Party`, `Artifacts`) are each
+used as map-like containers but with imprecise type annotations.  `Party` is
+the worst offender: its field type is `Union[int, Command, str, None]` because
+the same dataclass serves three completely different roles.  `Dungeon` has
+`Union[int, Command]` for the same reason (two roles).  These unions make
+static analysis nearly useless and hide semantic errors.
 
 ## Proposed Enums
 
-### 1. `DungeonFace` — the six dungeon die faces
+### `DungeonFace` — the six dungeon die faces
 
 ```python
 class DungeonFace(enum.Enum):
@@ -31,16 +27,7 @@ class DungeonFace(enum.Enum):
     DRAGON = "dragon"
 ```
 
-**Where it replaces strings today:**
-- `dungeon.py`: `decrement_dungeon(dungeon, target: str)` → `target: DungeonFace`
-- `dungeon.py`: `increment_dungeon(dungeon, target: str)` → `target: DungeonFace`
-- `dungeon.py`: `eliminate_dungeon(dungeon, target: str)` → `target: DungeonFace`
-- `regular.py`: `_classify_reroll_targets` membership checks against `_DUNGEON_NAMES`
-- `regular.py`: `bait_dragon` iterating `_enemies: Sequence[str]`
-- `ability.py`: calls like `increment_dungeon(dungeon, "potion")`
-- `special.py`: `convert_dungeon_to_party(world, source="goblin", ...)`
-
-### 2. `PartyDie` — the six party die faces
+### `PartyDie` — the six party die faces
 
 ```python
 class PartyDie(enum.Enum):
@@ -52,17 +39,7 @@ class PartyDie(enum.Enum):
     SCROLL = "scroll"
 ```
 
-**Where it replaces strings today:**
-- `party.py`: `decrement_party(party, hero: str)` → `hero: PartyDie`
-- `party.py`: `increment_party(party, hero: str)` → `hero: PartyDie`
-- `party.py`: `decrement_regroup(regroup, hero: str)` → `hero: PartyDie`
-- `regular.py`: `_classify_reroll_targets` membership checks against `_PARTY_NAMES`
-- `regular.py`: `defeat_dragon_heroes` disallowed set `{"scroll"}`
-- `ability.py`: calls like `increment_party(world.party, "scroll")`
-- `special.py`: `convert_dungeon_to_party(world, ..., destination="thief")`
-- `player.py`: artifact mapping values, `_partify_command` return values
-
-### 3. `ArtifactKind` — the ten treasure/artifact types
+### `ArtifactKind` — the ten treasure/artifact types
 
 ```python
 class ArtifactKind(enum.Enum):
@@ -78,17 +55,7 @@ class ArtifactKind(enum.Enum):
     SCALE = "scale"
 ```
 
-**Where it replaces strings today:**
-- `treasure.py`: `_draw` returns `str` → `ArtifactKind`
-- `treasure.py`: `replace_treasure(treasure, item: str)` → `item: ArtifactKind`
-- `player.py`: `_ARTIFACT_COMMANDS` frozenset
-- `player.py`: `artifacts=struct.Party(fighter="sword", ...)` mappings
-- `world.py`: `_apply_ring(world, *, noun: str = "ring")`
-- `world.py`: `_apply_portal(world, *, noun: str = "portal")`
-- `regular.py`: `bait_dragon` calling `replace_treasure(world.treasure, command)`
-- `regular.py`: `elixir` calling `replace_treasure(world.treasure, command)`
-
-### 4. `ActionVerb` — the special command verbs that aren't heroes
+### `ActionVerb` — the special command verbs that aren't heroes
 
 ```python
 class ActionVerb(enum.Enum):
@@ -98,144 +65,548 @@ class ActionVerb(enum.Enum):
     REROLL = "reroll"
 ```
 
-**Where it replaces strings today:**
-- `player.py:apply()`: `if command == "portal"`, `if command == "ring"`,
-  `if command in {"ability", "bait", "elixir"}`, `if command == "reroll"`
-- `game.py`: passing `"ability"` and `"reroll"` into `player.apply()`
+## Dataclass → Dict Type Replacement Table
 
-This enum is small but eliminates the riskiest string comparisons—the ones
-that dispatch to fundamentally different code paths.
+The key observation is that `Party`, `Dungeon`, and `Artifacts` are each used
+as map-like containers.  Today they share a single dataclass definition despite
+serving fundamentally different roles with different value types.  With enums as
+keys, each role becomes a distinct, precisely-typed dict:
 
-## Dataclass Field Access Pattern
+| Current Type | Role / Context | Current Field Annotation | New Type Alias | Used In |
+|---|---|---|---|---|
+| `Dungeon` | Die counts on a dungeon level | `Union[int, Command]` (only `int` at runtime) | `DungeonState = dict[DungeonFace, int]` | `World.dungeon`, `dice.roll_dungeon()`, `dungeon.py` functions |
+| `Dungeon` | Per-hero dispatch: what action does this hero take against each dungeon face? | `Union[int, Command]` (only `Command` at runtime) | `HeroActions = dict[DungeonFace, Command]` | Nested inside `Player.party` values (e.g. `Default.party[PartyDie.FIGHTER]`) |
+| `Party` | Die counts of heroes in the current party | `Union[int, Command, str, None]` (only `int` at runtime) | `PartyState = dict[PartyDie, int]` | `World.party`, `Regroup.discard`, `dice.roll_party()`, `party.py` functions |
+| `Party` | Full dispatch table: for each hero, what does it do to each dungeon face? | `Union[int, Command, str, None]` (only `HeroActions`/`Dungeon` at runtime) | `PartyActions = dict[PartyDie, HeroActions]` | `Player.party` — the two-level dispatch table |
+| `Party` | Which artifact corresponds to each hero? | `Union[int, Command, str, None]` (only `Optional[str]` at runtime) | `ArtifactMapping = dict[PartyDie, Optional[ArtifactKind]]` | `Player.artifacts` |
+| `Artifacts` | Counts of each treasure type (in hand or in box) | `int` | `ArtifactCounts = dict[ArtifactKind, int]` | `Treasure.own`, `Treasure.box`, `world.py` scoring |
 
-The core challenge is that `Dungeon`, `Party`, and `Artifacts` are frozen
-dataclasses whose fields are named after enum values.  Today the code uses
-`getattr(dungeon, target)` and `replace(dungeon, **{target: new_val})` where
-`target` is a bare string matching a field name.
+### What the type aliases look like in `struct.py`
 
-With enums, the accessor pattern becomes:
+```python
+# State containers (runtime values are always int)
+DungeonState  = dict[DungeonFace, int]
+PartyState    = dict[PartyDie, int]
+ArtifactCounts = dict[ArtifactKind, int]
+
+# Dispatch containers (runtime values are always Command)
+HeroActions   = dict[DungeonFace, Command]
+PartyActions  = dict[PartyDie, HeroActions]
+
+# Mapping container
+ArtifactMapping = dict[PartyDie, Optional[ArtifactKind]]
+```
+
+### Updated `Player`, `World`, `Treasure`, `Regroup`
+
+```python
+@dataclass(frozen=True)
+class Treasure:
+    own: ArtifactCounts    # was Artifacts
+    box: ArtifactCounts    # was Artifacts
+
+@dataclass(frozen=True)
+class Regroup:
+    discard: PartyState    # was Party
+
+@dataclass(frozen=True)
+class World:
+    delve: int = 0
+    depth: int = 0
+    experience: int = 0
+    dungeon: Optional[DungeonState] = None   # was Optional[Dungeon]
+    party: PartyState = ...                   # was Party
+    ability: bool = False
+    regroup: Regroup = ...
+    treasure: Treasure = ...
+
+@dataclass(frozen=True)
+class Player:
+    name: str
+    ability: Command
+    advance: Advance
+    bait: Command
+    elixir: Command
+    roll: Roll
+    artifacts: ArtifactMapping    # was Party(fighter="sword", ...)
+    party: PartyActions           # was Party(fighter=Dungeon(goblin=defeat_all, ...))
+```
+
+### Updated `Command` Signature
 
 ```python
 # Before
-getattr(dungeon, target)                  # target = "goblin"
-replace(dungeon, **{target: new_val})
+Command = Callable[[World, RandRange, str, tuple[str, ...]], World]
 
 # After
-getattr(dungeon, target.value)            # target = DungeonFace.GOBLIN
-replace(dungeon, **{target.value: new_val})
+Command = Callable[[World, RandRange, PartyDie, tuple[DungeonFace | PartyDie, ...]], World]
 ```
 
-This is the minimally invasive approach.  An alternative would be to replace
-the dataclasses with dict-like containers keyed by enum, but that would be a
-much larger change with less benefit from the frozen-dataclass guarantees.
+The `str` that was `hero` becomes `PartyDie`.  The `tuple[str, ...]` that was
+`targets` becomes `tuple[DungeonFace | PartyDie, ...]` (targets can be
+dungeon faces to attack, or party die names for reroll/quaff).
 
-## What the Finished Result Looks Like
+## What Changes in the Access Patterns
 
-1. **`struct.py`** gains four `enum.Enum` classes (`DungeonFace`, `PartyDie`,
-   `ArtifactKind`, `ActionVerb`) alongside the existing dataclasses.
+### `getattr`/`replace` → dict `[]`/`{**d, k: v}`
 
-2. **`Dungeon`, `Party`, `Artifacts` dataclasses** keep their field names
-   unchanged (so `Dungeon.goblin`, `Party.fighter`, etc. remain valid Python
-   identifiers).  The enum `.value` serves as the bridge between the typed
-   token and the field name.
+Every `getattr(obj, name)` / `replace(obj, **{name: val})` on these six types
+becomes a plain dict lookup / dict spread:
 
-3. **Module-internal validation** (`_check_dungeon_target`,
-   `_check_party_member`, `_DUNGEON_FIELDS`, `_PARTY_FIELDS`) **is deleted**
-   because the enum type annotation enforces membership at the call site.
+```python
+# Before (dungeon.py)
+def decrement_dungeon(dungeon: Dungeon, target: str) -> Dungeon:
+    _check_dungeon_target(target)
+    prior = getattr(dungeon, target)
+    return replace(dungeon, **{target: prior - 1})
 
-4. **`shell.py`** gains a thin `_parse_token(text: str) -> Enum` function at
-   the boundary where user input becomes typed.  `_tokenize` returns
-   `tuple[str, ...]` today; the new version would return typed tokens that the
-   rest of the engine consumes.
+# After
+def decrement_dungeon(dungeon: DungeonState, target: DungeonFace) -> DungeonState:
+    prior = dungeon[target]
+    if not prior:
+        raise DrollError(f"At least 1 {target.value} required in dungeon.")
+    return {**dungeon, target: prior - 1}
+```
 
-5. **All intermediate functions** (`decrement_dungeon`, `increment_party`,
-   `replace_treasure`, `bait_dragon`, `quaff`, etc.) accept enum parameters
-   instead of `str`, gaining static type safety.
+```python
+# Before (party.py)
+def increment_party(party: Party, hero: str) -> Party:
+    _check_party_member(hero)
+    return replace(party, **{hero: getattr(party, hero) + 1})
 
-6. **Error messages** use `target.value` to produce the same human-readable
-   strings as today—no user-facing change.
+# After
+def increment_party(party: PartyState, hero: PartyDie) -> PartyState:
+    return {**party, hero: party[hero] + 1}
+```
 
-7. **Tab completion** continues to work with string values; conversion happens
-   at the boundary.
+### `field_names`/`field_values`/`field_items` → dict methods
+
+```python
+# Before
+for name, count in field_items(dungeon): ...
+sum(field_values(dungeon))
+
+# After
+for face, count in dungeon.items(): ...
+sum(dungeon.values())
+```
+
+### `_check_*` validation functions → deleted
+
+`_check_dungeon_target`, `_check_party_member`, `_DUNGEON_FIELDS`,
+`_PARTY_FIELDS` all become unnecessary — the enum type enforces membership.
+
+### Hero definitions use dict literals instead of `replace()`
+
+```python
+# Before (knight.py)
+DragonSlayer = replace(Default, ...,
+    party=struct.Party(
+        fighter=replace(Default.party.fighter, dragon=_dragonslayer_defeat_dragon),
+        ...
+    ))
+
+# After
+DragonSlayer = replace(Default, ...,
+    party={
+        PartyDie.FIGHTER: {**Default.party[PartyDie.FIGHTER],
+                           DungeonFace.DRAGON: _dragonslayer_defeat_dragon},
+        ...
+    })
+```
+
+### `Dungeon()` as empty → dict comprehension or factory
+
+```python
+# Before
+struct.Dungeon()  # all zeros
+
+# After
+{face: 0 for face in DungeonFace}
+# or a helper: empty_dungeon()
+```
+
+### Constructor patterns with `*list` unpacking
+
+```python
+# Before (dice.py)
+Dungeon(*_roll(dice, 0, 6, randrange))
+
+# After
+dict(zip(DungeonFace, _roll(dice, 0, 6, randrange)))
+```
+
+## Detailed Per-File Impact
+
+### `struct.py`
+- Add four enums and six type aliases
+- Remove `Dungeon`, `Party`, `Artifacts` dataclasses
+- Add factory helpers: `empty_dungeon() -> DungeonState`,
+  `empty_party() -> PartyState`, `empty_artifacts() -> ArtifactCounts`
+- Update `Treasure` fields: `own: ArtifactCounts`, `box: ArtifactCounts`
+- Update `Regroup.discard: PartyState`
+- Update `World.dungeon: Optional[DungeonState]`, `World.party: PartyState`
+- Update `Player.artifacts: ArtifactMapping`, `Player.party: PartyActions`
+- Update `Command` signature
+- Replace `field_names`/`field_values`/`field_items` usages on the removed
+  types with dict `.keys()`/`.values()`/`.items()` (callers migrate too)
+- Keep `brief()` working via duck typing on dict `.items()`
+
+### `dungeon.py`
+- Param `target: str` → `target: DungeonFace` in all functions
+- Return `Dungeon` → `DungeonState` (i.e. `dict[DungeonFace, int]`)
+- Delete `_DUNGEON_FIELDS`, `_check_dungeon_target`
+- `getattr(dungeon, target)` → `dungeon[target]`
+- `replace(dungeon, **{target: v})` → `{**dungeon, target: v}`
+- Direct access `dungeon.goblin` → `dungeon[DungeonFace.GOBLIN]`
+- `field_values(dungeon)` → `dungeon.values()`
+
+### `party.py`
+- Param `hero: str` → `hero: PartyDie` in all functions
+- Return `Party` → `PartyState`
+- Delete `_PARTY_FIELDS`, `_check_party_member`
+- Same `getattr`→`[]` and `replace`→`{**d}` migration as `dungeon.py`
+
+### `treasure.py`
+- `_draw` returns `ArtifactKind` instead of `str`
+- `replace_treasure` param `item: str` → `item: ArtifactKind`
+- `field_items(box)` → `box.items()`
+- `field_values(box)` → `box.values()`
+- `getattr(treasure.own, drawn)` → `treasure.own[drawn]`
+- `replace(treasure.own, **{drawn: v})` → `{**treasure.own, drawn: v}`
+  (but `Treasure` itself stays a dataclass, so its `replace` stays)
+
+### `regular.py`
+- All `Command`-signature functions: `hero: str` → `hero: PartyDie`,
+  `targets: tuple[str, ...]` → `tuple[DungeonFace | PartyDie, ...]`
+- `_DUNGEON_NAMES`, `_PARTY_NAMES` frozensets → deleted (use `isinstance`
+  checks or enum type)
+- `_classify_reroll_targets`: check `isinstance(t, DungeonFace)` vs
+  `isinstance(t, PartyDie)`
+- `bait_dragon`: `_enemies` becomes `tuple[DungeonFace, ...]`
+- `defeat_dragon_heroes`: `disallowed_heroes` becomes `frozenset[PartyDie]`
+- `elixir`: `targets[0]` is already `PartyDie`
+- String literals like `"potion"` → `DungeonFace.POTION`, `"scroll"` →
+  `PartyDie.SCROLL`, etc.
+
+### `special.py`
+- Same `Command` signature updates as `regular.py`
+- `convert_dungeon_to_party`: `source: str` → `source: DungeonFace`,
+  `destination: str` → `destination: PartyDie`
+- `getattr(world.dungeon, source)` → `world.dungeon[source]`
+
+### `ability.py`
+- All ability functions: `command: str` → `command: ActionVerb`,
+  `targets: tuple[str, ...]` → typed tuple
+- `_choose_and_add_hero`: `acceptable: frozenset[str]` →
+  `frozenset[PartyDie]`
+- `_convert_one`/`_convert_two`: `source: str` → `DungeonFace`,
+  `destination: str` → `PartyDie`
+- Literal strings like `increment_dungeon(dungeon, "potion")` →
+  `increment_dungeon(dungeon, DungeonFace.POTION)`
+- `increment_party(world.party, "scroll")` →
+  `increment_party(world.party, PartyDie.SCROLL)`
+
+### `player.py`
+- `Default.artifacts` becomes `ArtifactMapping`:
+  `{PartyDie.FIGHTER: ArtifactKind.SWORD, ..., PartyDie.CHAMPION: None, ...}`
+- `Default.party` becomes `PartyActions`:
+  `{PartyDie.FIGHTER: {DungeonFace.GOBLIN: defeat_all, ...}, ...}`
+- `apply()`: `command: str` becomes a union or is pre-parsed into the
+  appropriate enum type by the caller; dispatch uses enum comparisons
+- `_partify_command`: `ArtifactKind` → `PartyDie` reverse lookup
+- `_ARTIFACT_COMMANDS`: `frozenset[ArtifactKind]`
+- `_TREASURE_NO_COMMAND`: `frozenset[ArtifactKind]`
+- `complete()`: returns `Sequence[str]` (for the shell), but internally
+  works with enum `.value` strings
+- `_available_nouns`/`_available_targets`: iterate `.items()` on dicts
+  instead of `field_items()`
+- `_adjust_phantom_treasures`: iterates `artifacts.items()` instead of
+  `field_items(artifacts)`
+
+### `world.py`
+- `new_world()`: `Artifacts(sword=3, ...)` →
+  `{ArtifactKind.SWORD: 3, ...}`
+- `_regroup()`: `Party(**{name: max(...)})` →
+  `{die: max(0, world.party[die] - world.regroup.discard[die]) for die in PartyDie}`
+- `descend()`: `replace(rolled, dragon=...)` → `{**rolled, DungeonFace.DRAGON: ...}`
+- `_apply_ring`/`_apply_portal`: `noun: str = "ring"` →
+  `noun: ArtifactKind = ArtifactKind.RING`
+- `score()`: `field_values(world.treasure.own)` → `world.treasure.own.values()`
+- `world.treasure.own.portal` → `world.treasure.own[ArtifactKind.PORTAL]`
+- `world.treasure.own.scale` → `world.treasure.own[ArtifactKind.SCALE]`
+
+### `display.py`
+- `_format_items`: `field_items(counts)` → `counts.items()`
+- `_format_treasure`: `field_items(artifacts)` → `artifacts.items()`
+- `field_values(party)` → `party.values()`
+- Item names in output use `face.value` / `die.value` for display strings
+- `_ALWAYS_COUNT = frozenset({DungeonFace.DRAGON})`
+
+### `dice.py`
+- `roll_dungeon` returns `DungeonState` instead of `Dungeon`
+- `roll_party` returns `PartyState` instead of `Party`
+- `Dungeon(*_roll(...))` → `dict(zip(DungeonFace, _roll(...)))`
+- `Party(*_roll(...))` → `dict(zip(PartyDie, _roll(...)))`
+- `len(fields(Dungeon))` → `len(DungeonFace)` (enum length)
+- `len(fields(Party))` → `len(PartyDie)`
+
+### `game.py`
+- `Game.ability()`: passes `ActionVerb.ABILITY` instead of `"ability"`
+- `Game.reroll()`: passes `ActionVerb.REROLL` instead of `"reroll"`
+- `Game.apply()`: tokenized strings arrive from shell; parsing happens
+  in `player.apply()` or the caller converts first
+- `_possible_world_actions()`: `"ability"` → `ActionVerb.ABILITY` etc.
+- `score_deltas()`: no enum changes (returns `dict[str, int]` for display)
+
+### `shell.py`
+- `_tokenize` stays string-based (it's the raw user input boundary)
+- `do_ability`, `default`, `do_reroll` pass raw strings into `Game`
+  methods, which forward to `player.apply()` where conversion happens
+- Alternatively: conversion at the shell boundary via a `_parse_token`
+  function
+- Tab completion operates on `.value` strings throughout
+- `_AVAILABLE_COMMANDS` stays as `frozenset[str]` (UI concern)
+
+### Hero files (`droll/heroes/*.py`)
+- All `struct.Party(fighter=struct.Dungeon(...), ...)` constructions →
+  `{PartyDie.FIGHTER: {DungeonFace.GOBLIN: defeat_all, ...}, ...}`
+- `replace(Default.party.fighter, dragon=...)` →
+  `{**Default.party[PartyDie.FIGHTER], DungeonFace.DRAGON: ...}`
+- `replace(Default.party, fighter=..., cleric=...)` →
+  `{**Default.party, PartyDie.FIGHTER: ..., PartyDie.CLERIC: ...}`
+- `Default.party.cleric.skeleton` → `Default.party[PartyDie.CLERIC][DungeonFace.SKELETON]`
+- `frozenset({"fighter", "cleric"})` → `frozenset({PartyDie.FIGHTER, PartyDie.CLERIC})`
+
+### Test files
+- Every `struct.Dungeon(goblin=1, ...)` → `{DungeonFace.GOBLIN: 1, ...}`
+  (or use `{**empty_dungeon(), DungeonFace.GOBLIN: 1}`)
+- Every `struct.Party(fighter=2, ...)` → same pattern with `PartyDie`
+- Every `struct.Artifacts(sword=1, ...)` → same pattern with `ArtifactKind`
+- Direct field access `game.dungeon.goblin` → `game.dungeon[DungeonFace.GOBLIN]`
+- Direct field access `game.party.fighter` → `game.party[PartyDie.FIGHTER]`
 
 ## Implementation Steps
 
-### Step 1: Define the enums in `struct.py`
+### Step 1: Define enums and type aliases in `struct.py`
 
-Add `DungeonFace`, `PartyDie`, `ArtifactKind`, and `ActionVerb` to `struct.py`.
-Export them from `__all__`.  No other file changes yet.  Tests still pass.
+Add `DungeonFace`, `PartyDie`, `ArtifactKind`, `ActionVerb` plus all six
+type aliases.  Add `empty_dungeon()`, `empty_party()`, `empty_artifacts()`
+factory helpers.  Keep the old dataclasses temporarily.  Tests still pass.
 
-### Step 2: Port `dungeon.py` to use `DungeonFace`
+### Step 2: Migrate `Artifacts` → `ArtifactCounts`
 
-- Change `decrement_dungeon`, `increment_dungeon`, `eliminate_dungeon` to
-  accept `target: DungeonFace` and use `target.value` for `getattr`/`replace`.
-- Remove `_check_dungeon_target` and `_DUNGEON_FIELDS`.
-- Update all callers in `regular.py`, `special.py`, and `ability.py` to pass
-  `DungeonFace.GOBLIN` instead of `"goblin"`, etc.
-- Update tests.
+This is the simplest migration — `Artifacts` has only one role (`int` fields).
+- Replace `Artifacts` dataclass with `ArtifactCounts = dict[ArtifactKind, int]`
+- Update `Treasure.own` and `Treasure.box` field types
+- Update `treasure.py`: `field_items` → `.items()`, `getattr` → `[]`,
+  `replace(own, **{k: v})` → `{**own, k: v}`
+- Update `world.py`: `new_world()` construction, `score()` access
+- Update `display.py`: `_format_treasure`
+- Update `player.py`: `_ARTIFACT_COMMANDS`, `_TREASURE_NO_COMMAND`,
+  `_available_nouns` treasure iteration
+- Update tests
+- Run tests
 
-### Step 3: Port `party.py` to use `PartyDie`
+### Step 3: Migrate `Dungeon` state → `DungeonState`
 
-- Change `decrement_party`, `increment_party`, `decrement_regroup` to accept
-  `hero: PartyDie` and use `hero.value`.
-- Remove `_check_party_member` and `_PARTY_FIELDS`.
-- Update all callers in `regular.py`, `special.py`, `ability.py`, and
-  `player.py`.
-- Update tests.
+Replace the `Dungeon` dataclass's state role (counting die faces) with
+`DungeonState = dict[DungeonFace, int]`.
+- Update `dungeon.py`: all functions take/return `DungeonState`, delete
+  `_check_dungeon_target` and `_DUNGEON_FIELDS`
+- Update `World.dungeon: Optional[DungeonState]`
+- Update `dice.py`: `roll_dungeon` returns `DungeonState`
+- Update `regular.py`, `special.py`, `ability.py`: all dungeon state access
+- Update `world.py`: `descend()`, `_regroup()`, `new_world()`
+- Update tests
+- Run tests
 
-### Step 4: Port `treasure.py` to use `ArtifactKind`
+### Step 4: Migrate `Party` state → `PartyState`
 
-- Change `_draw` to return `ArtifactKind`.
-- Change `replace_treasure` to accept `item: ArtifactKind`.
-- Update callers in `world.py`, `regular.py`, `ability.py`, and `player.py`.
-- Update tests.
+Replace the `Party` dataclass's counting role with
+`PartyState = dict[PartyDie, int]`.
+- Update `party.py`: all functions take/return `PartyState`, delete
+  `_check_party_member` and `_PARTY_FIELDS`
+- Update `World.party: PartyState`, `Regroup.discard: PartyState`
+- Update `dice.py`: `roll_party` returns `PartyState`
+- Update `regular.py`, `special.py`, `ability.py`: all party state access
+- Update `player.py`: `_adjust_phantom_treasures`, `apply()` party iteration
+- Update `world.py`: `_regroup()`
+- Update tests
+- Run tests
 
-### Step 5: Port `player.py` to use `ActionVerb` and integrate all enums
+### Step 5: Migrate `Dungeon` dispatch → `HeroActions`, and `Party` dispatch → `PartyActions`
 
-- Replace the string comparisons in `apply()` with `ActionVerb` checks.
-- Update `_partify_command` to work with `ArtifactKind` → `PartyDie` mapping.
-- Update `_ARTIFACT_COMMANDS` to use `ArtifactKind`.
-- Update `_available_nouns`, `_available_targets`, `_all_dice_names`, and
-  `complete` to return/compare enum values, converting to strings only for
-  display.
-- Update tests.
+These two are tightly coupled (a `PartyActions` is a dict of `HeroActions`).
+- Define `HeroActions = dict[DungeonFace, Command]`
+- Define `PartyActions = dict[PartyDie, HeroActions]`
+- Remove the `Dungeon` and `Party` dataclasses entirely
+- Update `Player.party: PartyActions`
+- Update `player.py:apply()`: `getattr(player.party, command)` →
+  `player.party[command]`, `getattr(action_, targets[0])` →
+  `action_[targets[0]]`
+- Update all hero files: `struct.Party(fighter=struct.Dungeon(...), ...)` →
+  dict literals; `replace(Default.party.fighter, ...)` → dict spread
+- Update tests
+- Run tests
 
-### Step 6: Port `game.py` and `shell.py` — the boundary layer
+### Step 6: Migrate `Party` artifact mapping → `ArtifactMapping`
 
-- In `game.py`, pass enum values instead of string literals to `player.apply`.
-- In `shell.py`, add `_parse_token` to convert user input strings into the
-  appropriate enum type.  `_tokenize` stays string-based; parsing happens
-  inside `do_ability`, `default`, `do_reroll`, and completion methods.
-- Tab completion operates on `.value` strings but the typed boundary ensures
-  invalid tokens are caught early.
-- Update tests.
+- Define `ArtifactMapping = dict[PartyDie, Optional[ArtifactKind]]`
+- Update `Player.artifacts: ArtifactMapping`
+- Update `player.py`: `Default.artifacts` construction,
+  `_partify_command`, `_adjust_phantom_treasures`, `_ARTIFACT_COMMANDS`
+- Update tests
+- Run tests
 
-### Step 7: Port the `Command` type signature
+### Step 7: Update `Command` signature and action functions
 
-- Update `struct.Command` from
-  `Callable[[World, RandRange, str, tuple[str, ...]], World]`
-  to use the appropriate enum types for the `hero` and `targets` parameters.
-- This is the signature used by `defeat_one`, `defeat_all`, `quaff`,
-  `defeat_dragon`, `bait_dragon`, `elixir`, and every hero ability.
-- Update all implementations and their callers.
-- Update tests.
+- Update `Command = Callable[[World, RandRange, PartyDie, tuple[...]], World]`
+- Update every function that matches the `Command` signature (`defeat_one`,
+  `defeat_all`, `open_one`, `open_all`, `quaff`, `reroll`, `defeat_dragon`,
+  `bait_dragon`, `elixir`, all ability functions, all special functions)
+- Update `player.py:apply()` to pass typed values
+- Update tests
+- Run tests
 
-### Step 8: Clean up and final verification
+### Step 8: Port `game.py`, `shell.py`, and the boundary layer
 
-- Remove any remaining `frozenset` lookups that the enums made redundant.
-- Run the full test suite.
-- Verify tab completion and shell interaction still work correctly.
-- Verify `brief()` display output is unchanged.
+- `game.py`: pass `ActionVerb.ABILITY` / `ActionVerb.REROLL` instead of
+  string literals
+- `shell.py`: add `_parse_token` to convert user input strings → enum at
+  the boundary; or let `player.apply` handle the conversion
+- Tab completion returns `.value` strings
+- Update tests
+- Run tests
+
+### Step 9: Clean up
+
+- Remove any remaining `field_names`/`field_values`/`field_items` usage
+  that operated on the now-deleted dataclasses
+- Remove helper functions in `struct.py` if no longer needed
+- Verify `brief()` works on the remaining dataclasses (`World`, `Treasure`,
+  `Regroup`, `Player`, `Roll`)
+- Run full test suite
+- Verify shell interaction and tab completion unchanged
+
+## Cross-Cutting Concerns
+
+### `brief()` must handle both dicts and surviving dataclasses
+
+`brief()` in `struct.py` recursively formats nested structures using
+`field_names()` / `field_values()`, which call `dataclasses.fields()`.
+After migration, `World.dungeon` will be a `dict` (or `None`), and
+`World.party` will be a `dict`.  When `brief()` recurses into these, it
+must detect dicts and use `.items()` instead of `fields()`.
+
+```python
+def brief(o: Any) -> str:
+    if isinstance(o, dict):
+        keyvalues = [f"{k.value if hasattr(k, 'value') else k}={brief(v)}"
+                     for k, v in o.items() if v]
+        return f"({', '.join(keyvalues)})"
+    try:
+        names = field_names(o)
+        values = field_values(o)
+    except TypeError:
+        return str(o)
+    keyvalues = [f"{f}={brief(v)}" for f, v in zip(names, values) if v]
+    return f"({', '.join(keyvalues)})"
+```
+
+### `field_names` / `field_values` / `field_items` helpers survive but shrink in scope
+
+These helpers remain useful for the surviving dataclasses (`World`,
+`Treasure`, `Regroup`, `Player`, `Roll`).  But they are no longer called
+on `Dungeon`, `Party`, or `Artifacts` — those callers migrate to dict
+`.keys()` / `.values()` / `.items()`.  The helpers themselves don't change;
+only their call sites do.
+
+Callers that used them on the removed types:
+
+| Caller | Was | Becomes |
+|---|---|---|
+| `dice.py`: `len(fields(Dungeon))` | dataclass field count | `len(DungeonFace)` |
+| `dice.py`: `len(fields(Party))` | dataclass field count | `len(PartyDie)` |
+| `dungeon.py`: `field_names(Dungeon)` | frozenset of names | deleted (enum membership) |
+| `dungeon.py`: `field_values(dungeon)` | sum of values | `dungeon.values()` |
+| `party.py`: `field_names(Party)` | frozenset of names | deleted (enum membership) |
+| `regular.py`: `field_names(Dungeon)` / `field_names(Party)` | frozensets | deleted |
+| `regular.py`: `field_values(dungeon)` / `field_values(party)` | for map/add | `.values()` |
+| `treasure.py`: `field_items(box)` / `field_values(box)` | iteration | `.items()` / `.values()` |
+| `player.py`: `field_items(artifacts)` | iteration | `.items()` |
+| `player.py`: `field_items(action_)` | iteration | `.items()` |
+| `player.py`: `field_names(player.party)` | membership check | `in player.party` |
+| `player.py`: `field_names(action_)` | membership check | `in action_` |
+| `player.py`: `field_names(struct.Party)` / `field_names(struct.Dungeon)` | completion | `PartyDie` / `DungeonFace` members |
+| `display.py`: `field_items(counts)` / `field_values(party)` | formatting | `.items()` / `.values()` |
+| `world.py`: `field_values(world.treasure.own)` | scoring | `.values()` |
+| `world.py`: `field_items(world.regroup.discard)` | regroup | `.items()` |
+| Tests: `len(fields(struct.Dungeon))` / `len(fields(struct.Party))` | construction | `len(DungeonFace)` / `len(PartyDie)` |
+
+### `RollDungeon` and `RollParty` type aliases need updating
+
+```python
+# Before
+RollDungeon = Callable[[int, RandRange], Dungeon]
+RollParty = Callable[[int, RandRange], tuple[Party, Regroup]]
+
+# After
+RollDungeon = Callable[[int, RandRange], DungeonState]
+RollParty = Callable[[int, RandRange], tuple[PartyState, Regroup]]
+```
+
+### `hasattr()` in `treasure.py` → `in` operator
+
+Line 49: `if not hasattr(treasure.own, item):` becomes
+`if item not in treasure.own:` — a natural dict idiom.
+
+### Frozen dict semantics
+
+`Dungeon` and `Party` are frozen dataclasses today; plain `dict` is mutable.
+Options:
+1. Use `types.MappingProxyType` for immutability (adds complexity)
+2. Use plain `dict` and rely on convention (simpler, matches `dataclasses.replace`
+   already returning new instances)
+3. Use a frozen-dict library
+
+Recommend option 2: plain `dict`.  The existing code already treats these
+immutably via `replace()` returning new instances.  The dict spread
+`{**d, key: val}` naturally produces a new dict.  `World` (which holds them)
+remains a frozen dataclass, so you can't accidentally mutate its fields.
+
+### All 8 hero files need migration
+
+The plan's Step 5 must cover all hero files:
+- `enchantress.py` (Enchantress/Beguiler)
+- `crusader.py` (Crusader/Paladin)
+- `halfgoblin.py` (HalfGoblin/Chieftain)
+- `knight.py` (Knight/DragonSlayer)
+- `mercenary.py` (Mercenary/Commander)
+- `minstrel.py` (Minstrel/Bard)
+- `occultist.py` (Occultist/Necromancer)
+- `spellsword.py` (Spellsword/Battlemage)
+
+Each uses `replace(Default.party.X, ...)` and/or `struct.Party(X=struct.Dungeon(...))`
+patterns that must become dict literals / dict spreads.
 
 ## Risk Assessment
 
-- **Low risk:** Each step is independently testable.  The enum `.value`
-  property means all `getattr`/`replace` patterns work with a mechanical
-  `.value` suffix addition.
-- **Medium risk:** The `Command` type signature change (Step 7) touches
-  every action function.  Doing it last means the intermediate steps carry
-  a mixed `str`/`enum` signature, but this is manageable and each step's
-  tests confirm correctness.
-- **Boundary clarity:** The shell is the only place where raw user strings
-  enter the system.  Converting there means the entire engine interior
-  speaks enums, which is the ideal end state.
+- **Low risk:** `Artifacts` → `ArtifactCounts` (Step 2) is purely mechanical
+  — one role, one type, every field is `int`.
+- **Medium risk:** `Dungeon`/`Party` state migrations (Steps 3–4) touch many
+  files but each `getattr`→`[]` change is mechanical.
+- **Higher risk:** Dispatch table migration (Step 5) changes how hero files
+  build their action tables.  The `replace(Default.party.fighter, dragon=...)`
+  pattern becomes `{**Default.party[PartyDie.FIGHTER], DungeonFace.DRAGON: ...}`.
+  This is more verbose but precisely typed.  Must test all 8 hero variants.
+- **Medium risk:** `Command` signature (Step 7) touches every action function.
+  Doing it late means intermediate steps have a mixed `str`/`enum` period.
+- **`brief()` breakage:** If not handled in Step 1, `brief(world)` will
+  produce ugly `str(dict)` output for dungeon/party sub-objects.  Must be
+  addressed early (Step 1 or 2).
+- **Frozen semantics:** Moving to plain `dict` loses the frozen guarantee.
+  Mitigated by `World` being a frozen dataclass and the existing code already
+  following an immutable-update pattern.
+- **Boundary clarity:** The shell is the only place raw user strings enter.
+  Converting there (Step 8) means the engine interior speaks enums throughout.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,660 +1,191 @@
-# Plan: Replace Literal Strings with Enums and Overloaded Dataclasses with Typed Dicts
+# Plan: Strings → Enums, Overloaded Dataclasses → Typed Frozen Mappings
 
-## Problem Statement
+## Problem
 
-Throughout the codebase, a small number of literal string values—representing
-party members, dungeon faces, artifacts, and special commands—are passed as
-plain `str` from the shell layer all the way into the game engine.
+Literal strings (`"fighter"`, `"goblin"`, `"sword"`, …) flow from the shell
+into the engine with no static checking.  Three dataclasses (`Dungeon`,
+`Party`, `Artifacts`) serve as map-like containers with imprecise unions
+(`Party` fields are `Union[int, Command, str, None]` to cover three unrelated
+roles).
 
-Compounding this, three dataclasses (`Dungeon`, `Party`, `Artifacts`) are each
-used as map-like containers but with imprecise type annotations.  `Party` is
-the worst offender: its field type is `Union[int, Command, str, None]` because
-the same dataclass serves three completely different roles.  `Dungeon` has
-`Union[int, Command]` for the same reason (two roles).  These unions make
-static analysis nearly useless and hide semantic errors.
-
-## Proposed Enums
-
-### `Dungeon` enum — the six dungeon die faces
+## Enums
 
 ```python
-class Dungeon(enum.Enum):
-    GOBLIN = "goblin"
-    SKELETON = "skeleton"
-    OOZE = "ooze"
-    CHEST = "chest"
-    POTION = "potion"
-    DRAGON = "dragon"
-```
+class Dungeon(enum.Enum):                    # replaces Dungeon dataclass name
+    GOBLIN = "goblin";  SKELETON = "skeleton";  OOZE = "ooze"
+    CHEST = "chest";    POTION = "potion";      DRAGON = "dragon"
 
-### `Party` enum — the six party die faces
+class Party(enum.Enum):                      # replaces Party dataclass name
+    FIGHTER = "fighter"; CLERIC = "cleric"; MAGE = "mage"
+    THIEF = "thief";     CHAMPION = "champion"; SCROLL = "scroll"
 
-```python
-class Party(enum.Enum):
-    FIGHTER = "fighter"
-    CLERIC = "cleric"
-    MAGE = "mage"
-    THIEF = "thief"
-    CHAMPION = "champion"
-    SCROLL = "scroll"
-```
-
-### `Artifact` — the ten treasure/artifact types
-
-```python
 class Artifact(enum.Enum):
-    SWORD = "sword"
-    TALISMAN = "talisman"
-    SCEPTRE = "sceptre"
-    TOOLS = "tools"
-    SCROLL = "scroll"
-    ELIXIR = "elixir"
-    BAIT = "bait"
-    PORTAL = "portal"
-    RING = "ring"
-    SCALE = "scale"
-```
+    SWORD = "sword";   TALISMAN = "talisman"; SCEPTRE = "sceptre"
+    TOOLS = "tools";   SCROLL = "scroll";     ELIXIR = "elixir"
+    BAIT = "bait";     PORTAL = "portal";     RING = "ring";  SCALE = "scale"
 
-### `Action` — the special command verbs that aren't heroes
-
-```python
 class Action(enum.Enum):
-    ABILITY = "ability"
-    BAIT = "bait"
-    ELIXIR = "elixir"
-    REROLL = "reroll"
+    ABILITY = "ability"; BAIT = "bait"; ELIXIR = "elixir"; REROLL = "reroll"
 ```
 
-## Dataclass → Dict Type Replacement Table
-
-The key observation is that `Party`, `Dungeon`, and `Artifacts` are each used
-as map-like containers.  Today they share a single dataclass definition despite
-serving fundamentally different roles with different value types.  With enums as
-keys, each role becomes a distinct, precisely-typed dict:
-
-| Current Type | Role / Context | Current Field Annotation | New Type Alias | Used In |
-|---|---|---|---|---|
-| `Dungeon` | Die counts on a dungeon level | `Union[int, Command]` (only `int` at runtime) | `DungeonState = dict[Dungeon, int]` | `World.dungeon`, `dice.roll_dungeon()`, `dungeon.py` functions |
-| `Dungeon` | Per-hero dispatch: what action does this hero take against each dungeon face? | `Union[int, Command]` (only `Command` at runtime) | `HeroActions = dict[Dungeon, Command]` | Nested inside `Player.party` values (e.g. `Default.party[Party.FIGHTER]`) |
-| `Party` | Die counts of heroes in the current party | `Union[int, Command, str, None]` (only `int` at runtime) | `PartyState = dict[Party, int]` | `World.party`, `Regroup.discard`, `dice.roll_party()`, `party.py` functions |
-| `Party` | Full dispatch table: for each hero, what does it do to each dungeon face? | `Union[int, Command, str, None]` (only `HeroActions`/`Dungeon` at runtime) | `PartyActions = dict[Party, HeroActions]` | `Player.party` — the two-level dispatch table |
-| `Party` | Which artifact corresponds to each hero? | `Union[int, Command, str, None]` (only `Optional[str]` at runtime) | `ArtifactMapping = dict[Party, Optional[Artifact]]` | `Player.artifacts` |
-| `Artifacts` | Counts of each treasure type (in hand or in box) | `int` | `ArtifactCounts = dict[Artifact, int]` | `Treasure.own`, `Treasure.box`, `world.py` scoring |
-
-### What the type aliases look like in `struct.py`
-
-Runtime containers use `types.MappingProxyType` to preserve the frozen
-semantics of the dataclasses they replace.  Type annotations use
-`Mapping[K, V]` from `collections.abc` (read-only interface).
+## Type Aliases (annotations use `Mapping`; runtime is `MappingProxyType`)
 
 ```python
 from collections.abc import Mapping
 from types import MappingProxyType
 
-# State containers (runtime values are always int)
-DungeonState   = Mapping[Dungeon, int]
-PartyState     = Mapping[Party, int]
-ArtifactCounts = Mapping[Artifact, int]
-
-# Dispatch containers (runtime values are always Command)
-HeroActions    = Mapping[Dungeon, Command]
-PartyActions   = Mapping[Party, HeroActions]
-
-# Mapping container
-ArtifactMapping = Mapping[Party, Optional[Artifact]]
-```
-
-Annotations say `Mapping` (read-only contract); factories return
-`MappingProxyType` (enforced at runtime).  A thin `frozen()` helper
-wraps construction:
-
-```python
 def frozen(d: dict) -> MappingProxyType:
-    """Wrap a dict as an immutable MappingProxyType."""
     return MappingProxyType(d)
+
+DungeonState    = Mapping[Dungeon, int]                 # was Dungeon dataclass (int fields)
+PartyState      = Mapping[Party, int]                   # was Party dataclass (int fields)
+ArtifactCounts  = Mapping[Artifact, int]                # was Artifacts dataclass
+HeroActions     = Mapping[Dungeon, Command]             # was Dungeon dataclass (Command fields)
+PartyActions    = Mapping[Party, HeroActions]            # was Party dataclass (Dungeon-of-Command fields)
+ArtifactMapping = Mapping[Party, Optional[Artifact]]    # was Party dataclass (str|None fields)
+
+Command = Callable[[World, RandRange, Party, tuple[Dungeon | Party, ...]], World]
+RollDungeon = Callable[[int, RandRange], DungeonState]
+RollParty   = Callable[[int, RandRange], tuple[PartyState, Regroup]]
 ```
 
-### Updated `Player`, `World`, `Treasure`, `Regroup`
+`frozen=True` on surviving dataclasses prevents field reassignment;
+`MappingProxyType` prevents mutation of mapping contents — together matching
+the old frozen-dataclass depth of immutability.
 
-Note: `frozen=True` on the dataclasses prevents reassignment of the fields
-themselves (e.g. `world.party = ...` raises `FrozenInstanceError`).
-`MappingProxyType` on the mapping values prevents mutation of the
-containers (e.g. `world.party[Party.FIGHTER] = 99` raises `TypeError`).
-Together they provide the same depth of immutability as the old frozen
-dataclasses.
+## Dataclass Replacement Table
+
+| Old Type | Role | Old Field Type | New Alias | Primary Sites |
+|---|---|---|---|---|
+| `Dungeon` dc | die counts | `Union[int,Command]` → `int` | `DungeonState` | `World.dungeon`, `dungeon.py`, `dice.py` |
+| `Dungeon` dc | hero dispatch | `Union[int,Command]` → `Command` | `HeroActions` | nested in `Player.party` values |
+| `Party` dc | die counts | `Union[int,Command,str,None]` → `int` | `PartyState` | `World.party`, `Regroup.discard`, `party.py` |
+| `Party` dc | full dispatch | → `HeroActions` | `PartyActions` | `Player.party` |
+| `Party` dc | artifact map | → `Optional[str]` | `ArtifactMapping` | `Player.artifacts` |
+| `Artifacts` dc | treasure counts | `int` | `ArtifactCounts` | `Treasure.own`, `Treasure.box` |
+
+## Access Pattern Migration
+
+| Before | After |
+|---|---|
+| `getattr(dungeon, target)` | `dungeon[target]` |
+| `replace(dungeon, **{target: v})` | `frozen({**dungeon, target: v})` |
+| `field_items(dungeon)` / `field_values(d)` | `dungeon.items()` / `d.values()` |
+| `len(fields(Dungeon))` | `len(Dungeon)` |
+| `_check_dungeon_target(t)` | _(deleted — enum type enforces)_ |
+| `dungeon.goblin` | `dungeon[Dungeon.GOBLIN]` |
+| `Dungeon(*_roll(...))` | `frozen(dict(zip(Dungeon, _roll(...))))` |
+| `struct.Dungeon()` | `empty_dungeon()` |
+| `replace(Default.party.fighter, dragon=fn)` | `frozen({**Default.party[Party.FIGHTER], Dungeon.DRAGON: fn})` |
+| `Default.party.cleric.skeleton` | `Default.party[Party.CLERIC][Dungeon.SKELETON]` |
+| `hasattr(treasure.own, item)` | `item in treasure.own` |
+
+## Updated Surviving Dataclasses
 
 ```python
 @dataclass(frozen=True)
 class Treasure:
-    own: ArtifactCounts    # was Artifacts; runtime: MappingProxyType
-    box: ArtifactCounts    # was Artifacts; runtime: MappingProxyType
+    own: ArtifactCounts;  box: ArtifactCounts
 
 @dataclass(frozen=True)
 class Regroup:
-    discard: PartyState    # was Party; runtime: MappingProxyType
+    discard: PartyState
 
 @dataclass(frozen=True)
 class World:
-    delve: int = 0
-    depth: int = 0
-    experience: int = 0
-    dungeon: Optional[DungeonState] = None   # runtime: MappingProxyType | None
-    party: PartyState = ...                   # runtime: MappingProxyType
-    ability: bool = False
-    regroup: Regroup = ...
-    treasure: Treasure = ...
+    delve: int = 0;  depth: int = 0;  experience: int = 0
+    dungeon: Optional[DungeonState] = None;  party: PartyState = ...
+    ability: bool = False;  regroup: Regroup = ...;  treasure: Treasure = ...
 
 @dataclass(frozen=True)
 class Player:
-    name: str
-    ability: Command
-    advance: Advance
-    bait: Command
-    elixir: Command
-    roll: Roll
-    artifacts: ArtifactMapping    # runtime: MappingProxyType
-    party: PartyActions           # runtime: MappingProxyType of MappingProxyType
+    name: str;  ability: Command;  advance: Advance
+    bait: Command;  elixir: Command;  roll: Roll
+    artifacts: ArtifactMapping;  party: PartyActions
 ```
 
-### Updated `Command` Signature
+## `brief()` Update
 
 ```python
-# Before
-Command = Callable[[World, RandRange, str, tuple[str, ...]], World]
-
-# After
-Command = Callable[[World, RandRange, Party, tuple[Dungeon | Party, ...]], World]
-```
-
-The `str` that was `hero` becomes `Party`.  The `tuple[str, ...]` that was
-`targets` becomes `tuple[Dungeon | Party, ...]` (targets can be
-dungeon faces to attack, or party die names for reroll/quaff).
-
-## What Changes in the Access Patterns
-
-### `getattr`/`replace` → dict `[]`/`{**d, k: v}`
-
-Every `getattr(obj, name)` / `replace(obj, **{name: val})` on these six types
-becomes a plain dict lookup / dict spread:
-
-```python
-# Before (dungeon.py)
-def decrement_dungeon(dungeon: Dungeon, target: str) -> Dungeon:
-    _check_dungeon_target(target)
-    prior = getattr(dungeon, target)
-    return replace(dungeon, **{target: prior - 1})
-
-# After
-def decrement_dungeon(dungeon: DungeonState, target: Dungeon) -> DungeonState:
-    prior = dungeon[target]
-    if not prior:
-        raise DrollError(f"At least 1 {target.value} required in dungeon.")
-    return frozen({**dungeon, target: prior - 1})
-```
-
-```python
-# Before (party.py)
-def increment_party(party: Party, hero: str) -> Party:
-    _check_party_member(hero)
-    return replace(party, **{hero: getattr(party, hero) + 1})
-
-# After
-def increment_party(party: PartyState, hero: Party) -> PartyState:
-    return frozen({**party, hero: party[hero] + 1})
-```
-
-### `field_names`/`field_values`/`field_items` → dict methods
-
-```python
-# Before
-for name, count in field_items(dungeon): ...
-sum(field_values(dungeon))
-
-# After
-for face, count in dungeon.items(): ...
-sum(dungeon.values())
-```
-
-### `_check_*` validation functions → deleted
-
-`_check_dungeon_target`, `_check_party_member`, `_DUNGEON_FIELDS`,
-`_PARTY_FIELDS` all become unnecessary — the enum type enforces membership.
-
-### Hero definitions use dict literals instead of `replace()`
-
-```python
-# Before (knight.py)
-DragonSlayer = replace(Default, ...,
-    party=struct.Party(
-        fighter=replace(Default.party.fighter, dragon=_dragonslayer_defeat_dragon),
-        ...
-    ))
-
-# After
-DragonSlayer = replace(Default, ...,
-    party=frozen({
-        Party.FIGHTER: frozen({**Default.party[Party.FIGHTER],
-                                  Dungeon.DRAGON: _dragonslayer_defeat_dragon}),
-        ...
-    }))
-```
-
-### `Dungeon()` as empty → factory helper
-
-```python
-# Before
-struct.Dungeon()  # all zeros
-
-# After
-empty_dungeon()   # returns frozen({face: 0 for face in Dungeon})
-```
-
-### Constructor patterns with `*list` unpacking
-
-```python
-# Before (dice.py)
-Dungeon(*_roll(dice, 0, 6, randrange))
-
-# After
-frozen(dict(zip(Dungeon, _roll(dice, 0, 6, randrange))))
-```
-
-## Detailed Per-File Impact
-
-### `struct.py`
-- Add `from types import MappingProxyType` and `from collections.abc import Mapping`
-- Add `frozen()` helper wrapping `MappingProxyType`
-- Add four enums and six type aliases (using `Mapping[K, V]`)
-- Remove the old `Dungeon`, `Party`, `Artifacts` dataclasses (their names
-  are now reused by the `Dungeon`, `Party`, `Artifact` enums)
-- Add factory helpers: `empty_dungeon() -> DungeonState`,
-  `empty_party() -> PartyState`, `empty_artifacts() -> ArtifactCounts`
-  (each returns `frozen({...})`)
-- Update `Treasure` fields: `own: ArtifactCounts`, `box: ArtifactCounts`
-- Update `Regroup.discard: PartyState`
-- Update `World.dungeon: Optional[DungeonState]`, `World.party: PartyState`
-- Update `Player.artifacts: ArtifactMapping`, `Player.party: PartyActions`
-- Update `Command` signature
-- Replace `field_names`/`field_values`/`field_items` usages on the removed
-  types with dict `.keys()`/`.values()`/`.items()` (callers migrate too)
-- Keep `brief()` working via duck typing on dict `.items()`
-
-### `dungeon.py`
-- Param `target: str` → `target: Dungeon` in all functions
-- Return `Dungeon` → `DungeonState` (i.e. `dict[Dungeon, int]`)
-- Delete `_DUNGEON_FIELDS`, `_check_dungeon_target`
-- `getattr(dungeon, target)` → `dungeon[target]`
-- `replace(dungeon, **{target: v})` → `frozen({**dungeon, target: v})`
-- Direct access `dungeon.goblin` → `dungeon[Dungeon.GOBLIN]`
-- `field_values(dungeon)` → `dungeon.values()`
-
-### `party.py`
-- Param `hero: str` → `hero: Party` in all functions
-- Return `Party` → `PartyState`
-- Delete `_PARTY_FIELDS`, `_check_party_member`
-- Same `getattr`→`[]` and `replace`→`frozen({**d})` migration as `dungeon.py`
-
-### `treasure.py`
-- `_draw` returns `Artifact` instead of `str`
-- `replace_treasure` param `item: str` → `item: Artifact`
-- `field_items(box)` → `box.items()`
-- `field_values(box)` → `box.values()`
-- `getattr(treasure.own, drawn)` → `treasure.own[drawn]`
-- `replace(treasure.own, **{drawn: v})` → `frozen({**treasure.own, drawn: v})`
-  (but `Treasure` itself stays a dataclass, so its `replace` stays)
-
-### `regular.py`
-- All `Command`-signature functions: `hero: str` → `hero: Party`,
-  `targets: tuple[str, ...]` → `tuple[Dungeon | Party, ...]`
-- `_DUNGEON_NAMES`, `_PARTY_NAMES` frozensets → deleted (use `isinstance`
-  checks or enum type)
-- `_classify_reroll_targets`: check `isinstance(t, Dungeon)` vs
-  `isinstance(t, Party)`
-- `bait_dragon`: `_enemies` becomes `tuple[Dungeon, ...]`
-- `defeat_dragon_heroes`: `disallowed_heroes` becomes `frozenset[Party]`
-- `elixir`: `targets[0]` is already `Party`
-- String literals like `"potion"` → `Dungeon.POTION`, `"scroll"` →
-  `Party.SCROLL`, etc.
-
-### `special.py`
-- Same `Command` signature updates as `regular.py`
-- `convert_dungeon_to_party`: `source: str` → `source: Dungeon`,
-  `destination: str` → `destination: Party`
-- `getattr(world.dungeon, source)` → `world.dungeon[source]`
-
-### `ability.py`
-- All ability functions: `command: str` → `command: Action`,
-  `targets: tuple[str, ...]` → typed tuple
-- `_choose_and_add_hero`: `acceptable: frozenset[str]` →
-  `frozenset[Party]`
-- `_convert_one`/`_convert_two`: `source: str` → `Dungeon`,
-  `destination: str` → `Party`
-- Literal strings like `increment_dungeon(dungeon, "potion")` →
-  `increment_dungeon(dungeon, Dungeon.POTION)`
-- `increment_party(world.party, "scroll")` →
-  `increment_party(world.party, Party.SCROLL)`
-
-### `player.py`
-- `Default.artifacts` becomes `ArtifactMapping`:
-  `{Party.FIGHTER: Artifact.SWORD, ..., Party.CHAMPION: None, ...}`
-- `Default.party` becomes `PartyActions`:
-  `{Party.FIGHTER: {Dungeon.GOBLIN: defeat_all, ...}, ...}`
-- `apply()`: `command: str` becomes a union or is pre-parsed into the
-  appropriate enum type by the caller; dispatch uses enum comparisons
-- `_partify_command`: `Artifact` → `Party` reverse lookup
-- `_ARTIFACT_COMMANDS`: `frozenset[Artifact]`
-- `_TREASURE_NO_COMMAND`: `frozenset[Artifact]`
-- `complete()`: returns `Sequence[str]` (for the shell), but internally
-  works with enum `.value` strings
-- `_available_nouns`/`_available_targets`: iterate `.items()` on dicts
-  instead of `field_items()`
-- `_adjust_phantom_treasures`: iterates `artifacts.items()` instead of
-  `field_items(artifacts)`
-
-### `world.py`
-- `new_world()`: `Artifacts(sword=3, ...)` →
-  `{Artifact.SWORD: 3, ...}`
-- `_regroup()`: `Party(**{name: max(...)})` →
-  `{die: max(0, world.party[die] - world.regroup.discard[die]) for die in Party}`
-- `descend()`: `replace(rolled, dragon=...)` → `{**rolled, Dungeon.DRAGON: ...}`
-- `_apply_ring`/`_apply_portal`: `noun: str = "ring"` →
-  `noun: Artifact = Artifact.RING`
-- `score()`: `field_values(world.treasure.own)` → `world.treasure.own.values()`
-- `world.treasure.own.portal` → `world.treasure.own[Artifact.PORTAL]`
-- `world.treasure.own.scale` → `world.treasure.own[Artifact.SCALE]`
-
-### `display.py`
-- `_format_items`: `field_items(counts)` → `counts.items()`
-- `_format_treasure`: `field_items(artifacts)` → `artifacts.items()`
-- `field_values(party)` → `party.values()`
-- Item names in output use `face.value` / `die.value` for display strings
-- `_ALWAYS_COUNT = frozenset({Dungeon.DRAGON})`
-
-### `dice.py`
-- `roll_dungeon` returns `DungeonState` instead of `Dungeon`
-- `roll_party` returns `PartyState` instead of `Party`
-- `Dungeon(*_roll(...))` → `dict(zip(Dungeon, _roll(...)))`
-- `Party(*_roll(...))` → `dict(zip(Party, _roll(...)))`
-- `len(fields(Dungeon))` → `len(Dungeon)` (enum length)
-- `len(fields(Party))` → `len(Party)`
-
-### `game.py`
-- `Game.ability()`: passes `Action.ABILITY` instead of `"ability"`
-- `Game.reroll()`: passes `Action.REROLL` instead of `"reroll"`
-- `Game.apply()`: tokenized strings arrive from shell; parsing happens
-  in `player.apply()` or the caller converts first
-- `_possible_world_actions()`: `"ability"` → `Action.ABILITY` etc.
-- `score_deltas()`: no enum changes (returns `dict[str, int]` for display)
-
-### `shell.py`
-- `_tokenize` stays string-based (it's the raw user input boundary)
-- `do_ability`, `default`, `do_reroll` pass raw strings into `Game`
-  methods, which forward to `player.apply()` where conversion happens
-- Alternatively: conversion at the shell boundary via a `_parse_token`
-  function
-- Tab completion operates on `.value` strings throughout
-- `_AVAILABLE_COMMANDS` stays as `frozenset[str]` (UI concern)
-
-### Hero files (`droll/heroes/*.py`)
-- All `struct.Party(fighter=struct.Dungeon(...), ...)` constructions →
-  `{Party.FIGHTER: {Dungeon.GOBLIN: defeat_all, ...}, ...}`
-- `replace(Default.party.fighter, dragon=...)` →
-  `frozen({**Default.party[Party.FIGHTER], Dungeon.DRAGON: ...})`
-- `replace(Default.party, fighter=..., cleric=...)` →
-  `frozen({**Default.party, Party.FIGHTER: ..., Party.CLERIC: ...})`
-- `Default.party.cleric.skeleton` → `Default.party[Party.CLERIC][Dungeon.SKELETON]`
-- `frozenset({"fighter", "cleric"})` → `frozenset({Party.FIGHTER, Party.CLERIC})`
-
-### Test files
-- Every `struct.Dungeon(goblin=1, ...)` → `{Dungeon.GOBLIN: 1, ...}`
-  (or use `{**empty_dungeon(), Dungeon.GOBLIN: 1}`)
-- Every `struct.Party(fighter=2, ...)` → same pattern with `Party`
-- Every `struct.Artifacts(sword=1, ...)` → same pattern with `Artifact`
-- Direct field access `game.dungeon.goblin` → `game.dungeon[Dungeon.GOBLIN]`
-- Direct field access `game.party.fighter` → `game.party[Party.FIGHTER]`
-
-## Implementation Steps
-
-### Step 1: Define enums and type aliases in `struct.py`
-
-Add `Dungeon`, `Party`, `Artifact`, `Action` plus all six
-type aliases.  Add `empty_dungeon()`, `empty_party()`, `empty_artifacts()`
-factory helpers.  Keep the old dataclasses temporarily.  Tests still pass.
-
-### Step 2: Migrate `Artifacts` → `ArtifactCounts`
-
-This is the simplest migration — `Artifacts` has only one role (`int` fields).
-- Replace `Artifacts` dataclass with `ArtifactCounts = dict[Artifact, int]`
-- Update `Treasure.own` and `Treasure.box` field types
-- Update `treasure.py`: `field_items` → `.items()`, `getattr` → `[]`,
-  `replace(own, **{k: v})` → `{**own, k: v}`
-- Update `world.py`: `new_world()` construction, `score()` access
-- Update `display.py`: `_format_treasure`
-- Update `player.py`: `_ARTIFACT_COMMANDS`, `_TREASURE_NO_COMMAND`,
-  `_available_nouns` treasure iteration
-- Update tests
-- Run tests
-
-### Step 3: Migrate `Dungeon` state → `DungeonState`
-
-Replace the `Dungeon` dataclass's state role (counting die faces) with
-`DungeonState = dict[Dungeon, int]`.
-- Update `dungeon.py`: all functions take/return `DungeonState`, delete
-  `_check_dungeon_target` and `_DUNGEON_FIELDS`
-- Update `World.dungeon: Optional[DungeonState]`
-- Update `dice.py`: `roll_dungeon` returns `DungeonState`
-- Update `regular.py`, `special.py`, `ability.py`: all dungeon state access
-- Update `world.py`: `descend()`, `_regroup()`, `new_world()`
-- Update tests
-- Run tests
-
-### Step 4: Migrate `Party` state → `PartyState`
-
-Replace the `Party` dataclass's counting role with
-`PartyState = dict[Party, int]`.
-- Update `party.py`: all functions take/return `PartyState`, delete
-  `_check_party_member` and `_PARTY_FIELDS`
-- Update `World.party: PartyState`, `Regroup.discard: PartyState`
-- Update `dice.py`: `roll_party` returns `PartyState`
-- Update `regular.py`, `special.py`, `ability.py`: all party state access
-- Update `player.py`: `_adjust_phantom_treasures`, `apply()` party iteration
-- Update `world.py`: `_regroup()`
-- Update tests
-- Run tests
-
-### Step 5: Migrate `Dungeon` dispatch → `HeroActions`, and `Party` dispatch → `PartyActions`
-
-These two are tightly coupled (a `PartyActions` is a dict of `HeroActions`).
-- Define `HeroActions = dict[Dungeon, Command]`
-- Define `PartyActions = dict[Party, HeroActions]`
-- Remove the old `Dungeon` and `Party` dataclasses entirely (names now belong to enums)
-- Update `Player.party: PartyActions`
-- Update `player.py:apply()`: `getattr(player.party, command)` →
-  `player.party[command]`, `getattr(action_, targets[0])` →
-  `action_[targets[0]]`
-- Update all hero files: `struct.Party(fighter=struct.Dungeon(...), ...)` →
-  dict literals; `replace(Default.party.fighter, ...)` → dict spread
-- Update tests
-- Run tests
-
-### Step 6: Migrate `Party` artifact mapping → `ArtifactMapping`
-
-- Define `ArtifactMapping = dict[Party, Optional[Artifact]]`
-- Update `Player.artifacts: ArtifactMapping`
-- Update `player.py`: `Default.artifacts` construction,
-  `_partify_command`, `_adjust_phantom_treasures`, `_ARTIFACT_COMMANDS`
-- Update tests
-- Run tests
-
-### Step 7: Update `Command` signature and action functions
-
-- Update `Command = Callable[[World, RandRange, Party, tuple[...]], World]`
-- Update every function that matches the `Command` signature (`defeat_one`,
-  `defeat_all`, `open_one`, `open_all`, `quaff`, `reroll`, `defeat_dragon`,
-  `bait_dragon`, `elixir`, all ability functions, all special functions)
-- Update `player.py:apply()` to pass typed values
-- Update tests
-- Run tests
-
-### Step 8: Port `game.py`, `shell.py`, and the boundary layer
-
-- `game.py`: pass `Action.ABILITY` / `Action.REROLL` instead of
-  string literals
-- `shell.py`: add `_parse_token` to convert user input strings → enum at
-  the boundary; or let `player.apply` handle the conversion
-- Tab completion returns `.value` strings
-- Update tests
-- Run tests
-
-### Step 9: Clean up
-
-- Remove any remaining `field_names`/`field_values`/`field_items` usage
-  that operated on the now-deleted dataclasses
-- Remove helper functions in `struct.py` if no longer needed
-- Verify `brief()` works on the remaining dataclasses (`World`, `Treasure`,
-  `Regroup`, `Player`, `Roll`)
-- Run full test suite
-- Verify shell interaction and tab completion unchanged
-
-## Cross-Cutting Concerns
-
-### `brief()` must handle both dicts and surviving dataclasses
-
-`brief()` in `struct.py` recursively formats nested structures using
-`field_names()` / `field_values()`, which call `dataclasses.fields()`.
-After migration, `World.dungeon` will be a `dict` (or `None`), and
-`World.party` will be a `dict`.  When `brief()` recurses into these, it
-must detect dicts and use `.items()` instead of `fields()`.
-
-```python
-from collections.abc import Mapping
-
 def brief(o: Any) -> str:
-    if isinstance(o, Mapping):
-        keyvalues = [f"{k.value if hasattr(k, 'value') else k}={brief(v)}"
-                     for k, v in o.items() if v]
-        return f"({', '.join(keyvalues)})"
+    if isinstance(o, Mapping):                             # catches MappingProxyType
+        kv = [f"{k.value}={brief(v)}" for k, v in o.items() if v]
+        return f"({', '.join(kv)})"
     try:
-        names = field_names(o)
-        values = field_values(o)
+        names, values = field_names(o), field_values(o)
     except TypeError:
         return str(o)
-    keyvalues = [f"{f}={brief(v)}" for f, v in zip(names, values) if v]
-    return f"({', '.join(keyvalues)})"
+    return f"({', '.join(f'{f}={brief(v)}' for f, v in zip(names, values) if v)})"
 ```
 
-Note: `isinstance(o, Mapping)` catches both plain `dict` and
-`MappingProxyType`, since `MappingProxyType` implements `Mapping`.
+## Per-File Impact
 
-### `field_names` / `field_values` / `field_items` helpers survive but shrink in scope
+- **`struct.py`** — add enums, type aliases, `frozen()`, `empty_*()` factories;
+  remove `Dungeon`/`Party`/`Artifacts` dataclasses; update `Command`,
+  `RollDungeon`, `RollParty`, `Treasure`, `Regroup`, `World`, `Player`; update `brief()`
+- **`dungeon.py`** — `target: str` → `Dungeon`; return `DungeonState`;
+  delete `_check_dungeon_target`/`_DUNGEON_FIELDS`; `getattr`→`[]`, `replace`→`frozen({**d})`
+- **`party.py`** — `hero: str` → `Party`; return `PartyState`;
+  delete `_check_party_member`/`_PARTY_FIELDS`; same accessor migration
+- **`treasure.py`** — `_draw` returns `Artifact`; `replace_treasure` takes `Artifact`;
+  `field_items`→`.items()`, `hasattr`→`in`, `getattr`→`[]`
+- **`regular.py`** — `hero: str`→`Party`, `targets: tuple[str,...]`→`tuple[Dungeon|Party,...]`;
+  delete `_DUNGEON_NAMES`/`_PARTY_NAMES`; `_classify_reroll_targets` uses `isinstance`;
+  `"potion"`→`Dungeon.POTION`, `"scroll"`→`Party.SCROLL`, etc.
+- **`special.py`** — `source: str`→`Dungeon`, `destination: str`→`Party`;
+  `getattr`→`[]`
+- **`ability.py`** — `command: str`→`Action`; `acceptable: frozenset[str]`→`frozenset[Party]`;
+  `"potion"`→`Dungeon.POTION`, `"scroll"`→`Party.SCROLL`
+- **`player.py`** — `Default.artifacts`/`Default.party` become dict literals;
+  `apply()` dispatches on enums; `_partify_command`: `Artifact`→`Party` lookup;
+  `_ARTIFACT_COMMANDS`/`_TREASURE_NO_COMMAND`: `frozenset[Artifact]`;
+  `complete()` returns `.value` strings
+- **`world.py`** — `Artifacts(sword=3,...)`→`frozen({Artifact.SWORD: 3,...})`;
+  `.portal`→`[Artifact.PORTAL]`; `_apply_ring`/`_apply_portal` take `Artifact`;
+  `field_values`→`.values()`
+- **`display.py`** — `field_items`→`.items()`, `field_values`→`.values()`;
+  names via `.value`; `_ALWAYS_COUNT = frozenset({Dungeon.DRAGON})`
+- **`dice.py`** — returns `DungeonState`/`PartyState`;
+  `frozen(dict(zip(Dungeon, _roll(...))))`;
+  `len(fields(X))`→`len(X)`
+- **`game.py`** — `"ability"`→`Action.ABILITY`, `"reroll"`→`Action.REROLL`
+- **`shell.py`** — `_tokenize` stays string-based; add `_parse_token` str→enum
+  at the boundary; tab completion uses `.value`
+- **`heroes/*.py`** (all 8) — `struct.Party(fighter=struct.Dungeon(...),...)`→
+  `frozen({Party.FIGHTER: frozen({Dungeon.GOBLIN: defeat_all,...}),...})`;
+  `replace(Default.party.X, Y=fn)`→`frozen({**Default.party[X], Y: fn})`;
+  `frozenset({"fighter","cleric"})`→`frozenset({Party.FIGHTER, Party.CLERIC})`
+- **Tests** — `struct.Dungeon(goblin=1)`→`{**empty_dungeon(), Dungeon.GOBLIN: 1}`;
+  `.goblin`→`[Dungeon.GOBLIN]`; same for `Party`/`Artifacts`
 
-These helpers remain useful for the surviving dataclasses (`World`,
-`Treasure`, `Regroup`, `Player`, `Roll`).  But they are no longer called
-on `Dungeon`, `Party`, or `Artifacts` — those callers migrate to dict
-`.keys()` / `.values()` / `.items()`.  The helpers themselves don't change;
-only their call sites do.
+## `field_names`/`field_values`/`field_items`
 
-Callers that used them on the removed types:
+Survive for remaining dataclasses (`World`, `Treasure`, `Regroup`, `Player`,
+`Roll`).  All calls on removed types migrate to `.keys()`/`.values()`/`.items()`.
 
-| Caller | Was | Becomes |
-|---|---|---|
-| `dice.py`: `len(fields(Dungeon))` | dataclass field count | `len(Dungeon)` |
-| `dice.py`: `len(fields(Party))` | dataclass field count | `len(Party)` |
-| `dungeon.py`: `field_names(Dungeon)` | frozenset of names | deleted (enum membership) |
-| `dungeon.py`: `field_values(dungeon)` | sum of values | `dungeon.values()` |
-| `party.py`: `field_names(Party)` | frozenset of names | deleted (enum membership) |
-| `regular.py`: `field_names(Dungeon)` / `field_names(Party)` | frozensets | deleted |
-| `regular.py`: `field_values(dungeon)` / `field_values(party)` | for map/add | `.values()` |
-| `treasure.py`: `field_items(box)` / `field_values(box)` | iteration | `.items()` / `.values()` |
-| `player.py`: `field_items(artifacts)` | iteration | `.items()` |
-| `player.py`: `field_items(action_)` | iteration | `.items()` |
-| `player.py`: `field_names(player.party)` | membership check | `in player.party` |
-| `player.py`: `field_names(action_)` | membership check | `in action_` |
-| `player.py`: `field_names(struct.Party)` / `field_names(struct.Dungeon)` | completion | `Party` / `Dungeon` members |
-| `display.py`: `field_items(counts)` / `field_values(party)` | formatting | `.items()` / `.values()` |
-| `world.py`: `field_values(world.treasure.own)` | scoring | `.values()` |
-| `world.py`: `field_items(world.regroup.discard)` | regroup | `.items()` |
-| Tests: `len(fields(struct.Dungeon))` / `len(fields(struct.Party))` | construction | `len(Dungeon)` / `len(Party)` |
+## Steps
 
-### `RollDungeon` and `RollParty` type aliases need updating
+1. **Define enums + aliases** in `struct.py`. Add `frozen()`, `empty_*()`.
+   Keep old dataclasses temporarily. Tests pass.
+2. **`Artifacts` → `ArtifactCounts`** — `treasure.py`, `world.py`, `display.py`,
+   `player.py`, tests.
+3. **`Dungeon` state → `DungeonState`** — `dungeon.py`, `dice.py`, `World.dungeon`,
+   `regular.py`, `special.py`, `ability.py`, `world.py`, tests.
+4. **`Party` state → `PartyState`** — `party.py`, `dice.py`, `World.party`,
+   `Regroup.discard`, `regular.py`, `special.py`, `ability.py`, `player.py`,
+   `world.py`, tests.
+5. **Dispatch → `HeroActions`/`PartyActions`** — remove old `Dungeon`/`Party`
+   dataclasses; update `Player.party`, `player.py:apply()`, all 8 hero files, tests.
+6. **`ArtifactMapping`** — `Player.artifacts`, `player.py`, tests.
+7. **`Command` signature** — all action functions, ability functions, `player.py:apply()`, tests.
+8. **Boundary layer** — `game.py` (enum literals), `shell.py` (`_parse_token`), tests.
+9. **Clean up** — remove stale helpers, verify `brief()`, full test suite, shell smoke test.
 
-```python
-# Before
-RollDungeon = Callable[[int, RandRange], Dungeon]
-RollParty = Callable[[int, RandRange], tuple[Party, Regroup]]
+## Risk
 
-# After
-RollDungeon = Callable[[int, RandRange], DungeonState]
-RollParty = Callable[[int, RandRange], tuple[PartyState, Regroup]]
-```
-
-### `hasattr()` in `treasure.py` → `in` operator
-
-Line 49: `if not hasattr(treasure.own, item):` becomes
-`if item not in treasure.own:` — a natural dict idiom.
-
-### Frozen dict semantics — `MappingProxyType`
-
-`Dungeon` and `Party` are frozen dataclasses today.  To preserve the same
-runtime immutability, all six mapping types use `types.MappingProxyType`
-from the stdlib.  This is a zero-dependency read-only view over a `dict`:
-
-```python
-from types import MappingProxyType
-
-proxy = MappingProxyType({Dungeon.GOBLIN: 2})
-proxy[Dungeon.GOBLIN]          # 2 — reads work
-proxy[Dungeon.GOBLIN] = 99     # TypeError — mutation blocked
-```
-
-The "update" idiom builds a new plain `dict` via spread, then re-wraps:
-
-```python
-frozen({**proxy, Dungeon.GOBLIN: 0})
-# → MappingProxyType({Dungeon.GOBLIN: 0, ...})
-```
-
-This pairs with frozen dataclasses: `World(frozen=True)` prevents field
-reassignment, and `MappingProxyType` prevents mutation of the mapping
-values.  Together they provide the same depth of immutability as the
-original nested frozen dataclasses.
-
-Type annotations use `Mapping[K, V]` (the abstract read-only interface
-from `collections.abc`), so function signatures express the read-only
-contract without mentioning `MappingProxyType` directly.
-
-### All 8 hero files need migration
-
-The plan's Step 5 must cover all hero files:
-- `enchantress.py` (Enchantress/Beguiler)
-- `crusader.py` (Crusader/Paladin)
-- `halfgoblin.py` (HalfGoblin/Chieftain)
-- `knight.py` (Knight/DragonSlayer)
-- `mercenary.py` (Mercenary/Commander)
-- `minstrel.py` (Minstrel/Bard)
-- `occultist.py` (Occultist/Necromancer)
-- `spellsword.py` (Spellsword/Battlemage)
-
-Each uses `replace(Default.party.X, ...)` and/or `struct.Party(X=struct.Dungeon(...))`
-patterns that must become dict literals / dict spreads.
-
-## Risk Assessment
-
-- **Low risk:** `Artifacts` → `ArtifactCounts` (Step 2) is purely mechanical
-  — one role, one type, every field is `int`.
-- **Medium risk:** `Dungeon`/`Party` state migrations (Steps 3–4) touch many
-  files but each `getattr`→`[]` change is mechanical.
-- **Higher risk:** Dispatch table migration (Step 5) changes how hero files
-  build their action tables.  The `replace(Default.party.fighter, dragon=...)`
-  pattern becomes `{**Default.party[Party.FIGHTER], Dungeon.DRAGON: ...}`.
-  This is more verbose but precisely typed.  Must test all 8 hero variants.
-- **Medium risk:** `Command` signature (Step 7) touches every action function.
-  Doing it late means intermediate steps have a mixed `str`/`enum` period.
-- **`brief()` breakage:** If not handled in Step 1, `brief(world)` will
-  produce ugly `str(dict)` output for dungeon/party sub-objects.  Must be
-  addressed early (Step 1 or 2).
-- **Frozen semantics:** `MappingProxyType` preserves the same runtime
-  immutability as frozen dataclasses.  The `frozen()` helper adds one
-  function call per construction, which is negligible.
-- **Boundary clarity:** The shell is the only place raw user strings enter.
-  Converting there (Step 8) means the engine interior speaks enums throughout.
+- **Low:** Step 2 (`Artifacts`) — single role, mechanical.
+- **Medium:** Steps 3–4 (state dicts) — many files, but each change is `getattr`→`[]`.
+- **Higher:** Step 5 (dispatch) — all 8 hero files change construction patterns.
+- **Medium:** Step 7 (`Command` sig) — touches every action function.
+- **`brief()`** — must handle `Mapping` early (Step 1) to avoid ugly output.
+- **Frozen semantics** — `MappingProxyType` preserves immutability; `frozen()` cost negligible.

--- a/PLAN.md
+++ b/PLAN.md
@@ -15,10 +15,10 @@ static analysis nearly useless and hide semantic errors.
 
 ## Proposed Enums
 
-### `DungeonDie` — the six dungeon die faces
+### `Dungeon` enum — the six dungeon die faces
 
 ```python
-class DungeonDie(enum.Enum):
+class Dungeon(enum.Enum):
     GOBLIN = "goblin"
     SKELETON = "skeleton"
     OOZE = "ooze"
@@ -27,10 +27,10 @@ class DungeonDie(enum.Enum):
     DRAGON = "dragon"
 ```
 
-### `PartyDie` — the six party die faces
+### `Party` enum — the six party die faces
 
 ```python
-class PartyDie(enum.Enum):
+class Party(enum.Enum):
     FIGHTER = "fighter"
     CLERIC = "cleric"
     MAGE = "mage"
@@ -74,11 +74,11 @@ keys, each role becomes a distinct, precisely-typed dict:
 
 | Current Type | Role / Context | Current Field Annotation | New Type Alias | Used In |
 |---|---|---|---|---|
-| `Dungeon` | Die counts on a dungeon level | `Union[int, Command]` (only `int` at runtime) | `DungeonState = dict[DungeonDie, int]` | `World.dungeon`, `dice.roll_dungeon()`, `dungeon.py` functions |
-| `Dungeon` | Per-hero dispatch: what action does this hero take against each dungeon face? | `Union[int, Command]` (only `Command` at runtime) | `HeroActions = dict[DungeonDie, Command]` | Nested inside `Player.party` values (e.g. `Default.party[PartyDie.FIGHTER]`) |
-| `Party` | Die counts of heroes in the current party | `Union[int, Command, str, None]` (only `int` at runtime) | `PartyState = dict[PartyDie, int]` | `World.party`, `Regroup.discard`, `dice.roll_party()`, `party.py` functions |
-| `Party` | Full dispatch table: for each hero, what does it do to each dungeon face? | `Union[int, Command, str, None]` (only `HeroActions`/`Dungeon` at runtime) | `PartyActions = dict[PartyDie, HeroActions]` | `Player.party` — the two-level dispatch table |
-| `Party` | Which artifact corresponds to each hero? | `Union[int, Command, str, None]` (only `Optional[str]` at runtime) | `ArtifactMapping = dict[PartyDie, Optional[Artifact]]` | `Player.artifacts` |
+| `Dungeon` | Die counts on a dungeon level | `Union[int, Command]` (only `int` at runtime) | `DungeonState = dict[Dungeon, int]` | `World.dungeon`, `dice.roll_dungeon()`, `dungeon.py` functions |
+| `Dungeon` | Per-hero dispatch: what action does this hero take against each dungeon face? | `Union[int, Command]` (only `Command` at runtime) | `HeroActions = dict[Dungeon, Command]` | Nested inside `Player.party` values (e.g. `Default.party[Party.FIGHTER]`) |
+| `Party` | Die counts of heroes in the current party | `Union[int, Command, str, None]` (only `int` at runtime) | `PartyState = dict[Party, int]` | `World.party`, `Regroup.discard`, `dice.roll_party()`, `party.py` functions |
+| `Party` | Full dispatch table: for each hero, what does it do to each dungeon face? | `Union[int, Command, str, None]` (only `HeroActions`/`Dungeon` at runtime) | `PartyActions = dict[Party, HeroActions]` | `Player.party` — the two-level dispatch table |
+| `Party` | Which artifact corresponds to each hero? | `Union[int, Command, str, None]` (only `Optional[str]` at runtime) | `ArtifactMapping = dict[Party, Optional[Artifact]]` | `Player.artifacts` |
 | `Artifacts` | Counts of each treasure type (in hand or in box) | `int` | `ArtifactCounts = dict[Artifact, int]` | `Treasure.own`, `Treasure.box`, `world.py` scoring |
 
 ### What the type aliases look like in `struct.py`
@@ -92,16 +92,16 @@ from collections.abc import Mapping
 from types import MappingProxyType
 
 # State containers (runtime values are always int)
-DungeonState   = Mapping[DungeonDie, int]
-PartyState     = Mapping[PartyDie, int]
+DungeonState   = Mapping[Dungeon, int]
+PartyState     = Mapping[Party, int]
 ArtifactCounts = Mapping[Artifact, int]
 
 # Dispatch containers (runtime values are always Command)
-HeroActions    = Mapping[DungeonDie, Command]
-PartyActions   = Mapping[PartyDie, HeroActions]
+HeroActions    = Mapping[Dungeon, Command]
+PartyActions   = Mapping[Party, HeroActions]
 
 # Mapping container
-ArtifactMapping = Mapping[PartyDie, Optional[Artifact]]
+ArtifactMapping = Mapping[Party, Optional[Artifact]]
 ```
 
 Annotations say `Mapping` (read-only contract); factories return
@@ -119,7 +119,7 @@ def frozen(d: dict) -> MappingProxyType:
 Note: `frozen=True` on the dataclasses prevents reassignment of the fields
 themselves (e.g. `world.party = ...` raises `FrozenInstanceError`).
 `MappingProxyType` on the mapping values prevents mutation of the
-containers (e.g. `world.party[PartyDie.FIGHTER] = 99` raises `TypeError`).
+containers (e.g. `world.party[Party.FIGHTER] = 99` raises `TypeError`).
 Together they provide the same depth of immutability as the old frozen
 dataclasses.
 
@@ -163,11 +163,11 @@ class Player:
 Command = Callable[[World, RandRange, str, tuple[str, ...]], World]
 
 # After
-Command = Callable[[World, RandRange, PartyDie, tuple[DungeonDie | PartyDie, ...]], World]
+Command = Callable[[World, RandRange, Party, tuple[Dungeon | Party, ...]], World]
 ```
 
-The `str` that was `hero` becomes `PartyDie`.  The `tuple[str, ...]` that was
-`targets` becomes `tuple[DungeonDie | PartyDie, ...]` (targets can be
+The `str` that was `hero` becomes `Party`.  The `tuple[str, ...]` that was
+`targets` becomes `tuple[Dungeon | Party, ...]` (targets can be
 dungeon faces to attack, or party die names for reroll/quaff).
 
 ## What Changes in the Access Patterns
@@ -185,7 +185,7 @@ def decrement_dungeon(dungeon: Dungeon, target: str) -> Dungeon:
     return replace(dungeon, **{target: prior - 1})
 
 # After
-def decrement_dungeon(dungeon: DungeonState, target: DungeonDie) -> DungeonState:
+def decrement_dungeon(dungeon: DungeonState, target: Dungeon) -> DungeonState:
     prior = dungeon[target]
     if not prior:
         raise DrollError(f"At least 1 {target.value} required in dungeon.")
@@ -199,7 +199,7 @@ def increment_party(party: Party, hero: str) -> Party:
     return replace(party, **{hero: getattr(party, hero) + 1})
 
 # After
-def increment_party(party: PartyState, hero: PartyDie) -> PartyState:
+def increment_party(party: PartyState, hero: Party) -> PartyState:
     return frozen({**party, hero: party[hero] + 1})
 ```
 
@@ -233,8 +233,8 @@ DragonSlayer = replace(Default, ...,
 # After
 DragonSlayer = replace(Default, ...,
     party=frozen({
-        PartyDie.FIGHTER: frozen({**Default.party[PartyDie.FIGHTER],
-                                  DungeonDie.DRAGON: _dragonslayer_defeat_dragon}),
+        Party.FIGHTER: frozen({**Default.party[Party.FIGHTER],
+                                  Dungeon.DRAGON: _dragonslayer_defeat_dragon}),
         ...
     }))
 ```
@@ -246,7 +246,7 @@ DragonSlayer = replace(Default, ...,
 struct.Dungeon()  # all zeros
 
 # After
-empty_dungeon()   # returns frozen({face: 0 for face in DungeonDie})
+empty_dungeon()   # returns frozen({face: 0 for face in Dungeon})
 ```
 
 ### Constructor patterns with `*list` unpacking
@@ -256,7 +256,7 @@ empty_dungeon()   # returns frozen({face: 0 for face in DungeonDie})
 Dungeon(*_roll(dice, 0, 6, randrange))
 
 # After
-frozen(dict(zip(DungeonDie, _roll(dice, 0, 6, randrange))))
+frozen(dict(zip(Dungeon, _roll(dice, 0, 6, randrange))))
 ```
 
 ## Detailed Per-File Impact
@@ -265,7 +265,8 @@ frozen(dict(zip(DungeonDie, _roll(dice, 0, 6, randrange))))
 - Add `from types import MappingProxyType` and `from collections.abc import Mapping`
 - Add `frozen()` helper wrapping `MappingProxyType`
 - Add four enums and six type aliases (using `Mapping[K, V]`)
-- Remove `Dungeon`, `Party`, `Artifacts` dataclasses
+- Remove the old `Dungeon`, `Party`, `Artifacts` dataclasses (their names
+  are now reused by the `Dungeon`, `Party`, `Artifact` enums)
 - Add factory helpers: `empty_dungeon() -> DungeonState`,
   `empty_party() -> PartyState`, `empty_artifacts() -> ArtifactCounts`
   (each returns `frozen({...})`)
@@ -279,16 +280,16 @@ frozen(dict(zip(DungeonDie, _roll(dice, 0, 6, randrange))))
 - Keep `brief()` working via duck typing on dict `.items()`
 
 ### `dungeon.py`
-- Param `target: str` → `target: DungeonDie` in all functions
-- Return `Dungeon` → `DungeonState` (i.e. `dict[DungeonDie, int]`)
+- Param `target: str` → `target: Dungeon` in all functions
+- Return `Dungeon` → `DungeonState` (i.e. `dict[Dungeon, int]`)
 - Delete `_DUNGEON_FIELDS`, `_check_dungeon_target`
 - `getattr(dungeon, target)` → `dungeon[target]`
 - `replace(dungeon, **{target: v})` → `frozen({**dungeon, target: v})`
-- Direct access `dungeon.goblin` → `dungeon[DungeonDie.GOBLIN]`
+- Direct access `dungeon.goblin` → `dungeon[Dungeon.GOBLIN]`
 - `field_values(dungeon)` → `dungeon.values()`
 
 ### `party.py`
-- Param `hero: str` → `hero: PartyDie` in all functions
+- Param `hero: str` → `hero: Party` in all functions
 - Return `Party` → `PartyState`
 - Delete `_PARTY_FIELDS`, `_check_party_member`
 - Same `getattr`→`[]` and `replace`→`frozen({**d})` migration as `dungeon.py`
@@ -303,44 +304,44 @@ frozen(dict(zip(DungeonDie, _roll(dice, 0, 6, randrange))))
   (but `Treasure` itself stays a dataclass, so its `replace` stays)
 
 ### `regular.py`
-- All `Command`-signature functions: `hero: str` → `hero: PartyDie`,
-  `targets: tuple[str, ...]` → `tuple[DungeonDie | PartyDie, ...]`
+- All `Command`-signature functions: `hero: str` → `hero: Party`,
+  `targets: tuple[str, ...]` → `tuple[Dungeon | Party, ...]`
 - `_DUNGEON_NAMES`, `_PARTY_NAMES` frozensets → deleted (use `isinstance`
   checks or enum type)
-- `_classify_reroll_targets`: check `isinstance(t, DungeonDie)` vs
-  `isinstance(t, PartyDie)`
-- `bait_dragon`: `_enemies` becomes `tuple[DungeonDie, ...]`
-- `defeat_dragon_heroes`: `disallowed_heroes` becomes `frozenset[PartyDie]`
-- `elixir`: `targets[0]` is already `PartyDie`
-- String literals like `"potion"` → `DungeonDie.POTION`, `"scroll"` →
-  `PartyDie.SCROLL`, etc.
+- `_classify_reroll_targets`: check `isinstance(t, Dungeon)` vs
+  `isinstance(t, Party)`
+- `bait_dragon`: `_enemies` becomes `tuple[Dungeon, ...]`
+- `defeat_dragon_heroes`: `disallowed_heroes` becomes `frozenset[Party]`
+- `elixir`: `targets[0]` is already `Party`
+- String literals like `"potion"` → `Dungeon.POTION`, `"scroll"` →
+  `Party.SCROLL`, etc.
 
 ### `special.py`
 - Same `Command` signature updates as `regular.py`
-- `convert_dungeon_to_party`: `source: str` → `source: DungeonDie`,
-  `destination: str` → `destination: PartyDie`
+- `convert_dungeon_to_party`: `source: str` → `source: Dungeon`,
+  `destination: str` → `destination: Party`
 - `getattr(world.dungeon, source)` → `world.dungeon[source]`
 
 ### `ability.py`
 - All ability functions: `command: str` → `command: Action`,
   `targets: tuple[str, ...]` → typed tuple
 - `_choose_and_add_hero`: `acceptable: frozenset[str]` →
-  `frozenset[PartyDie]`
-- `_convert_one`/`_convert_two`: `source: str` → `DungeonDie`,
-  `destination: str` → `PartyDie`
+  `frozenset[Party]`
+- `_convert_one`/`_convert_two`: `source: str` → `Dungeon`,
+  `destination: str` → `Party`
 - Literal strings like `increment_dungeon(dungeon, "potion")` →
-  `increment_dungeon(dungeon, DungeonDie.POTION)`
+  `increment_dungeon(dungeon, Dungeon.POTION)`
 - `increment_party(world.party, "scroll")` →
-  `increment_party(world.party, PartyDie.SCROLL)`
+  `increment_party(world.party, Party.SCROLL)`
 
 ### `player.py`
 - `Default.artifacts` becomes `ArtifactMapping`:
-  `{PartyDie.FIGHTER: Artifact.SWORD, ..., PartyDie.CHAMPION: None, ...}`
+  `{Party.FIGHTER: Artifact.SWORD, ..., Party.CHAMPION: None, ...}`
 - `Default.party` becomes `PartyActions`:
-  `{PartyDie.FIGHTER: {DungeonDie.GOBLIN: defeat_all, ...}, ...}`
+  `{Party.FIGHTER: {Dungeon.GOBLIN: defeat_all, ...}, ...}`
 - `apply()`: `command: str` becomes a union or is pre-parsed into the
   appropriate enum type by the caller; dispatch uses enum comparisons
-- `_partify_command`: `Artifact` → `PartyDie` reverse lookup
+- `_partify_command`: `Artifact` → `Party` reverse lookup
 - `_ARTIFACT_COMMANDS`: `frozenset[Artifact]`
 - `_TREASURE_NO_COMMAND`: `frozenset[Artifact]`
 - `complete()`: returns `Sequence[str]` (for the shell), but internally
@@ -354,8 +355,8 @@ frozen(dict(zip(DungeonDie, _roll(dice, 0, 6, randrange))))
 - `new_world()`: `Artifacts(sword=3, ...)` →
   `{Artifact.SWORD: 3, ...}`
 - `_regroup()`: `Party(**{name: max(...)})` →
-  `{die: max(0, world.party[die] - world.regroup.discard[die]) for die in PartyDie}`
-- `descend()`: `replace(rolled, dragon=...)` → `{**rolled, DungeonDie.DRAGON: ...}`
+  `{die: max(0, world.party[die] - world.regroup.discard[die]) for die in Party}`
+- `descend()`: `replace(rolled, dragon=...)` → `{**rolled, Dungeon.DRAGON: ...}`
 - `_apply_ring`/`_apply_portal`: `noun: str = "ring"` →
   `noun: Artifact = Artifact.RING`
 - `score()`: `field_values(world.treasure.own)` → `world.treasure.own.values()`
@@ -367,15 +368,15 @@ frozen(dict(zip(DungeonDie, _roll(dice, 0, 6, randrange))))
 - `_format_treasure`: `field_items(artifacts)` → `artifacts.items()`
 - `field_values(party)` → `party.values()`
 - Item names in output use `face.value` / `die.value` for display strings
-- `_ALWAYS_COUNT = frozenset({DungeonDie.DRAGON})`
+- `_ALWAYS_COUNT = frozenset({Dungeon.DRAGON})`
 
 ### `dice.py`
 - `roll_dungeon` returns `DungeonState` instead of `Dungeon`
 - `roll_party` returns `PartyState` instead of `Party`
-- `Dungeon(*_roll(...))` → `dict(zip(DungeonDie, _roll(...)))`
-- `Party(*_roll(...))` → `dict(zip(PartyDie, _roll(...)))`
-- `len(fields(Dungeon))` → `len(DungeonDie)` (enum length)
-- `len(fields(Party))` → `len(PartyDie)`
+- `Dungeon(*_roll(...))` → `dict(zip(Dungeon, _roll(...)))`
+- `Party(*_roll(...))` → `dict(zip(Party, _roll(...)))`
+- `len(fields(Dungeon))` → `len(Dungeon)` (enum length)
+- `len(fields(Party))` → `len(Party)`
 
 ### `game.py`
 - `Game.ability()`: passes `Action.ABILITY` instead of `"ability"`
@@ -396,27 +397,27 @@ frozen(dict(zip(DungeonDie, _roll(dice, 0, 6, randrange))))
 
 ### Hero files (`droll/heroes/*.py`)
 - All `struct.Party(fighter=struct.Dungeon(...), ...)` constructions →
-  `{PartyDie.FIGHTER: {DungeonDie.GOBLIN: defeat_all, ...}, ...}`
+  `{Party.FIGHTER: {Dungeon.GOBLIN: defeat_all, ...}, ...}`
 - `replace(Default.party.fighter, dragon=...)` →
-  `frozen({**Default.party[PartyDie.FIGHTER], DungeonDie.DRAGON: ...})`
+  `frozen({**Default.party[Party.FIGHTER], Dungeon.DRAGON: ...})`
 - `replace(Default.party, fighter=..., cleric=...)` →
-  `frozen({**Default.party, PartyDie.FIGHTER: ..., PartyDie.CLERIC: ...})`
-- `Default.party.cleric.skeleton` → `Default.party[PartyDie.CLERIC][DungeonDie.SKELETON]`
-- `frozenset({"fighter", "cleric"})` → `frozenset({PartyDie.FIGHTER, PartyDie.CLERIC})`
+  `frozen({**Default.party, Party.FIGHTER: ..., Party.CLERIC: ...})`
+- `Default.party.cleric.skeleton` → `Default.party[Party.CLERIC][Dungeon.SKELETON]`
+- `frozenset({"fighter", "cleric"})` → `frozenset({Party.FIGHTER, Party.CLERIC})`
 
 ### Test files
-- Every `struct.Dungeon(goblin=1, ...)` → `{DungeonDie.GOBLIN: 1, ...}`
-  (or use `{**empty_dungeon(), DungeonDie.GOBLIN: 1}`)
-- Every `struct.Party(fighter=2, ...)` → same pattern with `PartyDie`
+- Every `struct.Dungeon(goblin=1, ...)` → `{Dungeon.GOBLIN: 1, ...}`
+  (or use `{**empty_dungeon(), Dungeon.GOBLIN: 1}`)
+- Every `struct.Party(fighter=2, ...)` → same pattern with `Party`
 - Every `struct.Artifacts(sword=1, ...)` → same pattern with `Artifact`
-- Direct field access `game.dungeon.goblin` → `game.dungeon[DungeonDie.GOBLIN]`
-- Direct field access `game.party.fighter` → `game.party[PartyDie.FIGHTER]`
+- Direct field access `game.dungeon.goblin` → `game.dungeon[Dungeon.GOBLIN]`
+- Direct field access `game.party.fighter` → `game.party[Party.FIGHTER]`
 
 ## Implementation Steps
 
 ### Step 1: Define enums and type aliases in `struct.py`
 
-Add `DungeonDie`, `PartyDie`, `Artifact`, `Action` plus all six
+Add `Dungeon`, `Party`, `Artifact`, `Action` plus all six
 type aliases.  Add `empty_dungeon()`, `empty_party()`, `empty_artifacts()`
 factory helpers.  Keep the old dataclasses temporarily.  Tests still pass.
 
@@ -437,7 +438,7 @@ This is the simplest migration — `Artifacts` has only one role (`int` fields).
 ### Step 3: Migrate `Dungeon` state → `DungeonState`
 
 Replace the `Dungeon` dataclass's state role (counting die faces) with
-`DungeonState = dict[DungeonDie, int]`.
+`DungeonState = dict[Dungeon, int]`.
 - Update `dungeon.py`: all functions take/return `DungeonState`, delete
   `_check_dungeon_target` and `_DUNGEON_FIELDS`
 - Update `World.dungeon: Optional[DungeonState]`
@@ -450,7 +451,7 @@ Replace the `Dungeon` dataclass's state role (counting die faces) with
 ### Step 4: Migrate `Party` state → `PartyState`
 
 Replace the `Party` dataclass's counting role with
-`PartyState = dict[PartyDie, int]`.
+`PartyState = dict[Party, int]`.
 - Update `party.py`: all functions take/return `PartyState`, delete
   `_check_party_member` and `_PARTY_FIELDS`
 - Update `World.party: PartyState`, `Regroup.discard: PartyState`
@@ -464,9 +465,9 @@ Replace the `Party` dataclass's counting role with
 ### Step 5: Migrate `Dungeon` dispatch → `HeroActions`, and `Party` dispatch → `PartyActions`
 
 These two are tightly coupled (a `PartyActions` is a dict of `HeroActions`).
-- Define `HeroActions = dict[DungeonDie, Command]`
-- Define `PartyActions = dict[PartyDie, HeroActions]`
-- Remove the `Dungeon` and `Party` dataclasses entirely
+- Define `HeroActions = dict[Dungeon, Command]`
+- Define `PartyActions = dict[Party, HeroActions]`
+- Remove the old `Dungeon` and `Party` dataclasses entirely (names now belong to enums)
 - Update `Player.party: PartyActions`
 - Update `player.py:apply()`: `getattr(player.party, command)` →
   `player.party[command]`, `getattr(action_, targets[0])` →
@@ -478,7 +479,7 @@ These two are tightly coupled (a `PartyActions` is a dict of `HeroActions`).
 
 ### Step 6: Migrate `Party` artifact mapping → `ArtifactMapping`
 
-- Define `ArtifactMapping = dict[PartyDie, Optional[Artifact]]`
+- Define `ArtifactMapping = dict[Party, Optional[Artifact]]`
 - Update `Player.artifacts: ArtifactMapping`
 - Update `player.py`: `Default.artifacts` construction,
   `_partify_command`, `_adjust_phantom_treasures`, `_ARTIFACT_COMMANDS`
@@ -487,7 +488,7 @@ These two are tightly coupled (a `PartyActions` is a dict of `HeroActions`).
 
 ### Step 7: Update `Command` signature and action functions
 
-- Update `Command = Callable[[World, RandRange, PartyDie, tuple[...]], World]`
+- Update `Command = Callable[[World, RandRange, Party, tuple[...]], World]`
 - Update every function that matches the `Command` signature (`defeat_one`,
   `defeat_all`, `open_one`, `open_all`, `quaff`, `reroll`, `defeat_dragon`,
   `bait_dragon`, `elixir`, all ability functions, all special functions)
@@ -557,8 +558,8 @@ Callers that used them on the removed types:
 
 | Caller | Was | Becomes |
 |---|---|---|
-| `dice.py`: `len(fields(Dungeon))` | dataclass field count | `len(DungeonDie)` |
-| `dice.py`: `len(fields(Party))` | dataclass field count | `len(PartyDie)` |
+| `dice.py`: `len(fields(Dungeon))` | dataclass field count | `len(Dungeon)` |
+| `dice.py`: `len(fields(Party))` | dataclass field count | `len(Party)` |
 | `dungeon.py`: `field_names(Dungeon)` | frozenset of names | deleted (enum membership) |
 | `dungeon.py`: `field_values(dungeon)` | sum of values | `dungeon.values()` |
 | `party.py`: `field_names(Party)` | frozenset of names | deleted (enum membership) |
@@ -569,11 +570,11 @@ Callers that used them on the removed types:
 | `player.py`: `field_items(action_)` | iteration | `.items()` |
 | `player.py`: `field_names(player.party)` | membership check | `in player.party` |
 | `player.py`: `field_names(action_)` | membership check | `in action_` |
-| `player.py`: `field_names(struct.Party)` / `field_names(struct.Dungeon)` | completion | `PartyDie` / `DungeonDie` members |
+| `player.py`: `field_names(struct.Party)` / `field_names(struct.Dungeon)` | completion | `Party` / `Dungeon` members |
 | `display.py`: `field_items(counts)` / `field_values(party)` | formatting | `.items()` / `.values()` |
 | `world.py`: `field_values(world.treasure.own)` | scoring | `.values()` |
 | `world.py`: `field_items(world.regroup.discard)` | regroup | `.items()` |
-| Tests: `len(fields(struct.Dungeon))` / `len(fields(struct.Party))` | construction | `len(DungeonDie)` / `len(PartyDie)` |
+| Tests: `len(fields(struct.Dungeon))` / `len(fields(struct.Party))` | construction | `len(Dungeon)` / `len(Party)` |
 
 ### `RollDungeon` and `RollParty` type aliases need updating
 
@@ -601,16 +602,16 @@ from the stdlib.  This is a zero-dependency read-only view over a `dict`:
 ```python
 from types import MappingProxyType
 
-proxy = MappingProxyType({DungeonDie.GOBLIN: 2})
-proxy[DungeonDie.GOBLIN]          # 2 — reads work
-proxy[DungeonDie.GOBLIN] = 99     # TypeError — mutation blocked
+proxy = MappingProxyType({Dungeon.GOBLIN: 2})
+proxy[Dungeon.GOBLIN]          # 2 — reads work
+proxy[Dungeon.GOBLIN] = 99     # TypeError — mutation blocked
 ```
 
 The "update" idiom builds a new plain `dict` via spread, then re-wraps:
 
 ```python
-frozen({**proxy, DungeonDie.GOBLIN: 0})
-# → MappingProxyType({DungeonDie.GOBLIN: 0, ...})
+frozen({**proxy, Dungeon.GOBLIN: 0})
+# → MappingProxyType({Dungeon.GOBLIN: 0, ...})
 ```
 
 This pairs with frozen dataclasses: `World(frozen=True)` prevents field
@@ -645,7 +646,7 @@ patterns that must become dict literals / dict spreads.
   files but each `getattr`→`[]` change is mechanical.
 - **Higher risk:** Dispatch table migration (Step 5) changes how hero files
   build their action tables.  The `replace(Default.party.fighter, dragon=...)`
-  pattern becomes `{**Default.party[PartyDie.FIGHTER], DungeonDie.DRAGON: ...}`.
+  pattern becomes `{**Default.party[Party.FIGHTER], Dungeon.DRAGON: ...}`.
   This is more verbose but precisely typed.  Must test all 8 hero variants.
 - **Medium risk:** `Command` signature (Step 7) touches every action function.
   Doing it late means intermediate steps have a mixed `str`/`enum` period.

--- a/PLAN.md
+++ b/PLAN.md
@@ -1,0 +1,241 @@
+# Plan: Replace Literal Strings with Enums
+
+## Problem Statement
+
+Throughout the codebase, a small number of literal string values—representing
+party members, dungeon faces, artifacts, and special commands—are passed as
+plain `str` from the shell layer all the way into the game engine.  These
+strings are the game's vocabulary: `"fighter"`, `"goblin"`, `"sword"`,
+`"reroll"`, `"ability"`, etc.  They are never arbitrary user text; they always
+belong to one of a few closed sets.  Using bare strings means:
+
+- No static checking that a value belongs to its intended set.
+- `getattr(obj, name)` / `replace(obj, **{name: ...})` patterns where `name`
+  is a raw string, bypassing type-checker visibility.
+- Validation scattered across ad-hoc `frozenset` lookups and runtime `if`
+  checks (`_DUNGEON_FIELDS`, `_PARTY_FIELDS`, `_check_dungeon_target`, etc.).
+- Easy to accidentally pass a dungeon name where a party name is expected (or
+  vice versa) with no tool-time feedback.
+
+## Proposed Enums
+
+### 1. `DungeonFace` — the six dungeon die faces
+
+```python
+class DungeonFace(enum.Enum):
+    GOBLIN = "goblin"
+    SKELETON = "skeleton"
+    OOZE = "ooze"
+    CHEST = "chest"
+    POTION = "potion"
+    DRAGON = "dragon"
+```
+
+**Where it replaces strings today:**
+- `dungeon.py`: `decrement_dungeon(dungeon, target: str)` → `target: DungeonFace`
+- `dungeon.py`: `increment_dungeon(dungeon, target: str)` → `target: DungeonFace`
+- `dungeon.py`: `eliminate_dungeon(dungeon, target: str)` → `target: DungeonFace`
+- `regular.py`: `_classify_reroll_targets` membership checks against `_DUNGEON_NAMES`
+- `regular.py`: `bait_dragon` iterating `_enemies: Sequence[str]`
+- `ability.py`: calls like `increment_dungeon(dungeon, "potion")`
+- `special.py`: `convert_dungeon_to_party(world, source="goblin", ...)`
+
+### 2. `PartyDie` — the six party die faces
+
+```python
+class PartyDie(enum.Enum):
+    FIGHTER = "fighter"
+    CLERIC = "cleric"
+    MAGE = "mage"
+    THIEF = "thief"
+    CHAMPION = "champion"
+    SCROLL = "scroll"
+```
+
+**Where it replaces strings today:**
+- `party.py`: `decrement_party(party, hero: str)` → `hero: PartyDie`
+- `party.py`: `increment_party(party, hero: str)` → `hero: PartyDie`
+- `party.py`: `decrement_regroup(regroup, hero: str)` → `hero: PartyDie`
+- `regular.py`: `_classify_reroll_targets` membership checks against `_PARTY_NAMES`
+- `regular.py`: `defeat_dragon_heroes` disallowed set `{"scroll"}`
+- `ability.py`: calls like `increment_party(world.party, "scroll")`
+- `special.py`: `convert_dungeon_to_party(world, ..., destination="thief")`
+- `player.py`: artifact mapping values, `_partify_command` return values
+
+### 3. `ArtifactKind` — the ten treasure/artifact types
+
+```python
+class ArtifactKind(enum.Enum):
+    SWORD = "sword"
+    TALISMAN = "talisman"
+    SCEPTRE = "sceptre"
+    TOOLS = "tools"
+    SCROLL = "scroll"
+    ELIXIR = "elixir"
+    BAIT = "bait"
+    PORTAL = "portal"
+    RING = "ring"
+    SCALE = "scale"
+```
+
+**Where it replaces strings today:**
+- `treasure.py`: `_draw` returns `str` → `ArtifactKind`
+- `treasure.py`: `replace_treasure(treasure, item: str)` → `item: ArtifactKind`
+- `player.py`: `_ARTIFACT_COMMANDS` frozenset
+- `player.py`: `artifacts=struct.Party(fighter="sword", ...)` mappings
+- `world.py`: `_apply_ring(world, *, noun: str = "ring")`
+- `world.py`: `_apply_portal(world, *, noun: str = "portal")`
+- `regular.py`: `bait_dragon` calling `replace_treasure(world.treasure, command)`
+- `regular.py`: `elixir` calling `replace_treasure(world.treasure, command)`
+
+### 4. `ActionVerb` — the special command verbs that aren't heroes
+
+```python
+class ActionVerb(enum.Enum):
+    ABILITY = "ability"
+    BAIT = "bait"
+    ELIXIR = "elixir"
+    REROLL = "reroll"
+```
+
+**Where it replaces strings today:**
+- `player.py:apply()`: `if command == "portal"`, `if command == "ring"`,
+  `if command in {"ability", "bait", "elixir"}`, `if command == "reroll"`
+- `game.py`: passing `"ability"` and `"reroll"` into `player.apply()`
+
+This enum is small but eliminates the riskiest string comparisons—the ones
+that dispatch to fundamentally different code paths.
+
+## Dataclass Field Access Pattern
+
+The core challenge is that `Dungeon`, `Party`, and `Artifacts` are frozen
+dataclasses whose fields are named after enum values.  Today the code uses
+`getattr(dungeon, target)` and `replace(dungeon, **{target: new_val})` where
+`target` is a bare string matching a field name.
+
+With enums, the accessor pattern becomes:
+
+```python
+# Before
+getattr(dungeon, target)                  # target = "goblin"
+replace(dungeon, **{target: new_val})
+
+# After
+getattr(dungeon, target.value)            # target = DungeonFace.GOBLIN
+replace(dungeon, **{target.value: new_val})
+```
+
+This is the minimally invasive approach.  An alternative would be to replace
+the dataclasses with dict-like containers keyed by enum, but that would be a
+much larger change with less benefit from the frozen-dataclass guarantees.
+
+## What the Finished Result Looks Like
+
+1. **`struct.py`** gains four `enum.Enum` classes (`DungeonFace`, `PartyDie`,
+   `ArtifactKind`, `ActionVerb`) alongside the existing dataclasses.
+
+2. **`Dungeon`, `Party`, `Artifacts` dataclasses** keep their field names
+   unchanged (so `Dungeon.goblin`, `Party.fighter`, etc. remain valid Python
+   identifiers).  The enum `.value` serves as the bridge between the typed
+   token and the field name.
+
+3. **Module-internal validation** (`_check_dungeon_target`,
+   `_check_party_member`, `_DUNGEON_FIELDS`, `_PARTY_FIELDS`) **is deleted**
+   because the enum type annotation enforces membership at the call site.
+
+4. **`shell.py`** gains a thin `_parse_token(text: str) -> Enum` function at
+   the boundary where user input becomes typed.  `_tokenize` returns
+   `tuple[str, ...]` today; the new version would return typed tokens that the
+   rest of the engine consumes.
+
+5. **All intermediate functions** (`decrement_dungeon`, `increment_party`,
+   `replace_treasure`, `bait_dragon`, `quaff`, etc.) accept enum parameters
+   instead of `str`, gaining static type safety.
+
+6. **Error messages** use `target.value` to produce the same human-readable
+   strings as today—no user-facing change.
+
+7. **Tab completion** continues to work with string values; conversion happens
+   at the boundary.
+
+## Implementation Steps
+
+### Step 1: Define the enums in `struct.py`
+
+Add `DungeonFace`, `PartyDie`, `ArtifactKind`, and `ActionVerb` to `struct.py`.
+Export them from `__all__`.  No other file changes yet.  Tests still pass.
+
+### Step 2: Port `dungeon.py` to use `DungeonFace`
+
+- Change `decrement_dungeon`, `increment_dungeon`, `eliminate_dungeon` to
+  accept `target: DungeonFace` and use `target.value` for `getattr`/`replace`.
+- Remove `_check_dungeon_target` and `_DUNGEON_FIELDS`.
+- Update all callers in `regular.py`, `special.py`, and `ability.py` to pass
+  `DungeonFace.GOBLIN` instead of `"goblin"`, etc.
+- Update tests.
+
+### Step 3: Port `party.py` to use `PartyDie`
+
+- Change `decrement_party`, `increment_party`, `decrement_regroup` to accept
+  `hero: PartyDie` and use `hero.value`.
+- Remove `_check_party_member` and `_PARTY_FIELDS`.
+- Update all callers in `regular.py`, `special.py`, `ability.py`, and
+  `player.py`.
+- Update tests.
+
+### Step 4: Port `treasure.py` to use `ArtifactKind`
+
+- Change `_draw` to return `ArtifactKind`.
+- Change `replace_treasure` to accept `item: ArtifactKind`.
+- Update callers in `world.py`, `regular.py`, `ability.py`, and `player.py`.
+- Update tests.
+
+### Step 5: Port `player.py` to use `ActionVerb` and integrate all enums
+
+- Replace the string comparisons in `apply()` with `ActionVerb` checks.
+- Update `_partify_command` to work with `ArtifactKind` → `PartyDie` mapping.
+- Update `_ARTIFACT_COMMANDS` to use `ArtifactKind`.
+- Update `_available_nouns`, `_available_targets`, `_all_dice_names`, and
+  `complete` to return/compare enum values, converting to strings only for
+  display.
+- Update tests.
+
+### Step 6: Port `game.py` and `shell.py` — the boundary layer
+
+- In `game.py`, pass enum values instead of string literals to `player.apply`.
+- In `shell.py`, add `_parse_token` to convert user input strings into the
+  appropriate enum type.  `_tokenize` stays string-based; parsing happens
+  inside `do_ability`, `default`, `do_reroll`, and completion methods.
+- Tab completion operates on `.value` strings but the typed boundary ensures
+  invalid tokens are caught early.
+- Update tests.
+
+### Step 7: Port the `Command` type signature
+
+- Update `struct.Command` from
+  `Callable[[World, RandRange, str, tuple[str, ...]], World]`
+  to use the appropriate enum types for the `hero` and `targets` parameters.
+- This is the signature used by `defeat_one`, `defeat_all`, `quaff`,
+  `defeat_dragon`, `bait_dragon`, `elixir`, and every hero ability.
+- Update all implementations and their callers.
+- Update tests.
+
+### Step 8: Clean up and final verification
+
+- Remove any remaining `frozenset` lookups that the enums made redundant.
+- Run the full test suite.
+- Verify tab completion and shell interaction still work correctly.
+- Verify `brief()` display output is unchanged.
+
+## Risk Assessment
+
+- **Low risk:** Each step is independently testable.  The enum `.value`
+  property means all `getattr`/`replace` patterns work with a mechanical
+  `.value` suffix addition.
+- **Medium risk:** The `Command` type signature change (Step 7) touches
+  every action function.  Doing it last means the intermediate steps carry
+  a mixed `str`/`enum` signature, but this is manageable and each step's
+  tests confirm correctness.
+- **Boundary clarity:** The shell is the only place where raw user strings
+  enter the system.  Converting there means the entire engine interior
+  speaks enums, which is the ideal end state.

--- a/droll/ability.py
+++ b/droll/ability.py
@@ -4,6 +4,7 @@
 """Ability functions for all heroes."""
 
 from dataclasses import replace
+from typing import Union
 from . import regular, special, struct
 from .dungeon import (
     defeated_monsters,
@@ -46,7 +47,7 @@ def _consume_ability(world: struct.World) -> struct.World:
 def _choose_and_add_hero(
     world: struct.World,
     command: Action,
-    targets: tuple[Dungeon | Party, ...],
+    targets: tuple[Union[Dungeon, Party], ...],
     acceptable: frozenset[Party],
 ) -> struct.World:
     """Default target to sorted-first acceptable; validate; add one hero."""
@@ -63,7 +64,7 @@ def _choose_and_add_hero(
 
 def _convert_one(
     world: struct.World,
-    targets: tuple[Dungeon | Party, ...],
+    targets: tuple[Union[Dungeon, Party], ...],
     source: Dungeon,
     destination: Party,
 ) -> struct.World:
@@ -80,7 +81,7 @@ def _convert_one(
 
 def _convert_two(
     world: struct.World,
-    targets: tuple[Dungeon | Party, ...],
+    targets: tuple[Union[Dungeon, Party], ...],
     source: Dungeon,
     destination: Party,
 ) -> struct.World:
@@ -101,7 +102,7 @@ def default_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """No special ability."""
     world = _consume_ability(world)
@@ -114,7 +115,7 @@ def battlemage_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Discard all monsters, chests, potions, and dice in the dragon's lair.
 
@@ -129,7 +130,7 @@ def beguiler_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Transform at most 2 monsters into 1 potion.
     Requires transforming 2 monsters when 2+ monsters available.
@@ -156,7 +157,7 @@ def chieftain_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Transform up to 2 goblins into thieves, discarding them on regroup.
     Open chests and quaff potions before clearing monsters.
@@ -169,7 +170,7 @@ def commander_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Rerolls any number of Party and Dungeon dice.
     Each fighter defeats one additional monster beyond its usual targets.
@@ -192,7 +193,7 @@ def crusader_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
     *,
     _acceptable_targets: frozenset[Party] = frozenset({Party.FIGHTER, Party.CLERIC}),
 ) -> struct.World:
@@ -207,7 +208,7 @@ def enchantress_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Transform exactly 1 monster into 1 potion.
 
@@ -227,7 +228,7 @@ def halfgoblin_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Transform 1 goblin into 1 thief, discarding it on regroup.
 
@@ -239,7 +240,7 @@ def knight_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Convert all monster faces into dragon dice.
 
@@ -254,7 +255,7 @@ def dragonslayer_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Convert all monster faces into dragon dice.
     Dragons require only 2 distinct party members to defeat.
@@ -268,7 +269,7 @@ def mercenary_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Defeat any 2 monsters.
 
@@ -287,7 +288,7 @@ def minstrel_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Discard all dragon dice.
 
@@ -302,7 +303,7 @@ def bard_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Discard all dragon dice.
     Each champion defeats one additional monster beyond its usual targets.
@@ -318,7 +319,7 @@ def necromancer_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Transform up to 2 skeletons into fighters, discarding on regroup.
     Heroes cleric and mage are interchangeable.
@@ -331,7 +332,7 @@ def occultist_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Transform 1 skeleton into 1 fighter, discarding it on regroup.
 
@@ -343,7 +344,7 @@ def paladin_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
 ) -> struct.World:
     """Consume treasure to clear dungeon, open chests, and quaff potions.
     Specify consumed treasure as first argument.
@@ -390,7 +391,7 @@ def spellsword_ability(
     world: struct.World,
     randrange: struct.RandRange,
     command: Action,
-    targets: tuple[Dungeon | Party, ...] = (),
+    targets: tuple[Union[Dungeon, Party], ...] = (),
     *,
     _acceptable_targets: frozenset[Party] = frozenset({Party.FIGHTER, Party.MAGE}),
 ) -> struct.World:

--- a/droll/ability.py
+++ b/droll/ability.py
@@ -12,7 +12,7 @@ from .dungeon import (
     increment_dungeon,
 )
 from .party import increment_party
-from .struct import DrollError
+from .struct import Action, Artifact, Dungeon, DrollError, Party
 from .treasure import draw_treasure, replace_treasure
 
 __all__ = (
@@ -45,34 +45,34 @@ def _consume_ability(world: struct.World) -> struct.World:
 
 def _choose_and_add_hero(
     world: struct.World,
-    command: str,
-    targets: tuple[str, ...],
-    acceptable: frozenset[str],
+    command: Action,
+    targets: tuple[Dungeon | Party, ...],
+    acceptable: frozenset[Party],
 ) -> struct.World:
     """Default target to sorted-first acceptable; validate; add one hero."""
     world = _consume_ability(world)
     if len(targets) > 1:
-        raise DrollError(f"At most 1 target accepted for {command}.")
-    target = targets[0] if targets else next(iter(sorted(acceptable)))
+        raise DrollError(f"At most 1 target accepted for {command.value}.")
+    target = targets[0] if targets else next(iter(sorted(acceptable, key=lambda p: p.value)))
     if target not in acceptable:
         raise DrollError(
-            f"Target '{target}' not one of {', '.join(sorted(acceptable))}."
+            f"Target '{target.value}' not one of {', '.join(sorted(p.value for p in acceptable))}."
         )
     return replace(world, party=increment_party(world.party, target))
 
 
 def _convert_one(
     world: struct.World,
-    targets: tuple[str, ...],
-    source: str,
-    destination: str,
+    targets: tuple[Dungeon | Party, ...],
+    source: Dungeon,
+    destination: Party,
 ) -> struct.World:
     """Validate optional target; convert 1 dungeon die to party."""
     world = _consume_ability(world)
-    if any(t != source for t in targets):
-        raise DrollError(f"Ability can only target 1 {source}.")
+    if any(t is not source for t in targets):
+        raise DrollError(f"Ability can only target 1 {source.value}.")
     if len(targets) > 1:
-        raise DrollError(f"Ability can only target 1 {source}.")
+        raise DrollError(f"Ability can only target 1 {source.value}.")
     return special.convert_dungeon_to_party(
         world, source=source, destination=destination, max_count=1
     )
@@ -80,16 +80,16 @@ def _convert_one(
 
 def _convert_two(
     world: struct.World,
-    targets: tuple[str, ...],
-    source: str,
-    destination: str,
+    targets: tuple[Dungeon | Party, ...],
+    source: Dungeon,
+    destination: Party,
 ) -> struct.World:
     """Validate optional targets; convert up to 2 dungeon dice to party."""
     world = _consume_ability(world)
-    if targets and targets[0] != source:
-        raise DrollError(f"Ability can only target a {source}.")
-    if len(targets) > 1 and targets[1] != source:
-        raise DrollError(f"Ability can only target a {source}.")
+    if targets and targets[0] is not source:
+        raise DrollError(f"Ability can only target a {source.value}.")
+    if len(targets) > 1 and targets[1] is not source:
+        raise DrollError(f"Ability can only target a {source.value}.")
     if len(targets) > 2:
         raise DrollError("At most 2 targets can be changed.")
     return special.convert_dungeon_to_party(
@@ -100,36 +100,36 @@ def _convert_two(
 def default_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """No special ability."""
     world = _consume_ability(world)
     if targets:
-        raise DrollError(f"No targets accepted for {command}.")
+        raise DrollError(f"No targets accepted for {command.value}.")
     return world
 
 
 def battlemage_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Discard all monsters, chests, potions, and dice in the dragon's lair.
 
     Example: ability"""
     world = _consume_ability(world)
     if targets:
-        raise DrollError(f"No targets accepted for {command}.")
-    return replace(world, dungeon=struct.Dungeon())
+        raise DrollError(f"No targets accepted for {command.value}.")
+    return replace(world, dungeon=struct.empty_dungeon())
 
 
 def beguiler_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Transform at most 2 monsters into 1 potion.
     Requires transforming 2 monsters when 2+ monsters available.
@@ -138,7 +138,7 @@ def beguiler_ability(
     Example: ability goblin skeleton
     Example: ability goblin"""
     if not targets:
-        raise struct.DrollError(f'"{command}" requires a monster target.')
+        raise struct.DrollError(f'"{command.value}" requires a monster target.')
     world = _consume_ability(world)
     dungeon = world.dungeon
     dungeon = decrement_dungeon(dungeon, targets[0])
@@ -148,28 +148,28 @@ def beguiler_ability(
         dungeon = decrement_dungeon(dungeon, targets[1])
     elif not defeated_monsters(dungeon):
         raise DrollError("2 targets required when 2+ available.")
-    dungeon = increment_dungeon(dungeon, "potion")
+    dungeon = increment_dungeon(dungeon, Dungeon.POTION)
     return replace(world, dungeon=dungeon)
 
 
 def chieftain_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Transform up to 2 goblins into thieves, discarding them on regroup.
     Open chests and quaff potions before clearing monsters.
 
     Example: ability"""
-    return _convert_two(world, targets, source="goblin", destination="thief")
+    return _convert_two(world, targets, source=Dungeon.GOBLIN, destination=Party.THIEF)
 
 
 def commander_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Rerolls any number of Party and Dungeon dice.
     Each fighter defeats one additional monster beyond its usual targets.
@@ -179,22 +179,22 @@ def commander_ability(
     Example: ability goblin skeleton
     Example: fighter goblin ooze"""
     if not targets:
-        raise DrollError(f"At least 1 reroll target required for {command}.")
+        raise DrollError(f"At least 1 reroll target required for {command.value}.")
     world = _consume_ability(world)
     # Temporarily add a scroll to be consumed by reroll
-    world = replace(world, party=increment_party(world.party, "scroll"))
+    world = replace(world, party=increment_party(world.party, Party.SCROLL))
     return regular.reroll(
-        world, randrange, "scroll", targets, allow_dragon=True
+        world, randrange, Party.SCROLL, targets, allow_dragon=True
     )
 
 
 def crusader_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
     *,
-    _acceptable_targets: frozenset[str] = frozenset({"fighter", "cleric"}),
+    _acceptable_targets: frozenset[Party] = frozenset({Party.FIGHTER, Party.CLERIC}),
 ) -> struct.World:
     """Add 1 fighter or cleric to the party.
 
@@ -206,40 +206,40 @@ def crusader_ability(
 def enchantress_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Transform exactly 1 monster into 1 potion.
 
     Example: ability goblin"""
     if not targets:
-        raise struct.DrollError(f'"{command}" requires a monster target.')
+        raise struct.DrollError(f'"{command.value}" requires a monster target.')
     if len(targets) > 1:
-        raise struct.DrollError(f'"{command}" accepts only 1 monster target.')
+        raise struct.DrollError(f'"{command.value}" accepts only 1 monster target.')
     world = _consume_ability(world)
     dungeon = world.dungeon
     dungeon = decrement_dungeon(dungeon, targets[0])
-    dungeon = increment_dungeon(dungeon, "potion")
+    dungeon = increment_dungeon(dungeon, Dungeon.POTION)
     return replace(world, dungeon=dungeon)
 
 
 def halfgoblin_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Transform 1 goblin into 1 thief, discarding it on regroup.
 
     Example: ability"""
-    return _convert_one(world, targets, source="goblin", destination="thief")
+    return _convert_one(world, targets, source=Dungeon.GOBLIN, destination=Party.THIEF)
 
 
 def knight_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Convert all monster faces into dragon dice.
 
@@ -253,8 +253,8 @@ def knight_ability(
 def dragonslayer_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Convert all monster faces into dragon dice.
     Dragons require only 2 distinct party members to defeat.
@@ -267,42 +267,42 @@ def dragonslayer_ability(
 def mercenary_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Defeat any 2 monsters.
 
     Example: ability goblin skeleton"""
     if not targets:
-        raise DrollError(f"At least 1 target required for {command}.")
+        raise DrollError(f"At least 1 target required for {command.value}.")
     world = _consume_ability(world)
     # Temporarily add a champion to be consumed by defeat_one_plus_additional
-    world = replace(world, party=increment_party(world.party, "champion"))
+    world = replace(world, party=increment_party(world.party, Party.CHAMPION))
     return special.defeat_one_plus_additional(
-        world, randrange, "champion", targets
+        world, randrange, Party.CHAMPION, targets
     )
 
 
 def minstrel_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Discard all dragon dice.
 
     Example: ability"""
     world = _consume_ability(world)
-    if any(t != "dragon" for t in targets):
+    if any(t is not Dungeon.DRAGON for t in targets):
         raise DrollError("Can discard only dragon dice.")
-    return replace(world, dungeon=eliminate_dungeon(world.dungeon, "dragon"))
+    return replace(world, dungeon=eliminate_dungeon(world.dungeon, Dungeon.DRAGON))
 
 
 def bard_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Discard all dragon dice.
     Each champion defeats one additional monster beyond its usual targets.
@@ -317,33 +317,33 @@ def bard_ability(
 def necromancer_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Transform up to 2 skeletons into fighters, discarding on regroup.
     Heroes cleric and mage are interchangeable.
 
     Example: ability"""
-    return _convert_two(world, targets, source="skeleton", destination="fighter")
+    return _convert_two(world, targets, source=Dungeon.SKELETON, destination=Party.FIGHTER)
 
 
 def occultist_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Transform 1 skeleton into 1 fighter, discarding it on regroup.
 
     Example: ability"""
-    return _convert_one(world, targets, source="skeleton", destination="fighter")
+    return _convert_one(world, targets, source=Dungeon.SKELETON, destination=Party.FIGHTER)
 
 
 def paladin_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
 ) -> struct.World:
     """Consume treasure to clear dungeon, open chests, and quaff potions.
     Specify consumed treasure as first argument.
@@ -355,21 +355,22 @@ def paladin_ability(
     world = _consume_ability(world)
     # Validate that a treasure was specified
     if not targets:
-        raise DrollError(f"Treasure to consume required for {command}.")
+        raise DrollError(f"Treasure to consume required for {command.value}.")
 
     # Consume the specified treasure (will error if not possessed)
+    # targets[0] is an Artifact enum for paladin
     world = replace(world, treasure=replace_treasure(world.treasure, targets[0]))
 
     # Validate potion/revivable count before making changes
     if world.dungeon is not None:
-        if len(targets) - 1 != world.dungeon.potion:
+        if len(targets) - 1 != world.dungeon[Dungeon.POTION]:
             raise DrollError(
-                f"Exactly {world.dungeon.potion} heroes to revive required."
+                f"Exactly {world.dungeon[Dungeon.POTION]} heroes to revive required."
             )
 
         # Draw treasure for each chest
         treasure = world.treasure
-        for _ in range(world.dungeon.chest):
+        for _ in range(world.dungeon[Dungeon.CHEST]):
             treasure = draw_treasure(treasure, randrange)
         world = replace(world, treasure=treasure)
 
@@ -380,7 +381,7 @@ def paladin_ability(
         world = replace(world, party=party)
 
     # Clear the entire dungeon (all monsters, chests, potions, dragons)
-    world = replace(world, dungeon=struct.Dungeon())
+    world = replace(world, dungeon=struct.empty_dungeon())
 
     return world
 
@@ -388,10 +389,10 @@ def paladin_ability(
 def spellsword_ability(
     world: struct.World,
     randrange: struct.RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Action,
+    targets: tuple[Dungeon | Party, ...] = (),
     *,
-    _acceptable_targets: frozenset[str] = frozenset({"fighter", "mage"}),
+    _acceptable_targets: frozenset[Party] = frozenset({Party.FIGHTER, Party.MAGE}),
 ) -> struct.World:
     """Add 1 fighter or mage to the party.
 

--- a/droll/dice.py
+++ b/droll/dice.py
@@ -3,9 +3,15 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Functionality associated with rolling dungeon and party dice."""
 
-from dataclasses import fields
-
-from .struct import Dungeon, Party, RandRange, Regroup
+from .struct import (
+    Dungeon,
+    DungeonState,
+    Party,
+    PartyState,
+    RandRange,
+    Regroup,
+    frozen,
+)
 
 __all__ = (
     "roll_dungeon",
@@ -22,20 +28,20 @@ def _roll(dice: int, start: int, stop: int, randrange: RandRange) -> list[int]:
     return result
 
 
-def roll_dungeon(dice: int, randrange: RandRange) -> Dungeon:
+def roll_dungeon(dice: int, randrange: RandRange) -> DungeonState:
     """Roll a new Dungeon using given number of dice.
 
     Any implementation must follow type signature of RollDungeon.
     On Dungeon N one should account for the number of extant dragons."""
     assert dice >= 1, f"At least one dice required (requested {dice})"
-    return Dungeon(*_roll(dice, 0, len(fields(Dungeon)), randrange))
+    return frozen(dict(zip(Dungeon, _roll(dice, 0, len(Dungeon), randrange))))
 
 
-def roll_party(dice: int, randrange: RandRange) -> tuple[Party, Regroup]:
+def roll_party(dice: int, randrange: RandRange) -> tuple[PartyState, Regroup]:
     """Roll a new Party using given number of dice.
 
     Any implementation must follow type signature of RollParty."""
     return (
-        Party(*_roll(dice, 0, len(fields(Party)), randrange)),
+        frozen(dict(zip(Party, _roll(dice, 0, len(Party), randrange)))),
         Regroup(),
     )

--- a/droll/display.py
+++ b/droll/display.py
@@ -3,10 +3,11 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Compact display formatting for the experimental CLI mode."""
 
-from enum import Enum
+import enum
 from typing import Any, Optional, Sequence
 
 from . import struct
+from .struct import Dungeon
 
 __all__ = (
     "DisplayMode",
@@ -14,7 +15,7 @@ __all__ = (
 )
 
 
-class DisplayMode(Enum):
+class DisplayMode(enum.Enum):
     """Display mode for the droll CLI."""
 
     CURRENT = "current"
@@ -22,35 +23,35 @@ class DisplayMode(Enum):
 
 
 # Dragons always show count (tracking them is crucial to gameplay)
-_ALWAYS_COUNT = frozenset({"dragon"})
+_ALWAYS_COUNT = frozenset({Dungeon.DRAGON})
 
 
 def _format_item(name: str, count: int, discard: int = 0) -> Optional[str]:
     """Format a single item, returning None if count is zero."""
     if not count:
         return None
-    counted = count > 1 or name in _ALWAYS_COUNT
+    counted = count > 1 or name in {d.value for d in _ALWAYS_COUNT}
     if discard:
         return f"{name}×{count}~{discard}" if counted else f"{name}~{discard}"
     return f"{name}×{count}" if counted else name
 
 
-def _format_items(counts: Any, discards: Any = None) -> str:
-    """Format dataclass fields as 'name' or 'name×N' or 'name×N-M'."""
+def _format_mapping(counts: Any, discards: Any = None) -> str:
+    """Format mapping fields as 'name' or 'name×N' or 'name×N-M'."""
     if discards is None:
-        parts = (_format_item(n, c) for n, c in struct.field_items(counts))
+        parts = (_format_item(k.value, v) for k, v in counts.items())
     else:
         parts = (
-            _format_item(n, getattr(counts, n), getattr(discards, n))
-            for n in struct.field_names(counts)
+            _format_item(k.value, counts[k], discards[k])
+            for k in counts
         )
     return " ".join(filter(None, parts)) or "(empty)"
 
 
-def _format_treasure(artifacts: struct.Artifacts) -> str:
+def _format_treasure(artifacts: struct.ArtifactCounts) -> str:
     """Format treasure alphabetically."""
     parts = (
-        _format_item(n, c) for n, c in sorted(struct.field_items(artifacts))
+        _format_item(k.value, v) for k, v in sorted(artifacts.items(), key=lambda kv: kv[0].value)
     )
     return " ".join(filter(None, parts)) or "(empty)"
 
@@ -67,22 +68,22 @@ def _format_available(
 
 
 def _format_party(
-    party: struct.Party,
-    discard: struct.Party,
+    party: struct.PartyState,
+    discard: struct.PartyState,
 ) -> Optional[str]:
     """Format party contents, returning None if empty."""
-    if not any(struct.field_values(party)):
+    if not any(party.values()):
         return None
-    return _format_items(counts=party, discards=discard)
+    return _format_mapping(counts=party, discards=discard)
 
 
 def _format_dungeon(
-    dungeon: Optional[struct.Dungeon],
+    dungeon: Optional[struct.DungeonState],
 ) -> str:
     """Format dungeon contents, always returning a displayable string."""
     if dungeon is None:
         return "(empty)"
-    return _format_items(dungeon)
+    return _format_mapping(dungeon)
 
 
 def compact_summary(
@@ -120,3 +121,7 @@ def compact_summary(
     lines.append(f"{'Dungeon:':<{width}} {dungeon_str}")
 
     return "\n".join(lines)
+
+
+# Keep old names as aliases for backward compatibility in tests
+_format_items = _format_mapping

--- a/droll/dungeon.py
+++ b/droll/dungeon.py
@@ -3,10 +3,9 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Functionality associated with dungeon state and dungeon mechanics."""
 
-from dataclasses import replace
 from typing import Optional
 
-from .struct import DrollError, Dungeon, field_names, field_values
+from .struct import DrollError, Dungeon, DungeonState, frozen
 
 __all__ = (
     "DRAGON_BLOCKING_THRESHOLD",
@@ -19,66 +18,55 @@ __all__ = (
     "increment_dungeon",
 )
 
-_DUNGEON_FIELDS = frozenset(field_names(Dungeon))
-
-
-def _check_dungeon_target(target: str) -> None:
-    if target not in _DUNGEON_FIELDS:
-        raise DrollError(f"Unknown dungeon target '{target}'.")
-
 # A dragon blocks progress when this many or more dragon dice are present.
 DRAGON_BLOCKING_THRESHOLD = 3
 
 
-def defeated_monsters(dungeon: Optional[Dungeon]) -> bool:
+def defeated_monsters(dungeon: Optional[DungeonState]) -> bool:
     """Are all non-dragon monsters on this dungeon defeated?"""
     return (dungeon is None) or (
-        dungeon.goblin + dungeon.skeleton + dungeon.ooze
+        dungeon[Dungeon.GOBLIN] + dungeon[Dungeon.SKELETON] + dungeon[Dungeon.OOZE]
     ) == 0
 
 
-def defeated_dungeon(dungeon: Optional[Dungeon]) -> bool:
+def defeated_dungeon(dungeon: Optional[DungeonState]) -> bool:
     """Are all monsters and any dragon on this dungeon defeated?"""
     return (dungeon is None) or (
-        defeated_monsters(dungeon) and dungeon.dragon < DRAGON_BLOCKING_THRESHOLD
+        defeated_monsters(dungeon) and dungeon[Dungeon.DRAGON] < DRAGON_BLOCKING_THRESHOLD
     )
 
 
-def blocking_dragon(dungeon: Dungeon) -> bool:
+def blocking_dragon(dungeon: DungeonState) -> bool:
     """Is a dragon blocking progress to the next level?"""
     return defeated_monsters(dungeon) and not defeated_dungeon(dungeon)
 
 
-def finished_dungeon(dungeon: Optional[Dungeon]) -> bool:
+def finished_dungeon(dungeon: Optional[DungeonState]) -> bool:
     """Has the player exhausted all possible actions for this dungeon?
 
     In contrast to defeated_dungeon(...), returns True if chests/etc remain."""
     return (dungeon is None) or (
-        (sum(field_values(dungeon)) - dungeon.dragon == 0)
+        (sum(dungeon.values()) - dungeon[Dungeon.DRAGON] == 0)
         and not blocking_dragon(dungeon)
     )
 
 
-def decrement_dungeon(dungeon: Dungeon, target: str) -> Dungeon:
+def decrement_dungeon(dungeon: DungeonState, target: Dungeon) -> DungeonState:
     """Decrease the count of the specified target type by one."""
-    _check_dungeon_target(target)
-    prior_targets = getattr(dungeon, target)
+    prior_targets = dungeon[target]
     if not prior_targets:
-        raise DrollError(f"At least 1 {target} required in dungeon.")
-    return replace(dungeon, **{target: prior_targets - 1})
+        raise DrollError(f"At least 1 {target.value} required in dungeon.")
+    return frozen({**dungeon, target: prior_targets - 1})
 
 
-def increment_dungeon(dungeon: Dungeon, target: str) -> Dungeon:
+def increment_dungeon(dungeon: DungeonState, target: Dungeon) -> DungeonState:
     """Increase the count of the specified target type by one."""
-    _check_dungeon_target(target)
-    prior_targets = getattr(dungeon, target, 0)
-    return replace(dungeon, **{target: prior_targets + 1})
+    return frozen({**dungeon, target: dungeon[target] + 1})
 
 
-def eliminate_dungeon(dungeon: Dungeon, target: str) -> Dungeon:
+def eliminate_dungeon(dungeon: DungeonState, target: Dungeon) -> DungeonState:
     """Remove all targets of the specified type from the dungeon."""
-    _check_dungeon_target(target)
-    prior_targets = getattr(dungeon, target)
+    prior_targets = dungeon[target]
     if not prior_targets:
-        raise DrollError(f"At least 1 {target} required in dungeon.")
-    return replace(dungeon, **{target: 0})
+        raise DrollError(f"At least 1 {target.value} required in dungeon.")
+    return frozen({**dungeon, target: 0})

--- a/droll/heroes/crusader.py
+++ b/droll/heroes/crusader.py
@@ -6,9 +6,10 @@
 from dataclasses import replace
 from functools import partial
 
-from .. import regular, struct
+from .. import regular
 from ..ability import crusader_ability, paladin_ability
 from ..player import Default
+from ..struct import Dungeon, Party, frozen
 
 __all__ = (
     "Crusader",
@@ -20,7 +21,7 @@ _crusader_defeat_dragon = partial(
     regular.defeat_dragon,
     hero_validator=partial(
         regular.defeat_dragon_heroes,
-        interchangeable=frozenset({"fighter", "cleric"}),
+        interchangeable=frozenset({Party.FIGHTER, Party.CLERIC}),
     ),
 )
 
@@ -30,34 +31,34 @@ Paladin = replace(
     name="Paladin",
     ability=paladin_ability,
     advance=(lambda _: Paladin),
-    party=struct.Party(
-        fighter=replace(
-            Default.party.fighter,
-            dragon=_crusader_defeat_dragon,
-            skeleton=Default.party.cleric.skeleton,
-        ),
-        cleric=replace(
-            Default.party.cleric,
-            dragon=_crusader_defeat_dragon,
-            goblin=Default.party.fighter.goblin,
-        ),
-        mage=replace(
-            Default.party.mage,
-            dragon=_crusader_defeat_dragon,
-        ),
-        thief=replace(
-            Default.party.thief,
-            dragon=_crusader_defeat_dragon,
-        ),
-        champion=replace(
-            Default.party.champion,
-            dragon=_crusader_defeat_dragon,
-        ),
-        scroll=replace(
-            Default.party.scroll,
-            dragon=_crusader_defeat_dragon,
-        ),
-    ),
+    party=frozen({
+        Party.FIGHTER: frozen({
+            **Default.party[Party.FIGHTER],
+            Dungeon.DRAGON: _crusader_defeat_dragon,
+            Dungeon.SKELETON: Default.party[Party.CLERIC][Dungeon.SKELETON],
+        }),
+        Party.CLERIC: frozen({
+            **Default.party[Party.CLERIC],
+            Dungeon.DRAGON: _crusader_defeat_dragon,
+            Dungeon.GOBLIN: Default.party[Party.FIGHTER][Dungeon.GOBLIN],
+        }),
+        Party.MAGE: frozen({
+            **Default.party[Party.MAGE],
+            Dungeon.DRAGON: _crusader_defeat_dragon,
+        }),
+        Party.THIEF: frozen({
+            **Default.party[Party.THIEF],
+            Dungeon.DRAGON: _crusader_defeat_dragon,
+        }),
+        Party.CHAMPION: frozen({
+            **Default.party[Party.CHAMPION],
+            Dungeon.DRAGON: _crusader_defeat_dragon,
+        }),
+        Party.SCROLL: frozen({
+            **Default.party[Party.SCROLL],
+            Dungeon.DRAGON: _crusader_defeat_dragon,
+        }),
+    }),
 )
 
 # Defined after Paladin to permit advance(...) closure

--- a/droll/heroes/enchantress.py
+++ b/droll/heroes/enchantress.py
@@ -6,9 +6,10 @@
 from dataclasses import replace
 from functools import partial
 
-from .. import regular, struct
+from .. import regular
 from ..ability import beguiler_ability, enchantress_ability
 from ..player import Default
+from ..struct import Dungeon, Party, frozen
 
 __all__ = (
     "Beguiler",
@@ -21,7 +22,7 @@ _beguiler_defeat_dragon = partial(
     hero_validator=partial(
         regular.defeat_dragon_heroes,
         disallowed_heroes=frozenset(),
-        wildcard=frozenset({"scroll"}),
+        wildcard=frozenset({Party.SCROLL}),
     ),
 )
 
@@ -31,18 +32,18 @@ Beguiler = replace(
     name="Beguiler",
     ability=beguiler_ability,
     advance=(lambda _: Beguiler),
-    party=replace(
-        Default.party,
+    party=frozen({
+        **Default.party,
         # Scrolls act offensively (defeat enemies, not re-roll)
-        scroll=struct.Dungeon(
-            goblin=regular.defeat_all,
-            skeleton=regular.defeat_all,
-            ooze=regular.defeat_all,
-            chest=regular.open_all,
-            potion=regular.quaff,
-            dragon=_beguiler_defeat_dragon,
-        ),
-    ),
+        Party.SCROLL: frozen({
+            Dungeon.GOBLIN: regular.defeat_all,
+            Dungeon.SKELETON: regular.defeat_all,
+            Dungeon.OOZE: regular.defeat_all,
+            Dungeon.CHEST: regular.open_all,
+            Dungeon.POTION: regular.quaff,
+            Dungeon.DRAGON: _beguiler_defeat_dragon,
+        }),
+    }),
 )
 
 # Defined after Beguiler to permit advance(...) closure

--- a/droll/heroes/halfgoblin.py
+++ b/droll/heroes/halfgoblin.py
@@ -9,6 +9,7 @@ from functools import partial
 from .. import regular
 from ..ability import chieftain_ability, halfgoblin_ability
 from ..player import Default
+from ..struct import Dungeon, Party, frozen
 
 __all__ = (
     "Chieftain",
@@ -35,38 +36,37 @@ Chieftain = replace(
     name="Chieftain",
     ability=chieftain_ability,
     advance=(lambda _: Chieftain),
-    party=replace(
-        Default.party,
-        fighter=replace(
-            Default.party.fighter,
-            chest=_halfgoblin_open_one,
-            potion=_halfgoblin_quaff,
-        ),
-        cleric=replace(
-            Default.party.cleric,
-            chest=_halfgoblin_open_one,
-            potion=_halfgoblin_quaff,
-        ),
-        mage=replace(
-            Default.party.mage,
-            chest=_halfgoblin_open_one,
-            potion=_halfgoblin_quaff,
-        ),
-        thief=replace(
-            Default.party.thief,
-            chest=_halfgoblin_open_all,
-            potion=_halfgoblin_quaff,
-        ),
-        champion=replace(
-            Default.party.champion,
-            chest=_halfgoblin_open_all,
-            potion=_halfgoblin_quaff,
-        ),
-        scroll=replace(
-            Default.party.scroll,
-            potion=_halfgoblin_quaff,
-        ),
-    ),
+    party=frozen({
+        Party.FIGHTER: frozen({
+            **Default.party[Party.FIGHTER],
+            Dungeon.CHEST: _halfgoblin_open_one,
+            Dungeon.POTION: _halfgoblin_quaff,
+        }),
+        Party.CLERIC: frozen({
+            **Default.party[Party.CLERIC],
+            Dungeon.CHEST: _halfgoblin_open_one,
+            Dungeon.POTION: _halfgoblin_quaff,
+        }),
+        Party.MAGE: frozen({
+            **Default.party[Party.MAGE],
+            Dungeon.CHEST: _halfgoblin_open_one,
+            Dungeon.POTION: _halfgoblin_quaff,
+        }),
+        Party.THIEF: frozen({
+            **Default.party[Party.THIEF],
+            Dungeon.CHEST: _halfgoblin_open_all,
+            Dungeon.POTION: _halfgoblin_quaff,
+        }),
+        Party.CHAMPION: frozen({
+            **Default.party[Party.CHAMPION],
+            Dungeon.CHEST: _halfgoblin_open_all,
+            Dungeon.POTION: _halfgoblin_quaff,
+        }),
+        Party.SCROLL: frozen({
+            **Default.party[Party.SCROLL],
+            Dungeon.POTION: _halfgoblin_quaff,
+        }),
+    }),
 )
 
 # Defined after Chieftain to permit advance(...) closure

--- a/droll/heroes/knight.py
+++ b/droll/heroes/knight.py
@@ -6,9 +6,10 @@
 from dataclasses import replace
 from functools import partial
 
-from .. import dice, regular, struct
+from .. import dice, regular
 from ..ability import dragonslayer_ability, knight_ability
 from ..player import Default
+from ..struct import Dungeon, Party, RandRange, PartyState, Regroup, frozen
 
 __all__ = (
     "DragonSlayer",
@@ -17,12 +18,12 @@ __all__ = (
 
 
 def _knight_roll_party(
-    count: int, randrange: struct.RandRange
-) -> tuple[struct.Party, struct.Regroup]:
+    count: int, randrange: RandRange
+) -> tuple[PartyState, Regroup]:
     """Roll a new Party, changing all Scrolls into Champions."""
     default, regroup = dice.roll_party(dice=count, randrange=randrange)
     return (
-        replace(default, scroll=0, champion=default.champion + default.scroll),
+        frozen({**default, Party.SCROLL: 0, Party.CHAMPION: default[Party.CHAMPION] + default[Party.SCROLL]}),
         regroup,
     )
 
@@ -40,32 +41,32 @@ DragonSlayer = replace(
     ability=dragonslayer_ability,
     advance=(lambda _: DragonSlayer),
     roll=replace(Default.roll, party=_knight_roll_party),
-    party=struct.Party(
-        fighter=replace(
-            Default.party.fighter,
-            dragon=_dragonslayer_defeat_dragon,
-        ),
-        cleric=replace(
-            Default.party.cleric,
-            dragon=_dragonslayer_defeat_dragon,
-        ),
-        mage=replace(
-            Default.party.mage,
-            dragon=_dragonslayer_defeat_dragon,
-        ),
-        thief=replace(
-            Default.party.thief,
-            dragon=_dragonslayer_defeat_dragon,
-        ),
-        champion=replace(
-            Default.party.champion,
-            dragon=_dragonslayer_defeat_dragon,
-        ),
-        scroll=replace(
-            Default.party.scroll,
-            dragon=_dragonslayer_defeat_dragon,
-        ),
-    ),
+    party=frozen({
+        Party.FIGHTER: frozen({
+            **Default.party[Party.FIGHTER],
+            Dungeon.DRAGON: _dragonslayer_defeat_dragon,
+        }),
+        Party.CLERIC: frozen({
+            **Default.party[Party.CLERIC],
+            Dungeon.DRAGON: _dragonslayer_defeat_dragon,
+        }),
+        Party.MAGE: frozen({
+            **Default.party[Party.MAGE],
+            Dungeon.DRAGON: _dragonslayer_defeat_dragon,
+        }),
+        Party.THIEF: frozen({
+            **Default.party[Party.THIEF],
+            Dungeon.DRAGON: _dragonslayer_defeat_dragon,
+        }),
+        Party.CHAMPION: frozen({
+            **Default.party[Party.CHAMPION],
+            Dungeon.DRAGON: _dragonslayer_defeat_dragon,
+        }),
+        Party.SCROLL: frozen({
+            **Default.party[Party.SCROLL],
+            Dungeon.DRAGON: _dragonslayer_defeat_dragon,
+        }),
+    }),
 )
 
 # Defined after DragonSlayer to permit advance(...) closure

--- a/droll/heroes/mercenary.py
+++ b/droll/heroes/mercenary.py
@@ -5,9 +5,10 @@
 
 from dataclasses import replace
 
-from .. import dice, special, struct
+from .. import dice, special
 from ..ability import commander_ability, mercenary_ability
 from ..player import Default
+from ..struct import Dungeon, Party, RandRange, PartyState, Regroup, frozen
 
 __all__ = (
     "Commander",
@@ -16,13 +17,13 @@ __all__ = (
 
 
 def _mercenary_roll_party(
-    count: int, randrange: struct.RandRange
-) -> tuple[struct.Party, struct.Regroup]:
+    count: int, randrange: RandRange
+) -> tuple[PartyState, Regroup]:
     """Roll a new Party, adding one bonus scroll discarded on regroup."""
     party, regroup = dice.roll_party(dice=count, randrange=randrange)
     return (
-        replace(party, scroll=party.scroll + 1),
-        replace(regroup, discard=replace(regroup.discard, scroll=1)),
+        frozen({**party, Party.SCROLL: party[Party.SCROLL] + 1}),
+        replace(regroup, discard=frozen({**regroup.discard, Party.SCROLL: 1})),
     )
 
 
@@ -33,15 +34,15 @@ Commander = replace(
     ability=commander_ability,
     advance=(lambda _: Commander),
     roll=replace(Default.roll, party=_mercenary_roll_party),
-    party=replace(
-        Default.party,
-        fighter=replace(
-            Default.party.fighter,
-            goblin=special.defeat_all_plus_additional,
-            skeleton=special.defeat_one_plus_additional,
-            ooze=special.defeat_one_plus_additional,
-        ),
-    ),
+    party=frozen({
+        **Default.party,
+        Party.FIGHTER: frozen({
+            **Default.party[Party.FIGHTER],
+            Dungeon.GOBLIN: special.defeat_all_plus_additional,
+            Dungeon.SKELETON: special.defeat_one_plus_additional,
+            Dungeon.OOZE: special.defeat_one_plus_additional,
+        }),
+    }),
 )
 
 # Defined after Commander to permit advance(...) closure

--- a/droll/heroes/minstrel.py
+++ b/droll/heroes/minstrel.py
@@ -6,10 +6,11 @@
 from dataclasses import replace
 from functools import partial
 
-from .. import special, struct
+from .. import special
 from ..ability import bard_ability, minstrel_ability
 from ..player import Default
 from ..regular import defeat_dragon, defeat_dragon_heroes
+from ..struct import Dungeon, Party, frozen
 
 __all__ = (
     "Bard",
@@ -21,39 +22,39 @@ _minstrel_defeat_dragon = partial(
     defeat_dragon,
     hero_validator=partial(
         defeat_dragon_heroes,
-        interchangeable=frozenset({"mage", "thief"}),
+        interchangeable=frozenset({Party.MAGE, Party.THIEF}),
     ),
 )
 
 # Building block: dragon defeat + mage/thief interchangeability in combat
-_Minstrel_Party = struct.Party(
-    fighter=replace(
-        Default.party.fighter,
-        dragon=_minstrel_defeat_dragon,
-    ),
-    cleric=replace(
-        Default.party.cleric,
-        dragon=_minstrel_defeat_dragon,
-    ),
-    mage=replace(
-        Default.party.mage,
-        chest=Default.party.thief.chest,
-        dragon=_minstrel_defeat_dragon,
-    ),
-    thief=replace(
-        Default.party.thief,
-        dragon=_minstrel_defeat_dragon,
-        ooze=Default.party.mage.ooze,
-    ),
-    champion=replace(
-        Default.party.champion,
-        dragon=_minstrel_defeat_dragon,
-    ),
-    scroll=replace(
-        Default.party.scroll,
-        dragon=_minstrel_defeat_dragon,
-    ),
-)
+_minstrel_party = frozen({
+    Party.FIGHTER: frozen({
+        **Default.party[Party.FIGHTER],
+        Dungeon.DRAGON: _minstrel_defeat_dragon,
+    }),
+    Party.CLERIC: frozen({
+        **Default.party[Party.CLERIC],
+        Dungeon.DRAGON: _minstrel_defeat_dragon,
+    }),
+    Party.MAGE: frozen({
+        **Default.party[Party.MAGE],
+        Dungeon.CHEST: Default.party[Party.THIEF][Dungeon.CHEST],
+        Dungeon.DRAGON: _minstrel_defeat_dragon,
+    }),
+    Party.THIEF: frozen({
+        **Default.party[Party.THIEF],
+        Dungeon.DRAGON: _minstrel_defeat_dragon,
+        Dungeon.OOZE: Default.party[Party.MAGE][Dungeon.OOZE],
+    }),
+    Party.CHAMPION: frozen({
+        **Default.party[Party.CHAMPION],
+        Dungeon.DRAGON: _minstrel_defeat_dragon,
+    }),
+    Party.SCROLL: frozen({
+        **Default.party[Party.SCROLL],
+        Dungeon.DRAGON: _minstrel_defeat_dragon,
+    }),
+})
 
 # Defined in terms of Default, not Minstrel, to permit advance(...) closure
 Bard = replace(
@@ -61,16 +62,16 @@ Bard = replace(
     name="Bard",
     ability=bard_ability,
     advance=(lambda _: Bard),  # Cannot advance further
-    party=replace(
-        _Minstrel_Party,
-        champion=replace(
-            _Minstrel_Party.champion,
+    party=frozen({
+        **_minstrel_party,
+        Party.CHAMPION: frozen({
+            **_minstrel_party[Party.CHAMPION],
             # Champions defeat one additional monster when attacking monsters
-            goblin=special.defeat_all_plus_additional,
-            skeleton=special.defeat_all_plus_additional,
-            ooze=special.defeat_all_plus_additional,
-        ),
-    ),
+            Dungeon.GOBLIN: special.defeat_all_plus_additional,
+            Dungeon.SKELETON: special.defeat_all_plus_additional,
+            Dungeon.OOZE: special.defeat_all_plus_additional,
+        }),
+    }),
 )
 
 # Defined after Bard to permit advance(...) closure
@@ -79,5 +80,5 @@ Minstrel = replace(
     name="Minstrel",
     ability=minstrel_ability,
     advance=(lambda world: Minstrel if world.experience < 5 else Bard),
-    party=_Minstrel_Party,
+    party=_minstrel_party,
 )

--- a/droll/heroes/occultist.py
+++ b/droll/heroes/occultist.py
@@ -9,6 +9,7 @@ from functools import partial
 from ..ability import necromancer_ability, occultist_ability
 from ..player import Default
 from ..regular import defeat_dragon, defeat_dragon_heroes
+from ..struct import Dungeon, Party, frozen
 
 __all__ = (
     "Necromancer",
@@ -20,7 +21,7 @@ _occultist_defeat_dragon = partial(
     defeat_dragon,
     hero_validator=partial(
         defeat_dragon_heroes,
-        interchangeable=frozenset({"cleric", "mage"}),
+        interchangeable=frozenset({Party.CLERIC, Party.MAGE}),
     ),
 )
 
@@ -30,35 +31,34 @@ Necromancer = replace(
     name="Necromancer",
     ability=necromancer_ability,
     advance=(lambda _: Necromancer),
-    party=replace(
-        Default.party,
-        fighter=replace(
-            Default.party.fighter,
-            dragon=_occultist_defeat_dragon,
-        ),
-        cleric=replace(
-            Default.party.cleric,
-            dragon=_occultist_defeat_dragon,
-            ooze=Default.party.mage.ooze,
-        ),
-        mage=replace(
-            Default.party.mage,
-            dragon=_occultist_defeat_dragon,
-            skeleton=Default.party.cleric.skeleton,
-        ),
-        thief=replace(
-            Default.party.thief,
-            dragon=_occultist_defeat_dragon,
-        ),
-        champion=replace(
-            Default.party.champion,
-            dragon=_occultist_defeat_dragon,
-        ),
-        scroll=replace(
-            Default.party.scroll,
-            dragon=_occultist_defeat_dragon,
-        ),
-    ),
+    party=frozen({
+        Party.FIGHTER: frozen({
+            **Default.party[Party.FIGHTER],
+            Dungeon.DRAGON: _occultist_defeat_dragon,
+        }),
+        Party.CLERIC: frozen({
+            **Default.party[Party.CLERIC],
+            Dungeon.DRAGON: _occultist_defeat_dragon,
+            Dungeon.OOZE: Default.party[Party.MAGE][Dungeon.OOZE],
+        }),
+        Party.MAGE: frozen({
+            **Default.party[Party.MAGE],
+            Dungeon.DRAGON: _occultist_defeat_dragon,
+            Dungeon.SKELETON: Default.party[Party.CLERIC][Dungeon.SKELETON],
+        }),
+        Party.THIEF: frozen({
+            **Default.party[Party.THIEF],
+            Dungeon.DRAGON: _occultist_defeat_dragon,
+        }),
+        Party.CHAMPION: frozen({
+            **Default.party[Party.CHAMPION],
+            Dungeon.DRAGON: _occultist_defeat_dragon,
+        }),
+        Party.SCROLL: frozen({
+            **Default.party[Party.SCROLL],
+            Dungeon.DRAGON: _occultist_defeat_dragon,
+        }),
+    }),
 )
 
 # Defined after Necromancer to permit advance(...) closure

--- a/droll/heroes/spellsword.py
+++ b/droll/heroes/spellsword.py
@@ -9,6 +9,7 @@ from functools import partial
 from .. import regular
 from ..ability import battlemage_ability, spellsword_ability
 from ..player import Default
+from ..struct import Dungeon, Party, frozen
 
 __all__ = (
     "Battlemage",
@@ -20,7 +21,7 @@ _spellsword_defeat_dragon = partial(
     regular.defeat_dragon,
     hero_validator=partial(
         regular.defeat_dragon_heroes,
-        interchangeable=frozenset({"fighter", "mage"}),
+        interchangeable=frozenset({Party.FIGHTER, Party.MAGE}),
     ),
 )
 
@@ -31,35 +32,34 @@ Battlemage = replace(
     name="Battlemage",
     ability=battlemage_ability,
     advance=(lambda _: Battlemage),
-    party=replace(
-        Default.party,
-        fighter=replace(
-            Default.party.fighter,
-            dragon=_spellsword_defeat_dragon,
-            ooze=Default.party.mage.ooze,
-        ),
-        cleric=replace(
-            Default.party.cleric,
-            dragon=_spellsword_defeat_dragon,
-        ),
-        mage=replace(
-            Default.party.mage,
-            dragon=_spellsword_defeat_dragon,
-            goblin=Default.party.fighter.goblin,
-        ),
-        thief=replace(
-            Default.party.thief,
-            dragon=_spellsword_defeat_dragon,
-        ),
-        champion=replace(
-            Default.party.champion,
-            dragon=_spellsword_defeat_dragon,
-        ),
-        scroll=replace(
-            Default.party.scroll,
-            dragon=_spellsword_defeat_dragon,
-        ),
-    ),
+    party=frozen({
+        Party.FIGHTER: frozen({
+            **Default.party[Party.FIGHTER],
+            Dungeon.DRAGON: _spellsword_defeat_dragon,
+            Dungeon.OOZE: Default.party[Party.MAGE][Dungeon.OOZE],
+        }),
+        Party.CLERIC: frozen({
+            **Default.party[Party.CLERIC],
+            Dungeon.DRAGON: _spellsword_defeat_dragon,
+        }),
+        Party.MAGE: frozen({
+            **Default.party[Party.MAGE],
+            Dungeon.DRAGON: _spellsword_defeat_dragon,
+            Dungeon.GOBLIN: Default.party[Party.FIGHTER][Dungeon.GOBLIN],
+        }),
+        Party.THIEF: frozen({
+            **Default.party[Party.THIEF],
+            Dungeon.DRAGON: _spellsword_defeat_dragon,
+        }),
+        Party.CHAMPION: frozen({
+            **Default.party[Party.CHAMPION],
+            Dungeon.DRAGON: _spellsword_defeat_dragon,
+        }),
+        Party.SCROLL: frozen({
+            **Default.party[Party.SCROLL],
+            Dungeon.DRAGON: _spellsword_defeat_dragon,
+        }),
+    }),
 )
 
 # Defined after Battlemage to permit advance(...) closure

--- a/droll/party.py
+++ b/droll/party.py
@@ -5,7 +5,7 @@
 
 from dataclasses import replace
 
-from .struct import DrollError, Party, Regroup, field_names
+from .struct import DrollError, Party, PartyState, Regroup, frozen
 
 __all__ = (
     "decrement_party",
@@ -13,33 +13,23 @@ __all__ = (
     "increment_party",
 )
 
-_PARTY_FIELDS = frozenset(field_names(Party))
 
-
-def _check_party_member(hero: str) -> None:
-    if hero not in _PARTY_FIELDS:
-        raise DrollError(f"Unknown party member '{hero}'.")
-
-
-def decrement_party(party: Party, hero: str) -> Party:
+def decrement_party(party: PartyState, hero: Party) -> PartyState:
     """Decrease the count of the specified hero type by one."""
-    _check_party_member(hero)
-    prior_heroes = getattr(party, hero)
+    prior_heroes = party[hero]
     if not prior_heroes:
-        raise DrollError(f"At least 1 {hero} required in party.")
-    return replace(party, **{hero: prior_heroes - 1})
+        raise DrollError(f"At least 1 {hero.value} required in party.")
+    return frozen({**party, hero: prior_heroes - 1})
 
 
-def decrement_regroup(regroup: Regroup, hero: str) -> Regroup:
+def decrement_regroup(regroup: Regroup, hero: Party) -> Regroup:
     """Decrement the regroup discard counter for hero, if positive."""
-    _check_party_member(hero)
-    prior = getattr(regroup.discard, hero, 0)
+    prior = regroup.discard[hero]
     return replace(
-        regroup, discard=replace(regroup.discard, **{hero: max(0, prior - 1)})
+        regroup, discard=frozen({**regroup.discard, hero: max(0, prior - 1)})
     )
 
 
-def increment_party(party: Party, hero: str) -> Party:
+def increment_party(party: PartyState, hero: Party) -> PartyState:
     """Increase the count of the specified hero type by one."""
-    _check_party_member(hero)
-    return replace(party, **{hero: getattr(party, hero) + 1})
+    return frozen({**party, hero: party[hero] + 1})

--- a/droll/player.py
+++ b/droll/player.py
@@ -5,6 +5,7 @@
 
 from collections.abc import Sequence
 from dataclasses import replace
+from typing import Union
 
 from . import ability, dice, regular, struct
 from .struct import (
@@ -115,7 +116,7 @@ def _adjust_phantom_treasures(world, artifacts, treasure, sign):
     )
 
 
-def _parse_token(token: str) -> Dungeon | Party | Artifact | Action:
+def _parse_token(token: str) -> Union[Dungeon, Party, Artifact, Action]:
     """Convert a string token to the appropriate enum."""
     # Try Action first (ability, bait, elixir, reroll)
     try:

--- a/droll/player.py
+++ b/droll/player.py
@@ -7,7 +7,14 @@ from collections.abc import Sequence
 from dataclasses import replace
 
 from . import ability, dice, regular, struct
-from .struct import DrollError
+from .struct import (
+    Action,
+    Artifact,
+    Dungeon,
+    DrollError,
+    Party,
+    frozen,
+)
 from .treasure import replace_treasure
 
 __all__ = (
@@ -31,67 +38,67 @@ Default = struct.Player(
     # Behavior at specific lifecycle events?
     roll=struct.Roll(dungeon=dice.roll_dungeon, party=dice.roll_party),
     # How do artifacts map to heroes?
-    artifacts=struct.Party(
-        fighter="sword",
-        cleric="talisman",
-        mage="sceptre",
-        thief="tools",
-        champion=None,
-        scroll="scroll",
-    ),
+    artifacts=frozen({
+        Party.FIGHTER: Artifact.SWORD,
+        Party.CLERIC: Artifact.TALISMAN,
+        Party.MAGE: Artifact.SCEPTRE,
+        Party.THIEF: Artifact.TOOLS,
+        Party.CHAMPION: None,
+        Party.SCROLL: Artifact.SCROLL,
+    }),
     # What effect does each hero have on each enemy?
-    party=struct.Party(
-        fighter=struct.Dungeon(
-            goblin=regular.defeat_all,
-            skeleton=regular.defeat_one,
-            ooze=regular.defeat_one,
-            chest=regular.open_one,
-            potion=regular.quaff,
-            dragon=regular.defeat_dragon,
-        ),
-        cleric=struct.Dungeon(
-            goblin=regular.defeat_one,
-            skeleton=regular.defeat_all,
-            ooze=regular.defeat_one,
-            chest=regular.open_one,
-            potion=regular.quaff,
-            dragon=regular.defeat_dragon,
-        ),
-        mage=struct.Dungeon(
-            goblin=regular.defeat_one,
-            skeleton=regular.defeat_one,
-            ooze=regular.defeat_all,
-            chest=regular.open_one,
-            potion=regular.quaff,
-            dragon=regular.defeat_dragon,
-        ),
-        thief=struct.Dungeon(
-            goblin=regular.defeat_one,
-            skeleton=regular.defeat_one,
-            ooze=regular.defeat_one,
-            chest=regular.open_all,
-            potion=regular.quaff,
-            dragon=regular.defeat_dragon,
-        ),
-        champion=struct.Dungeon(
-            goblin=regular.defeat_all,
-            skeleton=regular.defeat_all,
-            ooze=regular.defeat_all,
-            chest=regular.open_all,
-            potion=regular.quaff,
-            dragon=regular.defeat_dragon,
-        ),
+    party=frozen({
+        Party.FIGHTER: frozen({
+            Dungeon.GOBLIN: regular.defeat_all,
+            Dungeon.SKELETON: regular.defeat_one,
+            Dungeon.OOZE: regular.defeat_one,
+            Dungeon.CHEST: regular.open_one,
+            Dungeon.POTION: regular.quaff,
+            Dungeon.DRAGON: regular.defeat_dragon,
+        }),
+        Party.CLERIC: frozen({
+            Dungeon.GOBLIN: regular.defeat_one,
+            Dungeon.SKELETON: regular.defeat_all,
+            Dungeon.OOZE: regular.defeat_one,
+            Dungeon.CHEST: regular.open_one,
+            Dungeon.POTION: regular.quaff,
+            Dungeon.DRAGON: regular.defeat_dragon,
+        }),
+        Party.MAGE: frozen({
+            Dungeon.GOBLIN: regular.defeat_one,
+            Dungeon.SKELETON: regular.defeat_one,
+            Dungeon.OOZE: regular.defeat_all,
+            Dungeon.CHEST: regular.open_one,
+            Dungeon.POTION: regular.quaff,
+            Dungeon.DRAGON: regular.defeat_dragon,
+        }),
+        Party.THIEF: frozen({
+            Dungeon.GOBLIN: regular.defeat_one,
+            Dungeon.SKELETON: regular.defeat_one,
+            Dungeon.OOZE: regular.defeat_one,
+            Dungeon.CHEST: regular.open_all,
+            Dungeon.POTION: regular.quaff,
+            Dungeon.DRAGON: regular.defeat_dragon,
+        }),
+        Party.CHAMPION: frozen({
+            Dungeon.GOBLIN: regular.defeat_all,
+            Dungeon.SKELETON: regular.defeat_all,
+            Dungeon.OOZE: regular.defeat_all,
+            Dungeon.CHEST: regular.open_all,
+            Dungeon.POTION: regular.quaff,
+            Dungeon.DRAGON: regular.defeat_dragon,
+        }),
         # Scrolls re-roll via the 'reroll' command (see issue #133).
         # Using 'scroll' as a noun targets only quaff and dragon.
-        scroll=struct.Dungeon(
-            goblin=regular.not_reroll,
-            skeleton=regular.not_reroll,
-            ooze=regular.not_reroll,
-            chest=regular.not_reroll,
-            potion=regular.quaff,
-            dragon=regular.defeat_dragon,
-        ),
-    ),
+        Party.SCROLL: frozen({
+            Dungeon.GOBLIN: regular.not_reroll,
+            Dungeon.SKELETON: regular.not_reroll,
+            Dungeon.OOZE: regular.not_reroll,
+            Dungeon.CHEST: regular.not_reroll,
+            Dungeon.POTION: regular.quaff,
+            Dungeon.DRAGON: regular.defeat_dragon,
+        }),
+    }),
 )
 
 
@@ -99,16 +106,38 @@ def _adjust_phantom_treasures(world, artifacts, treasure, sign):
     """Add (+1) or remove (-1) treasure counts as phantom party members."""
     return replace(
         world,
-        party=replace(
-            world.party,
-            **{
-                hero: getattr(world.party, hero)
-                + sign * getattr(treasure, artifact)
-                for hero, artifact in struct.field_items(artifacts)
-                if artifact is not None
-            },
-        ),
+        party=frozen({
+            hero: world.party[hero] + (
+                sign * treasure[artifact] if artifact is not None else 0
+            )
+            for hero, artifact in artifacts.items()
+        }),
     )
+
+
+def _parse_token(token: str) -> Dungeon | Party | Artifact | Action:
+    """Convert a string token to the appropriate enum."""
+    # Try Action first (ability, bait, elixir, reroll)
+    try:
+        return Action(token)
+    except ValueError:
+        pass
+    # Try Party
+    try:
+        return Party(token)
+    except ValueError:
+        pass
+    # Try Dungeon
+    try:
+        return Dungeon(token)
+    except ValueError:
+        pass
+    # Try Artifact
+    try:
+        return Artifact(token)
+    except ValueError:
+        pass
+    raise DrollError(f'Unknown token "{token}".')
 
 
 def apply(
@@ -131,24 +160,38 @@ def apply(
             ' Just "descend" or "retire".'
         )
 
+    # Parse command token
+    cmd_enum = _parse_token(command)
+
     # Dispatch ability/bait/elixir before artifact-to-hero translation (#181).
     # These commands define their own target semantics (e.g. paladin_ability
     # expects a treasure name, not a hero name) so _partify_all is wrong here.
-    if command in {"ability", "bait", "elixir"}:
+    if isinstance(cmd_enum, Action) and cmd_enum in {Action.ABILITY, Action.BAIT, Action.ELIXIR}:
         try:
-            action_ = getattr(player, command)
-            return action_(world, randrange, command, targets)
-        except AttributeError as cause:
+            if cmd_enum is Action.ABILITY:
+                action_ = player.ability
+            elif cmd_enum is Action.BAIT:
+                action_ = player.bait
+            else:
+                action_ = player.elixir
+            # Parse targets: for ability, paladin expects Artifact targets
+            parsed_targets = tuple(_parse_token(t) for t in targets)
+            return action_(world, randrange, cmd_enum, parsed_targets)
+        except (AttributeError, TypeError, KeyError) as cause:
             if world.dungeon is None:
                 raise DrollError("You must descend first.") from cause
             raise DrollError(str(cause)) from cause
 
     # Reject artifact commands when the player doesn't own the treasure
-    if command in _ARTIFACT_COMMANDS and not getattr(world.treasure.own, command, 0):
-        raise DrollError(f"'{command}' not in player's treasure.")
+    if isinstance(cmd_enum, Artifact) and cmd_enum not in {Artifact.SCROLL}:
+        if not world.treasure.own.get(cmd_enum, 0):
+            raise DrollError(f"'{cmd_enum.value}' not in player's treasure.")
 
     # Convert artifact command name into corresponding hero type
-    command = _partify_command(player.artifacts, command)
+    hero = _partify_command(player.artifacts, cmd_enum)
+
+    # Parse targets
+    parsed_targets = tuple(_parse_token(t) for t in targets)
 
     # Temporarily inflate party with treasure-as-hero counts
     prior_own = world.treasure.own
@@ -156,111 +199,110 @@ def apply(
 
     # Dispatch: reroll always uses scroll mechanics;
     # everything else is hero-target
-    if command == "reroll":
-        world = regular.reroll(world, randrange, "scroll", targets)
+    if isinstance(cmd_enum, Action) and cmd_enum is Action.REROLL:
+        world = regular.reroll(world, randrange, Party.SCROLL, parsed_targets)
     else:
-        if command not in struct.field_names(player.party):
+        if hero not in player.party:
             raise DrollError(f'Unknown command "{command}".')
-        action_ = getattr(player.party, command)
-        if not targets:
+        hero_actions = player.party[hero]
+        if not parsed_targets:
             valid = [
-                name for name, _ in struct.field_items(action_)
-                if world.dungeon is not None and getattr(world.dungeon, name, 0)
+                d.value for d in Dungeon
+                if world.dungeon is not None and world.dungeon.get(d, 0)
             ]
             hint = f" Available: {', '.join(valid)}." if valid else ""
             raise DrollError(f'"{command}" requires a target.{hint}')
-        if targets[0] not in struct.field_names(action_):
+        target0 = parsed_targets[0]
+        if target0 not in hero_actions:
             raise DrollError(f'Unknown target "{targets[0]}".')
         if world.dungeon is None:
             raise DrollError("You must descend first.")
         try:
-            action_ = getattr(action_, targets[0])
-            world = action_(world, randrange, command, targets)
-        except (AttributeError, TypeError) as cause:
+            action_ = hero_actions[target0]
+            world = action_(world, randrange, hero, parsed_targets)
+        except (AttributeError, TypeError, KeyError) as cause:
             raise DrollError(str(cause)) from cause
 
     # Undo phantom inflation, then consume treasure for any artifacts spent
     world = _adjust_phantom_treasures(world, player.artifacts, prior_own, -1)
     treasure = world.treasure
     party_updates = {}
-    for hero, quantity in struct.field_items(world.party):
+    for hero_member, quantity in world.party.items():
         if quantity >= 0:
             continue
-        artifact = getattr(player.artifacts, hero)
+        artifact = player.artifacts[hero_member]
         for _ in range(-quantity):
             treasure = replace_treasure(treasure, artifact)
-        party_updates[hero] = 0
+        party_updates[hero_member] = 0
     if party_updates:
         world = replace(
             world,
-            party=replace(world.party, **party_updates),
+            party=frozen({**world.party, **party_updates}),
             treasure=treasure,
         )
 
     return world
 
 
-def _partify_command(artifacts: struct.Party, command: str) -> str:
-    """Convert an artifact name in the command to its hero name."""
-    reverse = {
-        artifact: hero
-        for hero, artifact in struct.field_items(artifacts)
-        if artifact is not None
-    }
-    return reverse.get(command, command)
+def _partify_command(artifacts: struct.ArtifactMapping, command) -> Party:
+    """Convert an artifact enum to its hero (Party) enum, or pass through."""
+    if isinstance(command, Party):
+        return command
+    if isinstance(command, Artifact):
+        # Reverse lookup: artifact -> hero
+        for hero, artifact in artifacts.items():
+            if artifact is command:
+                return hero
+    if isinstance(command, Action) and command is Action.REROLL:
+        return Party.SCROLL
+    # If it's already a Party enum, return it
+    raise DrollError(f'Unknown command "{command.value if hasattr(command, "value") else command}".')
 
-
-# Early tokens dominated by items/dice that can be applied/attacked.
-# Later tokens contain mixtures of present and requested items.
-# Attempts to specialize much beyond this seem to quickly go awry.
-# One notable special case is 'elixir' as any party die follows.
 
 # Artifact names that can be used as commands (sword, talisman, etc.).
 # Excludes artifacts whose name matches their hero (e.g. scroll -> scroll),
 # since those are already valid party die commands.
 _ARTIFACT_COMMANDS = frozenset(
     artifact
-    for hero, artifact in struct.field_items(Default.artifacts)
-    if artifact is not None and artifact != hero
+    for hero, artifact in Default.artifacts.items()
+    if artifact is not None and artifact.value != hero.value
 )
 
 # Treasures excluded from completion because they lack associated commands.
 # Portal and ring are auto-used; scale is for scoring only.
-_TREASURE_NO_COMMAND = frozenset({"portal", "ring", "scale"})
+_TREASURE_NO_COMMAND = frozenset({Artifact.PORTAL, Artifact.RING, Artifact.SCALE})
 
 
 def _available_nouns(world: struct.World) -> set[str]:
     """Candidate nouns (position 0): available party members and treasures."""
-    candidates = {
-        key
-        for source in (world.party, world.treasure.own)
-        if source is not None
-        for key, value in struct.field_items(source)
-        if value and key not in _TREASURE_NO_COMMAND
-    }
-    if "scroll" in candidates:
+    candidates = set()
+    for hero, count in world.party.items():
+        if count:
+            candidates.add(hero.value)
+    for artifact, count in world.treasure.own.items():
+        if count and artifact not in _TREASURE_NO_COMMAND:
+            candidates.add(artifact.value)
+    if Party.SCROLL.value in candidates:
         candidates.add("reroll")
     return candidates
 
 
 def _available_targets(world: struct.World) -> set[str]:
     """Candidate targets (position 1): available party and dungeon dice."""
-    return {
-        key
-        for source in (world.party, world.dungeon)
-        if source is not None
-        for key, value in struct.field_items(source)
-        if value
-    }
+    candidates = set()
+    for p, count in world.party.items():
+        if count:
+            candidates.add(p.value)
+    if world.dungeon is not None:
+        for d, count in world.dungeon.items():
+            if count:
+                candidates.add(d.value)
+    return candidates
 
 
 def _all_dice_names() -> set[str]:
     """All possible party and dungeon field names (position 2+)."""
-    return {
-        key
-        for source in (struct.Party, struct.Dungeon)
-        for key in struct.field_names(source)
-    }
+    return {p.value for p in Party} | {d.value for d in Dungeon}
 
 
 def complete(
@@ -273,7 +315,7 @@ def complete(
     if position == 0:
         candidates = _available_nouns(world)
     elif position == 1 and tokens[0] == "elixir":
-        candidates = set(struct.field_names(struct.Party))
+        candidates = {p.value for p in Party}
     elif position == 1:
         candidates = _available_targets(world)
     else:

--- a/droll/regular.py
+++ b/droll/regular.py
@@ -20,8 +20,7 @@ from .struct import (
     Party,
     RandRange,
     World,
-    field_names,
-    field_values,
+    frozen,
 )
 from .treasure import draw_treasure, replace_treasure
 
@@ -40,19 +39,16 @@ __all__ = (
     "reroll",
 )
 
-_DUNGEON_NAMES = frozenset(field_names(Dungeon))
-_PARTY_NAMES = frozenset(field_names(Party))
-
 
 def not_reroll(
-    world: World, randrange: RandRange, hero: str, targets: tuple[str, ...]
+    world: World, randrange: RandRange, hero: Party, targets: tuple[Dungeon | Party, ...]
 ) -> World:
     """Scrolls cannot target dungeon dice directly; use 'reroll' instead."""
-    raise DrollError(f'Use "reroll {targets[0]}" to re-roll with a scroll.')
+    raise DrollError(f'Use "reroll {targets[0].value}" to re-roll with a scroll.')
 
 
 def defeat_one(
-    world: World, randrange: RandRange, hero: str, targets: tuple[str, ...]
+    world: World, randrange: RandRange, hero: Party, targets: tuple[Dungeon, ...]
 ) -> World:
     """Update world after hero handles exactly one target."""
     if len(targets) != 1:
@@ -66,7 +62,7 @@ def defeat_one(
 
 
 def defeat_all(
-    world: World, randrange: RandRange, hero: str, targets: tuple[str, ...]
+    world: World, randrange: RandRange, hero: Party, targets: tuple[Dungeon, ...]
 ) -> World:
     """Update world after hero handles all of one type of target."""
     if len(targets) != 1:
@@ -82,8 +78,8 @@ def defeat_all(
 def open_one(
     world: World,
     randrange: RandRange,
-    hero: str,
-    targets: tuple[str, ...],
+    hero: Party,
+    targets: tuple[Dungeon, ...],
     *,
     after_monsters=True,
 ) -> World:
@@ -104,8 +100,8 @@ def open_one(
 def open_all(
     world: World,
     randrange: RandRange,
-    hero: str,
-    targets: tuple[str, ...],
+    hero: Party,
+    targets: tuple[Dungeon, ...],
     *,
     after_monsters=True,
 ) -> World:
@@ -114,9 +110,9 @@ def open_all(
         raise DrollError(f"Exactly 1 target required but {len(targets)} given.")
     if after_monsters and not defeated_monsters(world.dungeon):
         raise DrollError("Monsters must be defeated before opening.")
-    howmany = getattr(world.dungeon, targets[0])
+    howmany = world.dungeon[targets[0]]
     if not howmany:
-        raise DrollError(f"At least 1 {targets[0]} required.")
+        raise DrollError(f"At least 1 {targets[0].value} required.")
     treasure = world.treasure
     for _ in range(howmany):
         treasure = draw_treasure(treasure, randrange)
@@ -132,8 +128,8 @@ def open_all(
 def quaff(
     world: World,
     randrange: RandRange,
-    hero: str,
-    targets: tuple[str, ...],
+    hero: Party,
+    targets: tuple[Dungeon | Party, ...],
     *,
     after_monsters=True,
 ) -> World:
@@ -142,9 +138,9 @@ def quaff(
     Unlike {defeat,open}_{one,all}(...), heroes to revive are arguments."""
     if not targets:
         raise DrollError("At least 1 target required.")
-    howmany = getattr(world.dungeon, targets[0])
+    howmany = world.dungeon[targets[0]]
     if not howmany:
-        raise DrollError(f"At least 1 {targets[0]} required.")
+        raise DrollError(f"At least 1 {targets[0].value} required.")
     if len(targets) - 1 != howmany:
         raise DrollError(f"Specify exactly {howmany} to revive after 'potion'.")
     if after_monsters and not defeated_monsters(world.dungeon):
@@ -161,18 +157,18 @@ def quaff(
 
 
 def _classify_reroll_targets(
-    dungeon_or_party: tuple[str, ...],
+    dungeon_or_party: tuple[Dungeon | Party, ...],
     allow_dragon: bool,
-) -> tuple[list[str], list[str]]:
+) -> tuple[list[Dungeon], list[Party]]:
     """Classify reroll targets into dungeon and party lists."""
     dungeon_targets = []
     party_targets = []
     for target in dungeon_or_party:
-        if not allow_dragon and target == "dragon":
-            raise DrollError(f"{target} cannot be re-rolled.")
-        if target in _DUNGEON_NAMES:
+        if isinstance(target, Dungeon):
+            if not allow_dragon and target is Dungeon.DRAGON:
+                raise DrollError(f"{target.value} cannot be re-rolled.")
             dungeon_targets.append(target)
-        elif target in _PARTY_NAMES:
+        elif isinstance(target, Party):
             party_targets.append(target)
         else:
             raise DrollError(f"{target} cannot be re-rolled.")
@@ -182,8 +178,8 @@ def _classify_reroll_targets(
 def reroll(
     world: World,
     randrange: RandRange,
-    hero: str,
-    targets: tuple[str, ...],
+    hero: Party,
+    targets: tuple[Dungeon | Party, ...],
     *,
     allow_dragon: bool = False,
 ) -> World:
@@ -207,25 +203,17 @@ def reroll(
         increased = roll_dungeon(
             dice=len(dungeon_targets), randrange=randrange
         )
-        dungeon = Dungeon(
-            *map(
-                add,
-                field_values(dungeon),
-                field_values(increased),
-            )
-        )
+        dungeon = frozen({
+            d: dungeon[d] + increased[d] for d in Dungeon
+        })
 
     if party_targets:
         for target in party_targets:
             party = decrement_party(party, target)
         increased, _ = roll_party(dice=len(party_targets), randrange=randrange)
-        party = Party(
-            *map(
-                add,
-                field_values(party),
-                field_values(increased),
-            )
-        )
+        party = frozen({
+            p: party[p] + increased[p] for p in Party
+        })
 
     return replace(
         world,
@@ -236,10 +224,10 @@ def reroll(
 
 
 def distinct_heroes(
-    heroes: Sequence[str],
+    heroes: Sequence[Party],
     *,
-    wildcard: Set[str] = frozenset(),
-    interchangeable: Set[str] = frozenset(),
+    wildcard: Set[Party] = frozenset(),
+    interchangeable: Set[Party] = frozenset(),
 ) -> int:
     """How many distinct heroes does the given list represent?
 
@@ -257,11 +245,11 @@ def distinct_heroes(
 
 
 def defeat_dragon_heroes(
-    *heroes,
-    disallowed_heroes: Set[str] = frozenset({"scroll"}),
+    *heroes: Party,
+    disallowed_heroes: Set[Party] = frozenset({Party.SCROLL}),
     required: int = 3,
-    wildcard: Set[str] = frozenset(),
-    interchangeable: Set[str] = frozenset(),
+    wildcard: Set[Party] = frozenset(),
+    interchangeable: Set[Party] = frozenset(),
 ) -> None:
     """Validate sufficiently many distinct heroes to slay a dragon.
 
@@ -272,7 +260,7 @@ def defeat_dragon_heroes(
     hero_set = {*heroes}
     if hero_set & {*disallowed_heroes}:
         raise DrollError(
-            f"A {', '.join(sorted(disallowed_heroes))} cannot defeat a dragon."
+            f"A {', '.join(sorted(h.value for h in disallowed_heroes))} cannot defeat a dragon."
         )
     if len(heroes) != required:
         raise DrollError(f"Exactly {required} heroes required.")
@@ -282,15 +270,15 @@ def defeat_dragon_heroes(
     if n_distinct != required:
         raise DrollError(
             f"Exactly {required} distinct heroes required"
-            f" but '{', '.join(heroes)}' has only {n_distinct}."
+            f" but '{', '.join(h.value for h in heroes)}' has only {n_distinct}."
         )
 
 
 def defeat_dragon(
     world: World,
     randrange: RandRange,
-    hero: str,
-    targets: tuple[str, ...],
+    hero: Party,
+    targets: tuple[Dungeon | Party, ...],
     *,
     hero_validator: Callable[..., None] = defeat_dragon_heroes,
     _min_dragon_count: int = DRAGON_BLOCKING_THRESHOLD,
@@ -301,13 +289,13 @@ def defeat_dragon(
     if not targets:
         raise DrollError("At least 1 target required.")
     # Simple prerequisites for attempting to defeat the dragon
-    if world.dungeon.dragon < _min_dragon_count:
+    if world.dungeon[Dungeon.DRAGON] < _min_dragon_count:
         raise DrollError(
             f"At least {_min_dragon_count} dragon dice required to fight."
         )
     if not defeated_monsters(world.dungeon):
         raise DrollError(
-            f"Enemy {targets[0]} only comes after all others defeated."
+            f"Enemy {targets[0].value} only comes after all others defeated."
         )
 
     # Confirm required number of distinct heroes available
@@ -334,50 +322,52 @@ def defeat_dragon(
 def bait_dragon(
     world: World,
     randrange: RandRange,
-    command: str,
-    targets: tuple[str, ...] = (),
+    command: Dungeon | Party,
+    targets: tuple[Dungeon | Party, ...] = (),
     *,
-    _enemies: Sequence[str] = ("goblin", "skeleton", "ooze"),
+    _enemies: Sequence[Dungeon] = (Dungeon.GOBLIN, Dungeon.SKELETON, Dungeon.OOZE),
     require_treasure: bool = True,
 ) -> World:
     """Consume dragon bait to convert all monsters into dragon dice."""
     # Confirm well-formed request optionally containing a target
-    if any(t != "dragon" for t in targets):
-        raise DrollError(f"Can only {command} dragon dice.")
+    if any(t is not Dungeon.DRAGON for t in targets):
+        raise DrollError(f"Can only {command.value if hasattr(command, 'value') else command} dragon dice.")
     if require_treasure:
-        world = replace(world, treasure=replace_treasure(world.treasure, command))
+        from .struct import Artifact
+        world = replace(world, treasure=replace_treasure(world.treasure, Artifact(command.value if hasattr(command, 'value') else command)))
 
     # Compute how many new dragons will be produced and remove sources
     dungeon = world.dungeon
     new_dragons = (
-        sum(getattr(dungeon, enemy) for enemy in _enemies)
+        sum(dungeon[enemy] for enemy in _enemies)
         if dungeon is not None
         else 0
     )
     if not new_dragons:
         raise DrollError(
-            f"At least 1 monster ({', '.join(_enemies)}) required for '{command}'."
+            f"At least 1 monster ({', '.join(e.value for e in _enemies)}) required for '{command.value if hasattr(command, 'value') else command}'."
         )
 
     # Zero all enemy sources and increment the number of dragons
     return replace(
         world,
-        dungeon=replace(
-            dungeon,
+        dungeon=frozen({
+            **dungeon,
             **{enemy: 0 for enemy in _enemies},
-            dragon=dungeon.dragon + new_dragons,
-        ),
+            Dungeon.DRAGON: dungeon[Dungeon.DRAGON] + new_dragons,
+        }),
     )
 
 
 def elixir(
-    world: World, randrange: RandRange, command: str, targets: tuple[str, ...] = ()
+    world: World, randrange: RandRange, command: Dungeon | Party, targets: tuple[Dungeon | Party, ...] = ()
 ) -> World:
     """Consume an elixir to add one hero die of any type."""
     if not targets:
-        raise DrollError(f"Hero required for {command}.")
+        raise DrollError(f"Hero required for {command.value if hasattr(command, 'value') else command}.")
+    from .struct import Artifact
     return replace(
         world,
-        treasure=replace_treasure(world.treasure, command),
+        treasure=replace_treasure(world.treasure, Artifact(command.value if hasattr(command, 'value') else command)),
         party=increment_party(world.party, targets[0]),
     )

--- a/droll/regular.py
+++ b/droll/regular.py
@@ -6,6 +6,7 @@
 from dataclasses import replace
 from operator import add
 from collections.abc import Callable, Sequence, Set
+from typing import Union
 from .dice import roll_dungeon, roll_party
 from .dungeon import (
     DRAGON_BLOCKING_THRESHOLD,
@@ -41,7 +42,7 @@ __all__ = (
 
 
 def not_reroll(
-    world: World, randrange: RandRange, hero: Party, targets: tuple[Dungeon | Party, ...]
+    world: World, randrange: RandRange, hero: Party, targets: tuple[Union[Dungeon, Party], ...]
 ) -> World:
     """Scrolls cannot target dungeon dice directly; use 'reroll' instead."""
     raise DrollError(f'Use "reroll {targets[0].value}" to re-roll with a scroll.')
@@ -129,7 +130,7 @@ def quaff(
     world: World,
     randrange: RandRange,
     hero: Party,
-    targets: tuple[Dungeon | Party, ...],
+    targets: tuple[Union[Dungeon, Party], ...],
     *,
     after_monsters=True,
 ) -> World:
@@ -157,7 +158,7 @@ def quaff(
 
 
 def _classify_reroll_targets(
-    dungeon_or_party: tuple[Dungeon | Party, ...],
+    dungeon_or_party: tuple[Union[Dungeon, Party], ...],
     allow_dragon: bool,
 ) -> tuple[list[Dungeon], list[Party]]:
     """Classify reroll targets into dungeon and party lists."""
@@ -179,7 +180,7 @@ def reroll(
     world: World,
     randrange: RandRange,
     hero: Party,
-    targets: tuple[Dungeon | Party, ...],
+    targets: tuple[Union[Dungeon, Party], ...],
     *,
     allow_dragon: bool = False,
 ) -> World:
@@ -278,7 +279,7 @@ def defeat_dragon(
     world: World,
     randrange: RandRange,
     hero: Party,
-    targets: tuple[Dungeon | Party, ...],
+    targets: tuple[Union[Dungeon, Party], ...],
     *,
     hero_validator: Callable[..., None] = defeat_dragon_heroes,
     _min_dragon_count: int = DRAGON_BLOCKING_THRESHOLD,
@@ -322,8 +323,8 @@ def defeat_dragon(
 def bait_dragon(
     world: World,
     randrange: RandRange,
-    command: Dungeon | Party,
-    targets: tuple[Dungeon | Party, ...] = (),
+    command: Union[Dungeon, Party],
+    targets: tuple[Union[Dungeon, Party], ...] = (),
     *,
     _enemies: Sequence[Dungeon] = (Dungeon.GOBLIN, Dungeon.SKELETON, Dungeon.OOZE),
     require_treasure: bool = True,
@@ -360,7 +361,7 @@ def bait_dragon(
 
 
 def elixir(
-    world: World, randrange: RandRange, command: Dungeon | Party, targets: tuple[Dungeon | Party, ...] = ()
+    world: World, randrange: RandRange, command: Union[Dungeon, Party], targets: tuple[Union[Dungeon, Party], ...] = ()
 ) -> World:
     """Consume an elixir to add one hero die of any type."""
     if not targets:

--- a/droll/special.py
+++ b/droll/special.py
@@ -3,12 +3,10 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Functionality for hero-specific special actions."""
 
-from dataclasses import replace
-
 from .dungeon import defeated_monsters
 from .party import increment_party
 from .regular import defeat_all, defeat_one
-from .struct import DrollError, RandRange, World
+from .struct import Dungeon, DrollError, Party, RandRange, World, frozen
 
 __all__ = (
     "convert_dungeon_to_party",
@@ -20,14 +18,15 @@ __all__ = (
 def _defeat_plus_additional(
     world: World,
     randrange: RandRange,
-    hero: str,
+    hero: Party,
     additional: tuple,
 ) -> World:
     """After the initial defeat, optionally defeat one additional monster."""
+    from dataclasses import replace as dc_replace
     if defeated_monsters(world.dungeon):
         if additional:
             raise DrollError(
-                f"Additional target '{additional[0]}' given but no monsters left."
+                f"Additional target '{additional[0].value}' given but no monsters left."
             )
         return world
 
@@ -40,7 +39,7 @@ def _defeat_plus_additional(
         )
 
     return defeat_one(
-        world=replace(world, party=increment_party(world.party, hero)),
+        world=dc_replace(world, party=increment_party(world.party, hero)),
         randrange=randrange,
         hero=hero,
         targets=additional,
@@ -50,8 +49,8 @@ def _defeat_plus_additional(
 def defeat_all_plus_additional(
     world: World,
     randrange: RandRange,
-    hero: str,
-    targets: tuple[str, ...],
+    hero: Party,
+    targets: tuple[Dungeon, ...],
 ) -> World:
     """Update world after hero handles all of one target type plus one more."""
     if not targets:
@@ -65,8 +64,8 @@ def defeat_all_plus_additional(
 def defeat_one_plus_additional(
     world: World,
     randrange: RandRange,
-    hero: str,
-    targets: tuple[str, ...],
+    hero: Party,
+    targets: tuple[Dungeon, ...],
 ) -> World:
     """Update world after hero handles one target plus one more."""
     if not targets:
@@ -79,34 +78,26 @@ def defeat_one_plus_additional(
 
 def convert_dungeon_to_party(
     world: World,
-    source: str,
-    destination: str,
+    source: Dungeon,
+    destination: Party,
     max_count: int,
 ) -> World:
     """Convert dungeon dice into party dice with regroup discard.
 
     Converts min(available, max_count) of source into destination."""
-    count = min(getattr(world.dungeon, source), max_count)
+    from dataclasses import replace
+    count = min(world.dungeon[source], max_count)
     if count < 1:
-        raise DrollError(f"No {source} in dungeon to convert.")
+        raise DrollError(f"No {source.value} in dungeon to convert.")
     return replace(
         world,
-        dungeon=replace(
-            world.dungeon,
-            **{source: getattr(world.dungeon, source) - count},
-        ),
-        party=replace(
-            world.party,
-            **{destination: getattr(world.party, destination) + count},
-        ),
+        dungeon=frozen({**world.dungeon, source: world.dungeon[source] - count}),
+        party=frozen({**world.party, destination: world.party[destination] + count}),
         regroup=replace(
             world.regroup,
-            discard=replace(
-                world.regroup.discard,
-                **{
-                    destination: getattr(world.regroup.discard, destination)
-                    + count
-                },
-            ),
+            discard=frozen({
+                **world.regroup.discard,
+                destination: world.regroup.discard[destination] + count,
+            }),
         ),
     )

--- a/droll/struct.py
+++ b/droll/struct.py
@@ -3,17 +3,26 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Type definitions, generally of the struct-like variety."""
 
-from collections.abc import Callable
+import enum
+from collections.abc import Callable, Mapping
 from dataclasses import dataclass, fields
-from typing import Any, Optional, Union
+from types import MappingProxyType
+from typing import Any, Optional
 
 __all__ = (
-    "Command",
+    "Action",
     "Advance",
-    "Artifacts",
+    "Artifact",
+    "ArtifactCounts",
+    "ArtifactMapping",
+    "Command",
     "DrollError",
     "Dungeon",
+    "DungeonState",
+    "HeroActions",
     "Party",
+    "PartyActions",
+    "PartyState",
     "Player",
     "RandRange",
     "Regroup",
@@ -23,15 +32,200 @@ __all__ = (
     "Treasure",
     "World",
     "brief",
+    "empty_artifact_counts",
+    "empty_dungeon",
+    "empty_party",
     "field_items",
     "field_names",
     "field_values",
+    "frozen",
 )
 
 
 class DrollError(Exception):
     """Indicates attempts to take impossible actions."""
 
+
+# ── Enums ──────────────────────────────────────────────────────────────
+
+class Dungeon(enum.Enum):
+    GOBLIN = "goblin"
+    SKELETON = "skeleton"
+    OOZE = "ooze"
+    CHEST = "chest"
+    POTION = "potion"
+    DRAGON = "dragon"
+
+
+class Party(enum.Enum):
+    FIGHTER = "fighter"
+    CLERIC = "cleric"
+    MAGE = "mage"
+    THIEF = "thief"
+    CHAMPION = "champion"
+    SCROLL = "scroll"
+
+
+class Artifact(enum.Enum):
+    SWORD = "sword"
+    TALISMAN = "talisman"
+    SCEPTRE = "sceptre"
+    TOOLS = "tools"
+    SCROLL = "scroll"
+    ELIXIR = "elixir"
+    BAIT = "bait"
+    PORTAL = "portal"
+    RING = "ring"
+    SCALE = "scale"
+
+
+class Action(enum.Enum):
+    ABILITY = "ability"
+    BAIT = "bait"
+    ELIXIR = "elixir"
+    REROLL = "reroll"
+
+
+# ── Helpers ────────────────────────────────────────────────────────────
+
+def frozen(d: dict) -> MappingProxyType:
+    """Return an immutable mapping from d."""
+    return MappingProxyType(d)
+
+
+def empty_dungeon() -> MappingProxyType:
+    """A DungeonState with all counts zero."""
+    return frozen({d: 0 for d in Dungeon})
+
+
+def empty_party() -> MappingProxyType:
+    """A PartyState with all counts zero."""
+    return frozen({p: 0 for p in Party})
+
+
+def empty_artifact_counts() -> MappingProxyType:
+    """An ArtifactCounts with all counts zero."""
+    return frozen({a: 0 for a in Artifact})
+
+
+def make_dungeon(**kwargs: int) -> MappingProxyType:
+    """Build a DungeonState from keyword arguments using value names."""
+    base = {d: 0 for d in Dungeon}
+    for name, val in kwargs.items():
+        base[Dungeon(name)] = val
+    return frozen(base)
+
+
+def make_party(**kwargs: int) -> MappingProxyType:
+    """Build a PartyState from keyword arguments using value names."""
+    base = {p: 0 for p in Party}
+    for name, val in kwargs.items():
+        base[Party(name)] = val
+    return frozen(base)
+
+
+def make_artifacts(**kwargs: int) -> MappingProxyType:
+    """Build an ArtifactCounts from keyword arguments using value names."""
+    base = {a: 0 for a in Artifact}
+    for name, val in kwargs.items():
+        base[Artifact(name)] = val
+    return frozen(base)
+
+
+def all_dungeon(value: int) -> MappingProxyType:
+    """Build a DungeonState with all faces set to value."""
+    return frozen({d: value for d in Dungeon})
+
+
+def all_party(value: int) -> MappingProxyType:
+    """Build a PartyState with all faces set to value."""
+    return frozen({p: value for p in Party})
+
+
+# ── Type aliases (annotation-time: Mapping; runtime: MappingProxyType) ─
+
+DungeonState = Mapping[Dungeon, int]
+PartyState = Mapping[Party, int]
+ArtifactCounts = Mapping[Artifact, int]
+
+RandRange = Callable[[int, int], int]
+
+Command = Callable[["World", RandRange, "Party", "tuple[Dungeon | Party, ...]"], "World"]
+
+HeroActions = Mapping[Dungeon, Command]
+PartyActions = Mapping[Party, HeroActions]
+ArtifactMapping = Mapping[Party, Optional[Artifact]]
+
+
+RollDungeon = Callable[[int, RandRange], DungeonState]
+RollParty = Callable[[int, RandRange], "tuple[PartyState, Regroup]"]
+
+
+# ── Surviving dataclasses ──────────────────────────────────────────────
+
+@dataclass(frozen=True)
+class Regroup:
+    discard: PartyState = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if self.discard is None:
+            object.__setattr__(self, "discard", empty_party())
+
+
+@dataclass(frozen=True)
+class Roll:
+    dungeon: RollDungeon
+    party: RollParty
+
+
+@dataclass(frozen=True)
+class Treasure:
+    own: ArtifactCounts = None  # type: ignore[assignment]
+    box: ArtifactCounts = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if self.own is None:
+            object.__setattr__(self, "own", empty_artifact_counts())
+        if self.box is None:
+            object.__setattr__(self, "box", empty_artifact_counts())
+
+
+@dataclass(frozen=True)
+class World:
+    delve: int = 0
+    depth: int = 0
+    experience: int = 0
+    dungeon: Optional[DungeonState] = None
+    party: PartyState = None  # type: ignore[assignment]
+    ability: bool = False
+    regroup: Regroup = None  # type: ignore[assignment]
+    treasure: Treasure = None  # type: ignore[assignment]
+
+    def __post_init__(self):
+        if self.party is None:
+            object.__setattr__(self, "party", empty_party())
+        if self.regroup is None:
+            object.__setattr__(self, "regroup", Regroup())
+        if self.treasure is None:
+            object.__setattr__(self, "treasure", Treasure())
+
+
+@dataclass(frozen=True)
+class Player:
+    name: str
+    ability: Command
+    advance: "Advance"
+    bait: Command
+    elixir: Command
+    roll: Roll
+    artifacts: ArtifactMapping
+    party: PartyActions
+
+
+Advance = Callable[[World], Player]
+
+
+# ── Dataclass introspection helpers (for surviving dataclasses) ────────
 
 def field_names(cls_or_instance: Any) -> tuple[str, ...]:
     """Return field names for a dataclass or instance thereof."""
@@ -50,98 +244,13 @@ def field_items(
     return tuple((f.name, getattr(instance, f.name)) for f in fields(instance))
 
 
-RandRange = Callable[[int, int], int]
-
-Command = Callable[["World", RandRange, str, tuple[str, ...]], "World"]
-
-
-@dataclass(frozen=True)
-class Dungeon:
-    goblin: Union[int, Command] = 0
-    skeleton: Union[int, Command] = 0
-    ooze: Union[int, Command] = 0
-    chest: Union[int, Command] = 0
-    potion: Union[int, Command] = 0
-    dragon: Union[int, Command] = 0
-
-
-RollDungeon = Callable[[int, RandRange], Dungeon]
-
-
-@dataclass(frozen=True)
-class Party:
-    fighter: Union[int, Command, str, None] = 0
-    cleric: Union[int, Command, str, None] = 0
-    mage: Union[int, Command, str, None] = 0
-    thief: Union[int, Command, str, None] = 0
-    champion: Union[int, Command, str, None] = 0
-    scroll: Union[int, Command, str, None] = 0
-
-
-# Bookkeeping for operations performed during the regroup phase
-@dataclass(frozen=True)
-class Regroup:
-    discard: Party = Party()  # Discard N party dice in regroup phase
-
-
-RollParty = Callable[[int, RandRange], tuple[Party, Regroup]]
-
-
-@dataclass(frozen=True)
-class Roll:
-    dungeon: RollDungeon
-    party: RollParty
-
-
-@dataclass(frozen=True)
-class Artifacts:
-    sword: int = 0
-    talisman: int = 0
-    sceptre: int = 0
-    tools: int = 0
-    scroll: int = 0
-    elixir: int = 0
-    bait: int = 0
-    portal: int = 0
-    ring: int = 0
-    scale: int = 0
-
-
-@dataclass(frozen=True)
-class Treasure:
-    own: Artifacts = Artifacts()
-    box: Artifacts = Artifacts()
-
-
-@dataclass(frozen=True)
-class World:
-    delve: int = 0
-    depth: int = 0
-    experience: int = 0
-    dungeon: Optional[Dungeon] = None
-    party: Party = Party()
-    ability: bool = False
-    regroup: Regroup = Regroup()
-    treasure: Treasure = Treasure()
-
-
-@dataclass(frozen=True)
-class Player:
-    name: str
-    ability: Command
-    advance: "Advance"
-    bait: Command
-    elixir: Command
-    roll: Roll
-    artifacts: Party
-    party: Party
-
-
-Advance = Callable[[World], Player]
-
+# ── Display helper ─────────────────────────────────────────────────────
 
 def brief(o: Any) -> str:
     """A __str__(...) variant suppressing False fields within dataclasses."""
+    if isinstance(o, Mapping):
+        kv = [f"{k.value}={brief(v)}" for k, v in o.items() if v]
+        return f"({', '.join(kv)})"
     try:
         names = field_names(o)
         values = field_values(o)

--- a/droll/treasure.py
+++ b/droll/treasure.py
@@ -6,12 +6,12 @@
 from dataclasses import replace
 
 from .struct import (
-    Artifacts,
+    Artifact,
+    ArtifactCounts,
     DrollError,
     RandRange,
     Treasure,
-    field_items,
-    field_values,
+    frozen,
 )
 
 __all__ = (
@@ -20,17 +20,17 @@ __all__ = (
 )
 
 
-def _draw(box: Artifacts, randrange: RandRange) -> str:
+def _draw(box: ArtifactCounts, randrange: RandRange) -> Artifact:
     """Draw a random treasure from the box, weighted by counts."""
-    total = sum(field_values(box))
+    total = sum(box.values())
     if not total:
         raise DrollError("No items remaining in the box")
     choice = randrange(0, total)
     cumulative = 0
-    for name, count in field_items(box):
+    for artifact, count in box.items():
         cumulative += count
         if choice < cumulative:
-            return name
+            return artifact
     raise RuntimeError("Unreachable")
 
 
@@ -39,20 +39,20 @@ def draw_treasure(treasure: Treasure, randrange: RandRange) -> Treasure:
     drawn = _draw(box=treasure.box, randrange=randrange)
     return replace(
         treasure,
-        own=replace(treasure.own, **{drawn: getattr(treasure.own, drawn) + 1}),
-        box=replace(treasure.box, **{drawn: getattr(treasure.box, drawn) - 1}),
+        own=frozen({**treasure.own, drawn: treasure.own[drawn] + 1}),
+        box=frozen({**treasure.box, drawn: treasure.box[drawn] - 1}),
     )
 
 
-def replace_treasure(treasure: Treasure, item: str) -> Treasure:
+def replace_treasure(treasure: Treasure, item: Artifact) -> Treasure:
     """Replace a single item from the player's own artifacts into the box."""
-    if not hasattr(treasure.own, item):
-        raise DrollError(f"'{item}' is not a valid treasure type.")
-    prior_count = getattr(treasure.own, item)
+    if item not in treasure.own:
+        raise DrollError(f"'{item.value}' is not a valid treasure type.")
+    prior_count = treasure.own[item]
     if not prior_count:
-        raise DrollError(f"'{item}' not in player's treasure.")
+        raise DrollError(f"'{item.value}' not in player's treasure.")
     return replace(
         treasure,
-        own=replace(treasure.own, **{item: prior_count - 1}),
-        box=replace(treasure.box, **{item: getattr(treasure.box, item) + 1}),
+        own=frozen({**treasure.own, item: prior_count - 1}),
+        box=frozen({**treasure.box, item: treasure.box[item] + 1}),
     )

--- a/droll/world.py
+++ b/droll/world.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 
 from . import struct
 from .dungeon import blocking_dragon, defeated_dungeon, defeated_monsters
-from .struct import DrollError
+from .struct import Artifact, Dungeon, DrollError, Party, frozen
 from .treasure import replace_treasure
 
 __all__ = (
@@ -24,18 +24,18 @@ def new_world() -> struct.World:
     """Establish a new world independent of a delve/dungeon."""
     return struct.World(
         treasure=struct.Treasure(
-            box=struct.Artifacts(
-                sword=3,
-                talisman=3,
-                sceptre=3,
-                tools=3,
-                scroll=3,
-                elixir=3,
-                bait=4,
-                portal=4,
-                ring=4,
-                scale=6,
-            ),
+            box=frozen({
+                Artifact.SWORD: 3,
+                Artifact.TALISMAN: 3,
+                Artifact.SCEPTRE: 3,
+                Artifact.TOOLS: 3,
+                Artifact.SCROLL: 3,
+                Artifact.ELIXIR: 3,
+                Artifact.BAIT: 4,
+                Artifact.PORTAL: 4,
+                Artifact.RING: 4,
+                Artifact.SCALE: 6,
+            }),
         ),
     )
 
@@ -66,18 +66,12 @@ def delve(
 
 def _regroup(world: struct.World) -> struct.World:
     """The regroup phase occurs when descending, retiring, or retreating."""
-    # Possibly discard dice as dictated by, e.g., Half-Goblin ability
-    # Suppose the player must use, say, 2 fighter dice or lose during regroup
-    # Then, we decrement the fighters in the party by the discard count
-    # where decrementing never takes the allotted result below 0 fighters
     return replace(
         world,
-        party=struct.Party(
-            **{
-                name: max(0, getattr(world.party, name, 0) - count)
-                for name, count in struct.field_items(world.regroup.discard)
-            }
-        ),
+        party=frozen({
+            p: max(0, world.party[p] - world.regroup.discard[p])
+            for p in Party
+        }),
         regroup=struct.Regroup(),
     )
 
@@ -111,13 +105,13 @@ def descend(
     next_depth = world.depth + 1
     if next_depth > _max_depth:
         raise DrollError(f"Maximum depth is {_max_depth}.")
-    prior_dragons = 0 if world.dungeon is None else world.dungeon.dragon
+    prior_dragons = 0 if world.dungeon is None else world.dungeon[Dungeon.DRAGON]
     new_dice = max(1, min(_dungeon_dice - prior_dragons, next_depth))
     rolled = roll_dungeon(new_dice, randrange)
     return replace(
         world,
         depth=next_depth,
-        dungeon=replace(rolled, dragon=rolled.dragon + prior_dragons),
+        dungeon=frozen({**rolled, Dungeon.DRAGON: rolled[Dungeon.DRAGON] + prior_dragons}),
     )
 
 
@@ -180,31 +174,27 @@ def score(world: struct.World) -> int:
     """Compute the present score for the world, including all treasure."""
     return (
         world.experience
-        + sum(
-            struct.field_values(world.treasure.own)
-        )  # Each piece of treasure is +1 point
-        + world.treasure.own.portal  # Portals are +1 extra (2 total each)
-        + 2 * (world.treasure.own.scale // 2)  # Pairs of scales are +2 extra
+        + sum(world.treasure.own.values())
+        + world.treasure.own[Artifact.PORTAL]  # Portals are +1 extra (2 total each)
+        + 2 * (world.treasure.own[Artifact.SCALE] // 2)  # Pairs of scales are +2 extra
     )
 
 
-def _apply_ring(world: struct.World, *, noun: str = "ring") -> struct.World:
+def _apply_ring(world: struct.World) -> struct.World:
     """Attempt to use a ring of invisibility towards sneaking past a dragon."""
     if not blocking_dragon(world.dungeon):
-        raise DrollError(f"A dragon must be present to use a {noun}.")
-    world = replace(world, treasure=replace_treasure(world.treasure, noun))
-    return replace(world, dungeon=replace(world.dungeon, dragon=0))
+        raise DrollError("A dragon must be present to use a ring.")
+    world = replace(world, treasure=replace_treasure(world.treasure, Artifact.RING))
+    return replace(world, dungeon=frozen({**world.dungeon, Dungeon.DRAGON: 0}))
 
 
-def _apply_portal(
-    world: struct.World, *, noun: str = "portal"
-) -> struct.World:
+def _apply_portal(world: struct.World) -> struct.World:
     """Attempt to use a town portal towards retiring to town."""
     # No need to reset monsters/dragon as dungeon will be wholly replaced
     if defeated_dungeon(world.dungeon):
-        raise DrollError(f"No need to apply {noun} when dungeon clear.")
+        raise DrollError("No need to apply portal when dungeon clear.")
     return replace(
         world,
-        treasure=replace_treasure(world.treasure, "portal"),
-        dungeon=struct.Dungeon(),
+        treasure=replace_treasure(world.treasure, Artifact.PORTAL),
+        dungeon=struct.empty_dungeon(),
     )

--- a/tests/heroes/test_crusader.py
+++ b/tests/heroes/test_crusader.py
@@ -9,6 +9,7 @@ import pytest
 from droll import player, struct
 from droll.ability import crusader_ability, paladin_ability
 from droll.heroes.crusader import Crusader, Paladin
+from droll.struct import Action, Artifact, Dungeon, Party, make_dungeon, make_party, make_artifacts
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -18,10 +19,10 @@ def test_crusader_ability_adds_fighter():
     """Crusader ability adds a fighter to party."""
     world = struct.World(
         ability=True,
-        party=struct.Party(fighter=1, cleric=1),
+        party=make_party(fighter=1, cleric=1),
     )
-    result = crusader_ability(world, _UNUSED, "ability", ("fighter",))
-    assert result.party.fighter == 2
+    result = crusader_ability(world, _UNUSED, Action.ABILITY, (Party.FIGHTER,))
+    assert result.party[Party.FIGHTER] == 2
     assert not result.ability
 
 
@@ -29,20 +30,20 @@ def test_crusader_ability_adds_cleric():
     """Crusader ability adds a cleric to party."""
     world = struct.World(
         ability=True,
-        party=struct.Party(fighter=1, cleric=1),
+        party=make_party(fighter=1, cleric=1),
     )
-    result = crusader_ability(world, _UNUSED, "ability", ("cleric",))
-    assert result.party.cleric == 2
+    result = crusader_ability(world, _UNUSED, Action.ABILITY, (Party.CLERIC,))
+    assert result.party[Party.CLERIC] == 2
 
 
 def test_crusader_ability_rejects_invalid_target():
     """Crusader ability rejects invalid targets like mage."""
     world = struct.World(
         ability=True,
-        party=struct.Party(fighter=1, cleric=1),
+        party=make_party(fighter=1, cleric=1),
     )
     with pytest.raises(struct.DrollError):
-        crusader_ability(world, _UNUSED, "ability", ("mage",))
+        crusader_ability(world, _UNUSED, Action.ABILITY, (Party.MAGE,))
 
 
 def test_crusader_advances_to_paladin():
@@ -57,16 +58,16 @@ def test_paladin_ability_clears_dungeon():
     """Paladin ability consumes treasure and clears dungeon."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1, dragon=1),
-        party=struct.Party(fighter=1, cleric=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1, dragon=1),
+        party=make_party(fighter=1, cleric=1),
         treasure=struct.Treasure(
-            own=struct.Artifacts(elixir=1),
-            box=struct.Artifacts(sword=1, talisman=1),
+            own=make_artifacts(elixir=1),
+            box=make_artifacts(sword=1, talisman=1),
         ),
     )
-    result = paladin_ability(world, _UNUSED, "ability", ("elixir",))
-    assert sum(struct.field_values(result.dungeon)) == 0
-    assert result.treasure.own.elixir == 0
+    result = paladin_ability(world, _UNUSED, Action.ABILITY, (Artifact.ELIXIR,))
+    assert sum(result.dungeon.values()) == 0
+    assert result.treasure.own[Artifact.ELIXIR] == 0
     assert not result.ability
 
 
@@ -75,16 +76,16 @@ def test_paladin_ability_opens_chests():
     randrange = random.Random(4).randrange
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(chest=2),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(chest=2),
+        party=make_party(fighter=1),
         treasure=struct.Treasure(
-            own=struct.Artifacts(bait=1),
-            box=struct.Artifacts(sword=1, talisman=1, sceptre=1),
+            own=make_artifacts(bait=1),
+            box=make_artifacts(sword=1, talisman=1, sceptre=1),
         ),
     )
-    pre_treasure = sum(struct.field_values(world.treasure.own))
-    result = paladin_ability(world, randrange, "ability", ("bait",))
-    post_treasure = sum(struct.field_values(result.treasure.own))
+    pre_treasure = sum(world.treasure.own.values())
+    result = paladin_ability(world, randrange, Action.ABILITY, (Artifact.BAIT,))
+    post_treasure = sum(result.treasure.own.values())
     assert post_treasure == pre_treasure - 1 + 2  # -1 consumed, +2 from chests
 
 
@@ -92,48 +93,48 @@ def test_paladin_ability_revives_from_potions():
     """Paladin ability revives heroes from potions."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(potion=2),
-        party=struct.Party(fighter=1),
-        treasure=struct.Treasure(own=struct.Artifacts(elixir=1)),
+        dungeon=make_dungeon(potion=2),
+        party=make_party(fighter=1),
+        treasure=struct.Treasure(own=make_artifacts(elixir=1)),
     )
     result = paladin_ability(
-        world, _UNUSED, "ability", ("elixir", "mage", "thief")
+        world, _UNUSED, Action.ABILITY, (Artifact.ELIXIR, Party.MAGE, Party.THIEF)
     )
-    assert result.party.mage == 1
-    assert result.party.thief == 1
+    assert result.party[Party.MAGE] == 1
+    assert result.party[Party.THIEF] == 1
 
 
 def test_crusader_ability_default_target():
     """Crusader ability defaults to 'cleric' (first sorted) when no target."""
     world = struct.World(
         ability=True,
-        party=struct.Party(fighter=1, cleric=1),
+        party=make_party(fighter=1, cleric=1),
     )
-    result = crusader_ability(world, _UNUSED, "ability")
-    assert result.party.cleric == 2
+    result = crusader_ability(world, _UNUSED, Action.ABILITY)
+    assert result.party[Party.CLERIC] == 2
 
 
 def test_paladin_ability_wrong_revivable_count():
     """Paladin ability rejects wrong number of heroes for potions."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(potion=2),
-        party=struct.Party(fighter=1),
-        treasure=struct.Treasure(own=struct.Artifacts(elixir=1)),
+        dungeon=make_dungeon(potion=2),
+        party=make_party(fighter=1),
+        treasure=struct.Treasure(own=make_artifacts(elixir=1)),
     )
     with pytest.raises(struct.DrollError):
-        paladin_ability(world, _UNUSED, "ability", ("elixir", "mage"))
+        paladin_ability(world, _UNUSED, Action.ABILITY, (Artifact.ELIXIR, Party.MAGE))
 
 
 def test_paladin_ability_requires_treasure():
     """Paladin ability fails without specifying treasure."""
     world = struct.World(
         ability=True,
-        party=struct.Party(fighter=1),
-        treasure=struct.Treasure(own=struct.Artifacts(elixir=1)),
+        party=make_party(fighter=1),
+        treasure=struct.Treasure(own=make_artifacts(elixir=1)),
     )
     with pytest.raises(struct.DrollError):
-        paladin_ability(world, _UNUSED, "ability")
+        paladin_ability(world, _UNUSED, Action.ABILITY)
 
 
 def test_paladin_ability_talisman_via_apply(
@@ -145,14 +146,14 @@ def test_paladin_ability_talisman_via_apply(
     treasure name, producing "'Artifacts' object has no attribute 'cleric'"."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1, dragon=1),
-        party=struct.Party(fighter=1, cleric=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1, dragon=1),
+        party=make_party(fighter=1, cleric=1),
         treasure=struct.Treasure(
-            own=struct.Artifacts(talisman=1),
-            box=struct.Artifacts(sword=1),
+            own=make_artifacts(talisman=1),
+            box=make_artifacts(sword=1),
         ),
     )
     result = player.apply(Paladin, world, _UNUSED, "ability", "talisman")
-    assert sum(struct.field_values(result.dungeon)) == 0
-    assert result.treasure.own.talisman == 0
+    assert sum(result.dungeon.values()) == 0
+    assert result.treasure.own[Artifact.TALISMAN] == 0
     assert not result.ability

--- a/tests/heroes/test_enchantress.py
+++ b/tests/heroes/test_enchantress.py
@@ -8,6 +8,7 @@ import pytest
 from droll import struct
 from droll.ability import beguiler_ability, enchantress_ability
 from droll.heroes.enchantress import Beguiler, Enchantress
+from droll.struct import Action, Dungeon, Party, make_dungeon, make_party
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -17,12 +18,12 @@ def test_enchantress_transforms_monster_to_potion():
     """Enchantress transforms 1 monster into 1 potion."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
-    result = enchantress_ability(world, _UNUSED, "ability", ("goblin",))
-    assert result.dungeon.goblin == 1
-    assert result.dungeon.potion == 1
+    result = enchantress_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN,))
+    assert result.dungeon[Dungeon.GOBLIN] == 1
+    assert result.dungeon[Dungeon.POTION] == 1
     assert not result.ability
 
 
@@ -30,36 +31,36 @@ def test_beguiler_transforms_two_monsters():
     """Beguiler transforms 2 monsters into 1 potion when available."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
-    result = beguiler_ability(world, _UNUSED, "ability", ("goblin", "skeleton"))
-    assert result.dungeon.goblin == 1
-    assert result.dungeon.skeleton == 0
-    assert result.dungeon.potion == 1
+    result = beguiler_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN, Dungeon.SKELETON))
+    assert result.dungeon[Dungeon.GOBLIN] == 1
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.dungeon[Dungeon.POTION] == 1
 
 
 def test_beguiler_requires_two_when_available():
     """Beguiler must transform 2 monsters when 2+ available."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
     with pytest.raises(struct.DrollError):
-        beguiler_ability(world, _UNUSED, "ability", ("goblin",))
+        beguiler_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN,))
 
 
 def test_beguiler_rejects_too_many_targets():
     """Beguiler rejects more than 2 targets."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
     with pytest.raises(struct.DrollError):
         beguiler_ability(
-            world, _UNUSED, "ability", ("goblin", "skeleton", "goblin")
+            world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN, Dungeon.SKELETON, Dungeon.GOBLIN)
         )
 
 
@@ -67,22 +68,22 @@ def test_enchantress_message_without_target():
     """Enchantress fails gracefully when no targets supplied."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
     with pytest.raises(struct.DrollError):
-        result = enchantress_ability(world, _UNUSED, "ability")
+        result = enchantress_ability(world, _UNUSED, Action.ABILITY)
 
 
 def test_beguiler_message_without_target():
     """Beguiler fails gracefully when no targets supplied."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
     with pytest.raises(struct.DrollError):
-        result = beguiler_ability(world, _UNUSED, "ability")
+        result = beguiler_ability(world, _UNUSED, Action.ABILITY)
 
 
 def test_enchantress_advances_to_beguiler():

--- a/tests/heroes/test_halfgoblin.py
+++ b/tests/heroes/test_halfgoblin.py
@@ -9,6 +9,7 @@ import pytest
 from droll import struct
 from droll.ability import chieftain_ability, halfgoblin_ability
 from droll.heroes.halfgoblin import Chieftain, HalfGoblin
+from droll.struct import Action, Artifact, Dungeon, Party, make_dungeon, make_party, make_artifacts
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -18,13 +19,13 @@ def test_halfgoblin_transforms_goblin_to_thief():
     """HalfGoblin transforms 1 goblin into 1 thief."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
-    result = halfgoblin_ability(world, _UNUSED, "ability", ("goblin",))
+    result = halfgoblin_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN,))
     # Discard during subsequent regroup phase tested elsewhere
-    assert result.dungeon.goblin == 1
-    assert result.party.thief == 1
+    assert result.dungeon[Dungeon.GOBLIN] == 1
+    assert result.party[Party.THIEF] == 1
     assert not result.ability
 
 
@@ -32,60 +33,60 @@ def test_chieftain_transforms_two_monsters():
     """Chieftain transforms 2 goblins into 2 thieves when available."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
-    result = chieftain_ability(world, _UNUSED, "ability", ("goblin", "goblin"))
+    result = chieftain_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN, Dungeon.GOBLIN))
     # Discard during subsequent regroup phase tested elsewhere
-    assert result.dungeon.goblin == 0
-    assert result.dungeon.skeleton == 1
-    assert result.party.thief == 2
+    assert result.dungeon[Dungeon.GOBLIN] == 0
+    assert result.dungeon[Dungeon.SKELETON] == 1
+    assert result.party[Party.THIEF] == 2
 
 
 def test_chieftain_transforms_one_monster():
     """Chieftain transforms 1 goblin into 1 thief when 1 available."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=1, skeleton=1),
+        party=make_party(fighter=1),
     )
     result = chieftain_ability(
         world,
         _UNUSED,
-        "ability",
-        ("goblin",),
+        Action.ABILITY,
+        (Dungeon.GOBLIN,),
     )
     # Discard during subsequent regroup phase tested elsewhere
-    assert result.dungeon.goblin == 0
-    assert result.dungeon.skeleton == 1
-    assert result.party.thief == 1
+    assert result.dungeon[Dungeon.GOBLIN] == 0
+    assert result.dungeon[Dungeon.SKELETON] == 1
+    assert result.party[Party.THIEF] == 1
 
 
 def test_halfgoblin_rejects_non_goblin():
     """HalfGoblin ability rejects non-goblin targets."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=1, skeleton=1),
+        party=make_party(fighter=1),
     )
     with pytest.raises(struct.DrollError):
-        halfgoblin_ability(world, _UNUSED, "ability", ("skeleton",))
+        halfgoblin_ability(world, _UNUSED, Action.ABILITY, (Dungeon.SKELETON,))
 
 
 def test_chieftain_rejects_non_goblin_targets():
     """Chieftain rejects non-goblin, extra, and excess targets."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=1),
     )
     with pytest.raises(struct.DrollError):
-        chieftain_ability(world, _UNUSED, "ability", ("skeleton",))
+        chieftain_ability(world, _UNUSED, Action.ABILITY, (Dungeon.SKELETON,))
     with pytest.raises(struct.DrollError):
-        chieftain_ability(world, _UNUSED, "ability", ("goblin", "skeleton"))
+        chieftain_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN, Dungeon.SKELETON))
     with pytest.raises(struct.DrollError):
         chieftain_ability(
-            world, _UNUSED, "ability", ("goblin", "goblin", "goblin")
+            world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN, Dungeon.GOBLIN, Dungeon.GOBLIN)
         )
 
 
@@ -104,26 +105,26 @@ def test_halfgoblin_fighter_chests_potions():
         delve=1,
         depth=1,
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, chest=1, potion=1),
-        party=struct.Party(fighter=5),
+        dungeon=make_dungeon(goblin=1, chest=1, potion=1),
+        party=make_party(fighter=5),
         treasure=struct.Treasure(
-            own=struct.Artifacts(),
-            box=struct.Artifacts(scale=1),
+            own=make_artifacts(),
+            box=make_artifacts(scale=1),
         ),
     )
 
-    result1 = HalfGoblin.party.fighter.chest(
-        world, randrange, "fighter", ("chest",)
+    result1 = HalfGoblin.party[Party.FIGHTER][Dungeon.CHEST](
+        world, randrange, Party.FIGHTER, (Dungeon.CHEST,)
     )
-    assert result1.dungeon.chest == 0
-    assert result1.dungeon.goblin == 1
-    assert result1.party.fighter == 4
-    assert result1.treasure.own.scale == 1
+    assert result1.dungeon[Dungeon.CHEST] == 0
+    assert result1.dungeon[Dungeon.GOBLIN] == 1
+    assert result1.party[Party.FIGHTER] == 4
+    assert result1.treasure.own[Artifact.SCALE] == 1
 
-    result2 = HalfGoblin.party.fighter.potion(
-        world, randrange, "fighter", ("potion", "mage")
+    result2 = HalfGoblin.party[Party.FIGHTER][Dungeon.POTION](
+        world, randrange, Party.FIGHTER, (Dungeon.POTION, Party.MAGE)
     )
-    assert result2.dungeon.goblin == 1
-    assert result2.dungeon.potion == 0
-    assert result2.party.fighter == 4
-    assert result2.party.mage == 1
+    assert result2.dungeon[Dungeon.GOBLIN] == 1
+    assert result2.dungeon[Dungeon.POTION] == 0
+    assert result2.party[Party.FIGHTER] == 4
+    assert result2.party[Party.MAGE] == 1

--- a/tests/heroes/test_knight.py
+++ b/tests/heroes/test_knight.py
@@ -7,6 +7,7 @@ import random
 
 from droll import struct
 from droll.heroes.knight import Knight, DragonSlayer, _knight_roll_party
+from droll.struct import Action, Artifact, Dungeon, Party, make_dungeon, make_party, make_artifacts
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -16,8 +17,8 @@ def test_knight_roll_party_converts_scrolls():
     """Knight converts scrolls to champions when rolling party."""
     randrange = random.Random(4).randrange
     party, regroup = _knight_roll_party(7, randrange)
-    assert party.scroll == 0
-    assert sum(struct.field_values(party)) == 7
+    assert party[Party.SCROLL] == 0
+    assert sum(party.values()) == 7
     assert regroup == struct.Regroup()
 
 
@@ -25,13 +26,13 @@ def test_knight_ability_baits_dragon():
     """Knight ability converts monsters to dragons without treasure."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=2, champion=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=2, champion=1),
     )
-    result = Knight.ability(world, _UNUSED, "ability")
-    assert result.dungeon.dragon == 3
-    assert result.dungeon.goblin == 0
-    assert result.dungeon.skeleton == 0
+    result = Knight.ability(world, _UNUSED, Action.ABILITY)
+    assert result.dungeon[Dungeon.DRAGON] == 3
+    assert result.dungeon[Dungeon.GOBLIN] == 0
+    assert result.dungeon[Dungeon.SKELETON] == 0
     assert not result.ability
 
 
@@ -41,17 +42,17 @@ def test_dragonslayer_defeats_dragon_with_two_heroes():
     world = struct.World(
         delve=1,
         depth=1,
-        dungeon=struct.Dungeon(dragon=3),
-        party=struct.Party(fighter=1, mage=1),
+        dungeon=make_dungeon(dragon=3),
+        party=make_party(fighter=1, mage=1),
         treasure=struct.Treasure(
-            own=struct.Artifacts(),
-            box=struct.Artifacts(scale=6),
+            own=make_artifacts(),
+            box=make_artifacts(scale=6),
         ),
     )
-    result = DragonSlayer.party.fighter.dragon(
-        world, randrange, "fighter", ("dragon", "mage")
+    result = DragonSlayer.party[Party.FIGHTER][Dungeon.DRAGON](
+        world, randrange, Party.FIGHTER, (Dungeon.DRAGON, Party.MAGE)
     )
-    assert result.dungeon.dragon == 0
+    assert result.dungeon[Dungeon.DRAGON] == 0
     assert result.experience == 1
 
 

--- a/tests/heroes/test_mercenary.py
+++ b/tests/heroes/test_mercenary.py
@@ -9,6 +9,7 @@ import pytest
 from droll import struct
 from droll.ability import commander_ability, mercenary_ability
 from droll.heroes.mercenary import Commander, Mercenary, _mercenary_roll_party
+from droll.struct import Action, Dungeon, Party, make_dungeon, make_party
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -18,21 +19,21 @@ def test_mercenary_roll_party_adds_bonus_scroll():
     """Mercenary roll adds one bonus scroll with regroup discard."""
     randrange = random.Random(4).randrange
     party, regroup = _mercenary_roll_party(7, randrange)
-    assert sum(struct.field_values(party)) == 8
-    assert regroup.discard.scroll == 1
+    assert sum(party.values()) == 8
+    assert regroup.discard[Party.SCROLL] == 1
 
 
 def test_mercenary_ability_defeats_two_monsters():
     """Mercenary ability defeats 2 different monsters."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=1),
-        party=struct.Party(fighter=2),
+        dungeon=make_dungeon(goblin=1, skeleton=1),
+        party=make_party(fighter=2),
     )
-    result = mercenary_ability(world, _UNUSED, "ability", ("goblin", "skeleton"))
-    assert result.dungeon.goblin == 0
-    assert result.dungeon.skeleton == 0
-    assert result.party.fighter == 2
+    result = mercenary_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN, Dungeon.SKELETON))
+    assert result.dungeon[Dungeon.GOBLIN] == 0
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.party[Party.FIGHTER] == 2
     assert not result.ability
 
 
@@ -40,11 +41,11 @@ def test_mercenary_ability_defeats_one_when_only_one():
     """Mercenary ability defeats 1 monster when only 1 exists."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(fighter=2),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(fighter=2),
     )
-    result = mercenary_ability(world, _UNUSED, "ability", ("goblin",))
-    assert result.dungeon.goblin == 0
+    result = mercenary_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN,))
+    assert result.dungeon[Dungeon.GOBLIN] == 0
     assert not result.ability
 
 
@@ -52,11 +53,11 @@ def test_mercenary_ability_requires_target():
     """Mercenary ability requires at least one target."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(fighter=2),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(fighter=2),
     )
     with pytest.raises(struct.DrollError):
-        mercenary_ability(world, _UNUSED, "ability")
+        mercenary_ability(world, _UNUSED, Action.ABILITY)
 
 
 def test_commander_ability_rerolls_dungeon_dice():
@@ -64,12 +65,12 @@ def test_commander_ability_rerolls_dungeon_dice():
     randrange = random.Random(7).randrange
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=2),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=2),
     )
-    result = commander_ability(world, randrange, "ability", ("goblin", "goblin"))
+    result = commander_ability(world, randrange, Action.ABILITY, (Dungeon.GOBLIN, Dungeon.GOBLIN))
     assert not result.ability
-    assert result.party.fighter == 2
+    assert result.party[Party.FIGHTER] == 2
 
 
 def test_commander_ability_rerolls_dragon():
@@ -77,11 +78,11 @@ def test_commander_ability_rerolls_dragon():
     randrange = random.Random(7).randrange
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(dragon=3),
-        party=struct.Party(fighter=2),
+        dungeon=make_dungeon(dragon=3),
+        party=make_party(fighter=2),
     )
     result = commander_ability(
-        world, randrange, "ability", ("dragon", "dragon", "dragon")
+        world, randrange, Action.ABILITY, (Dungeon.DRAGON, Dungeon.DRAGON, Dungeon.DRAGON)
     )
     assert not result.ability
 
@@ -90,41 +91,41 @@ def test_commander_ability_requires_target():
     """Commander ability requires at least one target."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(fighter=2),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(fighter=2),
     )
     with pytest.raises(struct.DrollError):
-        commander_ability(world, _UNUSED, "ability")
+        commander_ability(world, _UNUSED, Action.ABILITY)
 
 
 def test_commander_fighter_defeats_goblin_plus_additional():
     """Commander fighters defeat all goblins plus one additional."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(fighter=2),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(fighter=2),
     )
-    result = Commander.party.fighter.goblin(
-        world, _UNUSED, "fighter", ("goblin", "skeleton")
+    result = Commander.party[Party.FIGHTER][Dungeon.GOBLIN](
+        world, _UNUSED, Party.FIGHTER, (Dungeon.GOBLIN, Dungeon.SKELETON)
     )
-    assert result.dungeon.goblin == 0
-    assert result.dungeon.skeleton == 0
-    assert result.party.fighter == 1
+    assert result.dungeon[Dungeon.GOBLIN] == 0
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.party[Party.FIGHTER] == 1
 
 
 def test_commander_fighter_defeats_skeleton_plus_additional():
     """Commander fighters defeat one skeleton plus one additional."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(skeleton=2, ooze=1),
-        party=struct.Party(fighter=2),
+        dungeon=make_dungeon(skeleton=2, ooze=1),
+        party=make_party(fighter=2),
     )
-    result = Commander.party.fighter.skeleton(
-        world, _UNUSED, "fighter", ("skeleton", "ooze")
+    result = Commander.party[Party.FIGHTER][Dungeon.SKELETON](
+        world, _UNUSED, Party.FIGHTER, (Dungeon.SKELETON, Dungeon.OOZE)
     )
-    assert result.dungeon.skeleton == 1
-    assert result.dungeon.ooze == 0
-    assert result.party.fighter == 1
+    assert result.dungeon[Dungeon.SKELETON] == 1
+    assert result.dungeon[Dungeon.OOZE] == 0
+    assert result.party[Party.FIGHTER] == 1
 
 
 def test_mercenary_advances_to_commander():

--- a/tests/heroes/test_minstrel.py
+++ b/tests/heroes/test_minstrel.py
@@ -8,6 +8,7 @@ import pytest
 from droll import struct
 from droll.ability import minstrel_ability
 from droll.heroes.minstrel import Bard, Minstrel
+from droll.struct import Action, Dungeon, Party, make_dungeon, make_party
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -17,12 +18,12 @@ def test_minstrel_ability_discards_dragons():
     """Minstrel/Bard ability discards all dragon dice."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, dragon=3),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=1, dragon=3),
+        party=make_party(fighter=1),
     )
-    result = minstrel_ability(world, _UNUSED, "ability")
-    assert result.dungeon.dragon == 0
-    assert result.dungeon.goblin == 1
+    result = minstrel_ability(world, _UNUSED, Action.ABILITY)
+    assert result.dungeon[Dungeon.DRAGON] == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 1
     assert not result.ability
 
 
@@ -30,26 +31,26 @@ def test_minstrel_ability_rejects_non_dragon():
     """Minstrel/Bard ability only works on dragons."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, dragon=3),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=1, dragon=3),
+        party=make_party(fighter=1),
     )
     with pytest.raises(struct.DrollError):
-        minstrel_ability(world, _UNUSED, "ability", ("goblin",))
+        minstrel_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN,))
 
 
 def test_bard_champion_defeats_all_plus_additional():
     """Bard champion defeats all of one type plus one additional."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(champion=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(champion=1),
     )
-    result = Bard.party.champion.goblin(
-        world, _UNUSED, "champion", ("goblin", "skeleton")
+    result = Bard.party[Party.CHAMPION][Dungeon.GOBLIN](
+        world, _UNUSED, Party.CHAMPION, (Dungeon.GOBLIN, Dungeon.SKELETON)
     )
-    assert result.dungeon.goblin == 0
-    assert result.dungeon.skeleton == 0
-    assert result.party.champion == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 0
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.party[Party.CHAMPION] == 0
 
 
 def test_minstrel_advances_to_bard():

--- a/tests/heroes/test_occultist.py
+++ b/tests/heroes/test_occultist.py
@@ -8,6 +8,7 @@ import pytest
 from droll import struct
 from droll.ability import necromancer_ability, occultist_ability
 from droll.heroes.occultist import Necromancer, Occultist
+from droll.struct import Action, Dungeon, Party, make_dungeon, make_party
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -17,13 +18,13 @@ def test_occultist_transforms_skeleton_to_fighter():
     """Occultist transforms 1 skeleton into 1 fighter."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=2),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(goblin=1, skeleton=2),
+        party=make_party(cleric=1),
     )
-    result = occultist_ability(world, _UNUSED, "ability", ("skeleton",))
+    result = occultist_ability(world, _UNUSED, Action.ABILITY, (Dungeon.SKELETON,))
     # Discard during subsequent regroup phase tested elsewhere
-    assert result.dungeon.skeleton == 1
-    assert result.party.fighter == 1
+    assert result.dungeon[Dungeon.SKELETON] == 1
+    assert result.party[Party.FIGHTER] == 1
     assert not result.ability
 
 
@@ -31,104 +32,104 @@ def test_occultist_rejects_non_skeleton_target():
     """Occultist ability rejects non-skeleton targets."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=1),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(goblin=1, skeleton=1),
+        party=make_party(cleric=1),
     )
     with pytest.raises(struct.DrollError):
-        occultist_ability(world, _UNUSED, "ability", ("goblin",))
+        occultist_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN,))
 
 
 def test_occultist_sets_regroup_discard():
     """Occultist marks the created fighter for regroup discard."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(skeleton=1),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(skeleton=1),
+        party=make_party(cleric=1),
     )
-    result = occultist_ability(world, _UNUSED, "ability", ("skeleton",))
-    assert result.regroup.discard.fighter == 1
+    result = occultist_ability(world, _UNUSED, Action.ABILITY, (Dungeon.SKELETON,))
+    assert result.regroup.discard[Party.FIGHTER] == 1
 
 
 def test_necromancer_transforms_two_skeletons():
     """Necromancer transforms 2 skeletons into 2 fighters when available."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=2),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(goblin=1, skeleton=2),
+        party=make_party(cleric=1),
     )
     result = necromancer_ability(
-        world, _UNUSED, "ability", ("skeleton", "skeleton")
+        world, _UNUSED, Action.ABILITY, (Dungeon.SKELETON, Dungeon.SKELETON)
     )
     # Discard during subsequent regroup phase tested elsewhere
-    assert result.dungeon.skeleton == 0
-    assert result.dungeon.goblin == 1
-    assert result.party.fighter == 2
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 1
+    assert result.party[Party.FIGHTER] == 2
 
 
 def test_necromancer_transforms_one_skeleton():
     """Necromancer transforms 1 skeleton into 1 fighter when 1 available."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=1),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(goblin=1, skeleton=1),
+        party=make_party(cleric=1),
     )
     result = necromancer_ability(
         world,
         _UNUSED,
-        "ability",
-        ("skeleton",),
+        Action.ABILITY,
+        (Dungeon.SKELETON,),
     )
     # Discard during subsequent regroup phase tested elsewhere
-    assert result.dungeon.skeleton == 0
-    assert result.dungeon.goblin == 1
-    assert result.party.fighter == 1
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 1
+    assert result.party[Party.FIGHTER] == 1
 
 
 def test_necromancer_sets_regroup_discard():
     """Necromancer marks created fighters for regroup discard."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(skeleton=2),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(skeleton=2),
+        party=make_party(cleric=1),
     )
     result = necromancer_ability(
-        world, _UNUSED, "ability", ("skeleton", "skeleton")
+        world, _UNUSED, Action.ABILITY, (Dungeon.SKELETON, Dungeon.SKELETON)
     )
-    assert result.regroup.discard.fighter == 2
+    assert result.regroup.discard[Party.FIGHTER] == 2
 
 
 def test_necromancer_rejects_non_skeleton_target():
     """Necromancer ability rejects non-skeleton targets."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=2),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(goblin=1, skeleton=2),
+        party=make_party(cleric=1),
     )
     with pytest.raises(struct.DrollError):
-        necromancer_ability(world, _UNUSED, "ability", ("goblin",))
+        necromancer_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN,))
 
 
 def test_necromancer_rejects_non_skeleton_extra_target():
     """Necromancer ability rejects non-skeleton extra targets."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1, skeleton=2),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(goblin=1, skeleton=2),
+        party=make_party(cleric=1),
     )
     with pytest.raises(struct.DrollError):
-        necromancer_ability(world, _UNUSED, "ability", ("skeleton", "goblin"))
+        necromancer_ability(world, _UNUSED, Action.ABILITY, (Dungeon.SKELETON, Dungeon.GOBLIN))
 
 
 def test_necromancer_rejects_too_many_targets():
     """Necromancer rejects more than 2 targets."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(skeleton=3),
-        party=struct.Party(cleric=1),
+        dungeon=make_dungeon(skeleton=3),
+        party=make_party(cleric=1),
     )
     with pytest.raises(struct.DrollError):
         necromancer_ability(
-            world, _UNUSED, "ability", ("skeleton", "skeleton", "skeleton")
+            world, _UNUSED, Action.ABILITY, (Dungeon.SKELETON, Dungeon.SKELETON, Dungeon.SKELETON)
         )
 
 

--- a/tests/heroes/test_spellsword.py
+++ b/tests/heroes/test_spellsword.py
@@ -8,6 +8,7 @@ import pytest
 from droll import struct
 from droll.ability import battlemage_ability, spellsword_ability
 from droll.heroes.spellsword import Battlemage, Spellsword
+from droll.struct import Action, Dungeon, Party, make_dungeon, make_party
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -17,10 +18,10 @@ def test_spellsword_ability_adds_fighter():
     """Spellsword ability adds a fighter to party."""
     world = struct.World(
         ability=True,
-        party=struct.Party(fighter=1, mage=1),
+        party=make_party(fighter=1, mage=1),
     )
-    result = spellsword_ability(world, _UNUSED, "ability", ("fighter",))
-    assert result.party.fighter == 2
+    result = spellsword_ability(world, _UNUSED, Action.ABILITY, (Party.FIGHTER,))
+    assert result.party[Party.FIGHTER] == 2
     assert not result.ability
 
 
@@ -28,32 +29,32 @@ def test_spellsword_ability_adds_mage():
     """Spellsword ability adds a mage to party."""
     world = struct.World(
         ability=True,
-        party=struct.Party(fighter=1, mage=1),
+        party=make_party(fighter=1, mage=1),
     )
-    result = spellsword_ability(world, _UNUSED, "ability", ("mage",))
-    assert result.party.mage == 2
+    result = spellsword_ability(world, _UNUSED, Action.ABILITY, (Party.MAGE,))
+    assert result.party[Party.MAGE] == 2
 
 
 def test_spellsword_ability_rejects_invalid_target():
     """Spellsword ability rejects invalid targets like cleric."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(),
-        party=struct.Party(fighter=1, mage=1),
+        dungeon=make_dungeon(),
+        party=make_party(fighter=1, mage=1),
     )
     with pytest.raises(struct.DrollError):
-        spellsword_ability(world, _UNUSED, "ability", ("cleric",))
+        spellsword_ability(world, _UNUSED, Action.ABILITY, (Party.CLERIC,))
 
 
 def test_battlemage_ability_clears_dungeon():
     """Battlemage ability clears entire dungeon."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=2, chest=1, potion=1, dragon=2),
-        party=struct.Party(fighter=1, mage=1),
+        dungeon=make_dungeon(goblin=2, chest=1, potion=1, dragon=2),
+        party=make_party(fighter=1, mage=1),
     )
-    result = battlemage_ability(world, _UNUSED, "ability")
-    assert sum(struct.field_values(result.dungeon)) == 0
+    result = battlemage_ability(world, _UNUSED, Action.ABILITY)
+    assert sum(result.dungeon.values()) == 0
     assert not result.ability
 
 
@@ -61,21 +62,21 @@ def test_spellsword_ability_default_target():
     """Spellsword ability defaults to 'fighter' when no target."""
     world = struct.World(
         ability=True,
-        party=struct.Party(fighter=1, mage=1),
+        party=make_party(fighter=1, mage=1),
     )
-    result = spellsword_ability(world, _UNUSED, "ability")
-    assert result.party.fighter == 2
+    result = spellsword_ability(world, _UNUSED, Action.ABILITY)
+    assert result.party[Party.FIGHTER] == 2
 
 
 def test_battlemage_ability_rejects_target():
     """Battlemage ability rejects any target argument."""
     world = struct.World(
         ability=True,
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(fighter=1, mage=1),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(fighter=1, mage=1),
     )
     with pytest.raises(struct.DrollError):
-        battlemage_ability(world, _UNUSED, "ability", ("goblin",))
+        battlemage_ability(world, _UNUSED, Action.ABILITY, (Dungeon.GOBLIN,))
 
 
 def test_spellsword_advances_to_battlemage():

--- a/tests/test_ability.py
+++ b/tests/test_ability.py
@@ -7,6 +7,7 @@ import pytest
 
 from droll import struct
 from droll.ability import default_ability
+from droll.struct import Action
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -16,11 +17,11 @@ def test_consume_ability_when_unavailable():
     """Cannot consume ability that is already used."""
     w = struct.World(ability=False)
     with pytest.raises(struct.DrollError):
-        default_ability(w, _UNUSED, "ability")
+        default_ability(w, _UNUSED, Action.ABILITY)
 
 
 def test_default_ability_rejects_target():
     """Default ability rejects any target."""
     w = struct.World(ability=True)
     with pytest.raises(struct.DrollError):
-        default_ability(w, _UNUSED, "ability", ("fighter",))
+        default_ability(w, _UNUSED, Action.ABILITY, (struct.Party.FIGHTER,))

--- a/tests/test_display.py
+++ b/tests/test_display.py
@@ -5,23 +5,24 @@
 
 from droll import display
 from droll import struct
+from droll.struct import Dungeon, Party, Artifact, make_dungeon, make_party, make_artifacts
 
 
 def test_format_items_multiple_items():
     """Test formatting party with multiple quantities uses × notation."""
-    party = struct.Party(fighter=2, cleric=1, mage=3)
+    party = make_party(fighter=2, cleric=1, mage=3)
     assert display._format_items(party) == "fighter×2 cleric mage×3"
 
 
 def test_format_items_dragon_always_shows_count():
     """Test that dragons always display with count, even when singular."""
-    dungeon = struct.Dungeon(dragon=1)
+    dungeon = make_dungeon(dragon=1)
     assert display._format_items(dungeon) == "dragon×1"
 
 
 def test_format_treasure_multiple_items_alphabetized():
     """Test multiple treasure items are alphabetized and use × notation."""
-    artifacts = struct.Artifacts(scale=4, sceptre=1, talisman=1, tools=1)
+    artifacts = make_artifacts(scale=4, sceptre=1, talisman=1, tools=1)
     assert (
         display._format_treasure(artifacts) == "scale×4 sceptre talisman tools"
     )
@@ -52,13 +53,13 @@ def test_format_available_negative_delta():
 
 def test_format_dungeon_empty():
     """Test formatting empty dungeon returns '(empty)'."""
-    dungeon = struct.Dungeon()
+    dungeon = make_dungeon()
     assert display._format_dungeon(dungeon) == "(empty)"
 
 
 def test_format_dungeon_with_monsters():
     """Test formatting dungeon with monsters."""
-    dungeon = struct.Dungeon(goblin=1, skeleton=2)
+    dungeon = make_dungeon(goblin=1, skeleton=2)
     assert display._format_dungeon(dungeon) == "goblin skeleton×2"
 
 
@@ -68,10 +69,10 @@ def test_compact_summary_in_dungeon():
         delve=1,
         depth=3,
         experience=0,
-        dungeon=struct.Dungeon(goblin=1, skeleton=2, ooze=2),
-        party=struct.Party(fighter=1, champion=1),
+        dungeon=make_dungeon(goblin=1, skeleton=2, ooze=2),
+        party=make_party(fighter=1, champion=1),
         ability=True,
-        treasure=struct.Treasure(own=struct.Artifacts(talisman=1)),
+        treasure=struct.Treasure(own=make_artifacts(talisman=1)),
     )
     result = display.compact_summary(
         world, "Default", 1, ["ability", "retreat"]
@@ -92,9 +93,9 @@ def test_compact_summary_fixed_alignment():
         depth=0,
         experience=5,
         dungeon=None,
-        party=struct.Party(fighter=1, cleric=2, mage=3, champion=1),
+        party=make_party(fighter=1, cleric=2, mage=3, champion=1),
         ability=True,
-        treasure=struct.Treasure(own=struct.Artifacts(talisman=1)),
+        treasure=struct.Treasure(own=make_artifacts(talisman=1)),
     )
     # Both short and long hero names should have the same alignment
     for name in ("Knight", "DragonSlayer"):
@@ -120,10 +121,10 @@ def test_compact_summary_dungeon_shown_when_empty():
         delve=1,
         depth=1,
         experience=0,
-        dungeon=struct.Dungeon(),
-        party=struct.Party(fighter=1, cleric=1),
+        dungeon=make_dungeon(),
+        party=make_party(fighter=1, cleric=1),
         ability=True,
-        treasure=struct.Treasure(own=struct.Artifacts()),
+        treasure=struct.Treasure(own=make_artifacts()),
     )
     result = display.compact_summary(
         world, "Knight", 0, ["ability", "descend", "retire"]
@@ -140,11 +141,11 @@ def test_compact_summary_cleared_level_10():
         delve=3,
         depth=10,
         experience=16,
-        dungeon=struct.Dungeon(),
-        party=struct.Party(champion=1, scroll=2),
+        dungeon=make_dungeon(),
+        party=make_party(champion=1, scroll=2),
         ability=False,
         treasure=struct.Treasure(
-            own=struct.Artifacts(scale=4, sceptre=1, talisman=1, tools=1)
+            own=make_artifacts(scale=4, sceptre=1, talisman=1, tools=1)
         ),
     )
     result = display.compact_summary(world, "Beguiler", 24, ["retire"])
@@ -164,10 +165,10 @@ def test_compact_summary_ending_state():
         delve=3,
         experience=16,
         dungeon=None,
-        party=struct.Party(champion=1),
+        party=make_party(champion=1),
         ability=False,
         treasure=struct.Treasure(
-            own=struct.Artifacts(scroll=1, elixir=1, bait=2, portal=1, scale=1)
+            own=make_artifacts(scroll=1, elixir=1, bait=2, portal=1, scale=1)
         ),
     )
     result = display.compact_summary(world, "DragonSlayer", 23, [])

--- a/tests/test_game.py
+++ b/tests/test_game.py
@@ -7,7 +7,7 @@ from dataclasses import replace
 import random
 import pytest
 
-from droll import struct
+from droll.struct import Artifact, Dungeon, Party, make_dungeon, make_party, frozen
 from droll.struct import DrollError
 from droll.game import Game, GameState
 from droll.player import Default
@@ -32,13 +32,13 @@ def test_reroll_dungeon_dice():
     g._world = replace(
         g._world,
         depth=1,
-        party=replace(g._world.party, scroll=1),
-        dungeon=struct.Dungeon(goblin=2),
+        party=frozen({**g._world.party, Party.SCROLL: 1}),
+        dungeon=make_dungeon(goblin=2),
     )
-    pre_scroll = g._world.party.scroll
+    pre_scroll = g._world.party[Party.SCROLL]
     g.reroll("goblin")
     # Scroll consumed, dungeon rerolled
-    assert g._world.party.scroll == pre_scroll - 1
+    assert g._world.party[Party.SCROLL] == pre_scroll - 1
 
 
 def test_reroll_portion():
@@ -49,13 +49,13 @@ def test_reroll_portion():
     g._world = replace(
         g._world,
         depth=1,
-        party=replace(g._world.party, scroll=1),
-        dungeon=struct.Dungeon(potion=2),
+        party=frozen({**g._world.party, Party.SCROLL: 1}),
+        dungeon=make_dungeon(potion=2),
     )
-    pre_scroll = g._world.party.scroll
+    pre_scroll = g._world.party[Party.SCROLL]
     g.reroll("potion")
     # Scroll consumed, dungeon rerolled
-    assert g._world.party.scroll == pre_scroll - 1
+    assert g._world.party[Party.SCROLL] == pre_scroll - 1
 
 
 def test_reroll_multiple_targets():
@@ -65,11 +65,11 @@ def test_reroll_multiple_targets():
     g._world = replace(
         g._world,
         depth=1,
-        party=replace(g._world.party, scroll=1),
-        dungeon=struct.Dungeon(goblin=1, skeleton=1),
+        party=frozen({**g._world.party, Party.SCROLL: 1}),
+        dungeon=make_dungeon(goblin=1, skeleton=1),
     )
     g.reroll("goblin", "skeleton")
-    assert g._world.party.scroll == 0
+    assert g._world.party[Party.SCROLL] == 0
 
 
 def test_apply_portal_directly_fails():
@@ -79,7 +79,7 @@ def test_apply_portal_directly_fails():
     g._world = replace(
         g._world,
         treasure=replace(
-            g._world.treasure, own=replace(g._world.treasure.own, portal=1)
+            g._world.treasure, own=frozen({**g._world.treasure.own, Artifact.PORTAL: 1})
         ),
     )
     with pytest.raises(DrollError):
@@ -93,7 +93,7 @@ def test_apply_ring_directly_fails():
     g._world = replace(
         g._world,
         treasure=replace(
-            g._world.treasure, own=replace(g._world.treasure.own, ring=1)
+            g._world.treasure, own=frozen({**g._world.treasure.own, Artifact.RING: 1})
         ),
     )
     with pytest.raises(DrollError):
@@ -105,7 +105,7 @@ def test_retreat():
     g = Game(random=random.Random(4), player=Default)
     g.descend()
     # Place a monster so retreat is valid (can't retreat from cleared dungeon)
-    g._world = replace(g._world, dungeon=struct.Dungeon(goblin=1))
+    g._world = replace(g._world, dungeon=make_dungeon(goblin=1))
     result = g.retreat()
     assert result == GameState.PLAY
     # After retreat, a new delve should have started
@@ -119,7 +119,7 @@ def test_completenames():
     g.descend()
 
     # With monsters: retreat is possible, retire is not
-    g._world = replace(g._world, dungeon=struct.Dungeon(goblin=1))
+    g._world = replace(g._world, dungeon=make_dungeon(goblin=1))
     names = g.completenames(text="", head=[], tail=[])
     assert "ability" in names
     assert "retreat" in names
@@ -130,7 +130,7 @@ def test_completenames():
     )
 
     # With cleared dungeon: retire is possible
-    g._world = replace(g._world, dungeon=struct.Dungeon())
+    g._world = replace(g._world, dungeon=make_dungeon())
     names = g.completenames(text="", head=[], tail=[])
     assert "retire" in names
 
@@ -141,8 +141,8 @@ def test_completedefault():
     g.descend()
     g._world = replace(
         g._world,
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(fighter=1),
     )
     results = g.completedefault(text="fi", head=[], tail=[])
     assert "fighter" in results
@@ -152,7 +152,7 @@ def test_score_deltas_retire_cleared():
     """score_deltas returns +depth for retire with cleared dungeon."""
     g = Game(random=random.Random(4), player=Default)
     g.descend()
-    g._world = replace(g._world, dungeon=struct.Dungeon())
+    g._world = replace(g._world, dungeon=make_dungeon())
     deltas = g.score_deltas()
     assert "retire" in deltas
     assert deltas["retire"] == g._world.depth
@@ -162,7 +162,7 @@ def test_score_deltas_retreat_with_monsters():
     """score_deltas returns 0 for retreat with monsters present."""
     g = Game(random=random.Random(4), player=Default)
     g.descend()
-    g._world = replace(g._world, dungeon=struct.Dungeon(goblin=1))
+    g._world = replace(g._world, dungeon=make_dungeon(goblin=1))
     deltas = g.score_deltas()
     assert "retreat" in deltas
     assert deltas["retreat"] == 0
@@ -175,9 +175,9 @@ def test_score_deltas_retire_consumes_portal():
     g._world = replace(
         g._world,
         depth=1,
-        dungeon=struct.Dungeon(goblin=1),
+        dungeon=make_dungeon(goblin=1),
         treasure=replace(
-            g._world.treasure, own=replace(g._world.treasure.own, portal=1)
+            g._world.treasure, own=frozen({**g._world.treasure.own, Artifact.PORTAL: 1})
         ),
     )
     deltas = g.score_deltas()
@@ -190,7 +190,7 @@ def test_score_deltas_retire_nonzero():
     """Retire at depth 5 with cleared dungeon earns +5."""
     g = Game(random=random.Random(4), player=Default)
     g.descend()
-    g._world = replace(g._world, depth=5, dungeon=struct.Dungeon())
+    g._world = replace(g._world, depth=5, dungeon=make_dungeon())
     deltas = g.score_deltas()
     assert deltas["retire"] == 5
 
@@ -202,9 +202,9 @@ def test_score_deltas_retreat_nonzero():
     g._world = replace(
         g._world,
         depth=5,
-        dungeon=struct.Dungeon(goblin=1),
+        dungeon=make_dungeon(goblin=1),
         treasure=replace(
-            g._world.treasure, own=replace(g._world.treasure.own, portal=1)
+            g._world.treasure, own=frozen({**g._world.treasure.own, Artifact.PORTAL: 1})
         ),
     )
     deltas = g.score_deltas()
@@ -218,11 +218,11 @@ def test_next_delve_returns_stop_after_three():
     # Play through 3 delves by retiring from each
     for _ in range(2):
         g.descend()
-        g._world = replace(g._world, dungeon=struct.Dungeon())
+        g._world = replace(g._world, dungeon=make_dungeon())
         result = g.retire()
         assert result == GameState.PLAY
     # Third delve: retire should trigger STOP
     g.descend()
-    g._world = replace(g._world, dungeon=struct.Dungeon())
+    g._world = replace(g._world, dungeon=make_dungeon())
     result = g.retire()
     assert result == GameState.STOP

--- a/tests/test_party.py
+++ b/tests/test_party.py
@@ -6,39 +6,39 @@
 import pytest
 
 from droll.party import decrement_party, decrement_regroup, increment_party
-from droll.struct import DrollError, Party, Regroup
+from droll.struct import DrollError, Party, Regroup, make_party
 
 
 def test_decrement_party():
     """Decrementing a positive hero count yields one fewer."""
-    party = Party(fighter=2, cleric=1)
-    result = decrement_party(party, "fighter")
-    assert result.fighter == 1
+    party = make_party(fighter=2, cleric=1)
+    result = decrement_party(party, Party.FIGHTER)
+    assert result[Party.FIGHTER] == 1
 
 
 def test_decrement_party_zero_target():
     """Cannot decrement a hero that is already zero."""
-    party = Party(fighter=0, cleric=1)
+    party = make_party(fighter=0, cleric=1)
     with pytest.raises(DrollError):
-        decrement_party(party, "fighter")
+        decrement_party(party, Party.FIGHTER)
 
 
 def test_increment_party():
     """Incrementing a hero count yields one more."""
-    party = Party(fighter=1)
-    result = increment_party(party, "fighter")
-    assert result.fighter == 2
+    party = make_party(fighter=1)
+    result = increment_party(party, Party.FIGHTER)
+    assert result[Party.FIGHTER] == 2
 
 
 def test_decrement_regroup_positive():
     """Decrementing a positive discard counter yields one fewer."""
-    regroup = Regroup(discard=Party(thief=2))
-    result = decrement_regroup(regroup, "thief")
-    assert result.discard.thief == 1
+    regroup = Regroup(discard=make_party(thief=2))
+    result = decrement_regroup(regroup, Party.THIEF)
+    assert result.discard[Party.THIEF] == 1
 
 
 def test_decrement_regroup_zero():
     """Decrementing a zero discard counter stays at zero."""
-    regroup = Regroup(discard=Party(thief=0))
-    result = decrement_regroup(regroup, "thief")
-    assert result.discard.thief == 0
+    regroup = Regroup(discard=make_party(thief=0))
+    result = decrement_regroup(regroup, Party.THIEF)
+    assert result.discard[Party.THIEF] == 0

--- a/tests/test_player.py
+++ b/tests/test_player.py
@@ -3,17 +3,22 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Testing of world-to-world transitions stemming from player actions."""
 
-from dataclasses import fields, replace
+from dataclasses import replace
 import random
 import pytest
 
 from droll import player, struct, world
+from droll.struct import Artifact, Dungeon, Party, make_dungeon, make_party, make_artifacts, all_dungeon, all_party
 
 
 def _remove_monsters(world: struct.World) -> struct.World:
     """Remove all monsters from dungeon for testing treasure interactions."""
+    from droll.struct import frozen
     return replace(
-        world, dungeon=replace(world.dungeon, goblin=0, skeleton=0, ooze=0)
+        world, dungeon=frozen({
+            **world.dungeon,
+            Dungeon.GOBLIN: 0, Dungeon.SKELETON: 0, Dungeon.OOZE: 0,
+        })
     )
 
 
@@ -23,8 +28,8 @@ class TestPlayer:
         """Fixtures with a game containing 2 of each dungeon and party item."""
         self.game = replace(
             world.new_world(),
-            dungeon=struct.Dungeon(*([2] * len(fields(struct.Dungeon)))),
-            party=struct.Party(*([2] * len(fields(struct.Party)))),
+            dungeon=all_dungeon(2),
+            party=all_party(2),
         )
         self.randrange = random.Random(4).randrange
 
@@ -33,12 +38,12 @@ class TestPlayer:
         game = player.apply(
             player.Default, self.game, None, "fighter", "goblin"
         )
-        assert game.party.fighter == 1
-        assert game.dungeon.goblin == 0
+        assert game.party[Party.FIGHTER] == 1
+        assert game.dungeon[Dungeon.GOBLIN] == 0
 
         game = player.apply(player.Default, game, None, "fighter", "ooze")
-        assert game.party.fighter == 0
-        assert game.dungeon.ooze == 1
+        assert game.party[Party.FIGHTER] == 0
+        assert game.dungeon[Dungeon.OOZE] == 1
 
         with pytest.raises(struct.DrollError):
             player.apply(player.Default, game, None, "fighter", "ooze")
@@ -51,42 +56,43 @@ class TestPlayer:
         game = player.apply(
             player.Default, self.game, None, "cleric", "skeleton"
         )
-        assert game.party.cleric == 1
-        assert game.dungeon.skeleton == 0
+        assert game.party[Party.CLERIC] == 1
+        assert game.dungeon[Dungeon.SKELETON] == 0
 
         game = _remove_monsters(game)  # Required for opening chest
         game = player.apply(
             player.Default, game, self.randrange, "cleric", "chest"
         )
-        assert game.party.cleric == 0
-        assert game.dungeon.chest == 1
-        assert sum(struct.field_values(game.treasure.own)) == 1
+        assert game.party[Party.CLERIC] == 0
+        assert game.dungeon[Dungeon.CHEST] == 1
+        assert sum(game.treasure.own.values()) == 1
 
     def test_mage(self):
         """Test mage hero attacking oozes and goblins."""
         game = player.apply(player.Default, self.game, None, "mage", "ooze")
-        assert game.party.mage == 1
-        assert game.dungeon.ooze == 0
+        assert game.party[Party.MAGE] == 1
+        assert game.dungeon[Dungeon.OOZE] == 0
 
         game = player.apply(player.Default, game, None, "mage", "goblin")
-        assert game.party.mage == 0
-        assert game.dungeon.goblin == 1
+        assert game.party[Party.MAGE] == 0
+        assert game.dungeon[Dungeon.GOBLIN] == 1
 
     def test_thief(self):
         """Test thief hero opening chests without consuming monsters."""
         game = player.apply(player.Default, self.game, None, "thief", "ooze")
-        assert game.party.thief == 1
-        assert game.dungeon.ooze == 1
+        assert game.party[Party.THIEF] == 1
+        assert game.dungeon[Dungeon.OOZE] == 1
 
         game = _remove_monsters(game)  # Required for opening chest
         game = player.apply(
             player.Default, game, self.randrange, "thief", "chest"
         )
-        assert game.party.thief == 0
-        assert game.dungeon.chest == 0
-        assert sum(struct.field_values(game.treasure.own)) == 2
+        assert game.party[Party.THIEF] == 0
+        assert game.dungeon[Dungeon.CHEST] == 0
+        assert sum(game.treasure.own.values()) == 2
 
-        game = replace(game, party=replace(game.party, thief=1))  # Add one
+        from droll.struct import frozen
+        game = replace(game, party=frozen({**game.party, Party.THIEF: 1}))
         with pytest.raises(struct.DrollError):
             player.apply(player.Default, game, None, "thief", "chest")
 
@@ -95,17 +101,17 @@ class TestPlayer:
         game = player.apply(
             player.Default, self.game, None, "champion", "goblin"
         )
-        assert game.party.champion == 1
-        assert game.dungeon.goblin == 0
+        assert game.party[Party.CHAMPION] == 1
+        assert game.dungeon[Dungeon.GOBLIN] == 0
 
         game = _remove_monsters(game)  # Required for drinking potion
         game = player.apply(
             player.Default, game, None, "champion", "potion", "cleric", "mage"
-        )  # Different
-        assert game.party.champion == 0
-        assert game.dungeon.potion == 0
-        assert game.party.cleric == 3
-        assert game.party.mage == 3
+        )
+        assert game.party[Party.CHAMPION] == 0
+        assert game.dungeon[Dungeon.POTION] == 0
+        assert game.party[Party.CLERIC] == 3
+        assert game.party[Party.MAGE] == 3
 
     def test_scroll_quaff(self):
         """Test scroll used to drink potions and obtain duplicate heroes."""
@@ -130,9 +136,9 @@ class TestPlayer:
             "fighter",
             "fighter",
         )  # Duplicate
-        assert game.party.scroll == 1
-        assert game.dungeon.potion == 0
-        assert game.party.fighter == 4
+        assert game.party[Party.SCROLL] == 1
+        assert game.dungeon[Dungeon.POTION] == 0
+        assert game.party[Party.FIGHTER] == 4
 
     def test_apply_hero_without_target(self):
         """Applying a hero without a target raises DrollError."""
@@ -141,14 +147,11 @@ class TestPlayer:
 
     def test_scroll_reroll(self):
         """Test reroll command to reroll dungeon dice (issue #133)."""
-        # Consumed by canned_sequence just below
         sequence = [0, 1, 2]
 
         def canned_sequence(start, stop):
-            """Predetermined sequence values for deterministic testing."""
             return start + sequence.pop(0)
 
-        # 'reroll' re-rolls chests via the scroll mechanic
         game = player.apply(
             player.Default,
             self.game,
@@ -158,19 +161,19 @@ class TestPlayer:
             "ooze",
             "chest",
         )
-        assert game.party.scroll == 1
-        assert game.dungeon == struct.Dungeon(
+        assert game.party[Party.SCROLL] == 1
+        assert game.dungeon == make_dungeon(
             goblin=3, skeleton=3, ooze=2, chest=0, potion=2, dragon=2
         )
 
     def test_unknown_command(self):
         """Unknown command raises DrollError without exposing internals."""
-        with pytest.raises(struct.DrollError, match='Unknown command "foo"'):
+        with pytest.raises(struct.DrollError, match='Unknown token "foo"'):
             player.apply(player.Default, self.game, None, "foo", "goblin")
 
     def test_unknown_target(self):
         """Unknown target raises DrollError without exposing internals."""
-        with pytest.raises(struct.DrollError, match='Unknown target "bar"'):
+        with pytest.raises(struct.DrollError, match='Unknown token "bar"'):
             player.apply(player.Default, self.game, None, "fighter", "bar")
 
     def test_scroll_not_reroll(self):
@@ -181,9 +184,9 @@ class TestPlayer:
     def test_no_dungeon_hero_target(self):
         """Hero targeting with no dungeon gives user-friendly error."""
         no_dungeon = replace(self.game, dungeon=None)
-        for hero in struct.field_names(struct.Party):
+        for hero in Party:
             with pytest.raises(struct.DrollError, match="You must descend first"):
-                player.apply(player.Default, no_dungeon, None, hero, "goblin")
+                player.apply(player.Default, no_dungeon, None, hero.value, "goblin")
 
     def test_no_dungeon_ability(self):
         """Ability targeting with no dungeon gives user-friendly error."""
@@ -206,22 +209,23 @@ class TestComplete:
         """Set up test fixtures for completion testing."""
         self.game = replace(
             world.new_world(),
-            dungeon=struct.Dungeon(*([2] * len(fields(struct.Dungeon)))),
-            party=struct.Party(*([2] * len(fields(struct.Party)))),
+            dungeon=all_dungeon(2),
+            party=all_party(2),
         )
 
     def test_complete0(self):
         """Complete available party and treasure in the zeroth position."""
         game = self.game
         assert complete(game, ("fig",), "fig", 0) == ["fighter"]
-        game = replace(game, party=replace(game.party, fighter=0))
+        from droll.struct import frozen
+        game = replace(game, party=frozen({**game.party, Party.FIGHTER: 0}))
         assert complete(game, ("fig",), "fig", 0) == []  # party
         assert complete(game, ("gob",), "gob", 0) == []  # dungeon
         assert complete(game, ("bai",), "bai", 0) == []  # treasure
         game = replace(
             game,
             treasure=replace(
-                game.treasure, own=replace(game.treasure.own, bait=1)
+                game.treasure, own=make_artifacts(bait=1)
             ),
         )
         assert complete(game, ("bai",), "bai", 0) == ["bait"]  # treasure
@@ -229,23 +233,20 @@ class TestComplete:
     def test_complete0_excludes_noncommand_treasures(self):
         """Non-command treasures (portal, ring, scale) excluded from pos 0."""
         game = self.game
-        # Add all three non-command treasures
         game = replace(
             game,
             treasure=replace(
                 game.treasure,
-                own=replace(game.treasure.own, portal=1, ring=1, scale=1),
+                own=make_artifacts(portal=1, ring=1, scale=1),
             ),
         )
-        # None of them should appear in completions
         assert complete(game, ("por",), "por", 0) == []
         assert complete(game, ("rin",), "rin", 0) == []
         assert complete(game, ("sca",), "sca", 0) == []
-        # But a command treasure like elixir should still work
         game = replace(
             game,
             treasure=replace(
-                game.treasure, own=replace(game.treasure.own, elixir=1)
+                game.treasure, own=make_artifacts(elixir=1)
             ),
         )
         assert complete(game, ("eli",), "eli", 0) == ["elixir"]
@@ -253,31 +254,30 @@ class TestComplete:
     def test_complete1(self):
         """Complete available party and dungeon in the first position."""
         game = self.game
-        # Vanilla first position stuff
         assert complete(game, ("fig", "gob"), "gob", 1) == ["goblin"]
         assert complete(game, ("fig", "fig"), "fig", 1) == ["fighter"]  # party
-        game = replace(game, dungeon=replace(game.dungeon, goblin=0))
+        from droll.struct import frozen
+        game = replace(game, dungeon=frozen({**game.dungeon, Dungeon.GOBLIN: 0}))
         assert complete(game, ("fig", "gob"), "gob", 1) == []  # dungeon
-        game = replace(game, party=replace(game.party, fighter=0))
+        game = replace(game, party=frozen({**game.party, Party.FIGHTER: 0}))
         assert complete(game, ("fig", "fig"), "fig", 1) == []  # dungeon
         game = replace(
             game,
             treasure=replace(
-                game.treasure, own=replace(game.treasure.own, bait=1)
+                game.treasure, own=make_artifacts(bait=1)
             ),
         )
         assert complete(game, ("fig", "bai"), "fig", 1) == []  # treasure
 
         # Special case associated with 'elixir'
-        game = replace(game, party=struct.Party())
+        game = replace(game, party=make_party())
         game = replace(game, treasure=struct.Treasure())
-        assert complete(game, ("elixir", ""), "", 1) == list(
-            sorted(struct.field_names(struct.Party))
-        )
+        assert complete(game, ("elixir", ""), "", 1) == sorted(p.value for p in Party)
 
     def test_complete2(self):
         """Complete all party and dungeon in the second position."""
-        game = replace(self.game, party=replace(self.game.party, fighter=0))
+        from droll.struct import frozen
+        game = replace(self.game, party=frozen({**self.game.party, Party.FIGHTER: 0}))
         game = _remove_monsters(game)
         assert complete(game, ("X", "Y", "fig"), "fig", 2) == ["fighter"]
         assert complete(game, ("X", "Y", "gob"), "gob", 2) == ["goblin"]

--- a/tests/test_regular.py
+++ b/tests/test_regular.py
@@ -3,13 +3,25 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Tests for regular module helpers."""
 
-from dataclasses import fields, replace
+from dataclasses import replace
 import random
 import pytest
 
 from droll import dice, heroes, player, regular, struct, world
 from droll.dungeon import decrement_dungeon, eliminate_dungeon
-from droll.struct import DrollError
+from droll.struct import (
+    Action,
+    Artifact,
+    Dungeon,
+    DrollError,
+    Party,
+    make_dungeon,
+    make_party,
+    make_artifacts,
+    all_dungeon,
+    all_party,
+    frozen,
+)
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -22,8 +34,8 @@ class TestRerollParty:
         """Fixture with a world containing known dungeon and party dice."""
         self.world = replace(
             world.new_world(),
-            dungeon=struct.Dungeon(goblin=2, skeleton=1),
-            party=struct.Party(fighter=2, cleric=1, scroll=2),
+            dungeon=make_dungeon(goblin=2, skeleton=1),
+            party=make_party(fighter=2, cleric=1, scroll=2),
         )
 
     def _canned_randrange(self, sequence):
@@ -39,11 +51,11 @@ class TestRerollParty:
         """Rerolling a single party die removes and re-rolls it."""
         # Roll value 0 => fighter
         randrange = self._canned_randrange([0])
-        result = regular.reroll(self.world, randrange, "scroll", ("fighter",))
+        result = regular.reroll(self.world, randrange, Party.SCROLL, (Party.FIGHTER,))
         # One scroll consumed for the hero cost
-        assert result.party.scroll == 1
+        assert result.party[Party.SCROLL] == 1
         # Fighter was removed (2-1=1) then re-rolled as fighter (+1=2)
-        assert result.party.fighter == 2
+        assert result.party[Party.FIGHTER] == 2
         # Dungeon unchanged
         assert result.dungeon == self.world.dungeon
 
@@ -52,13 +64,13 @@ class TestRerollParty:
         # Roll values: 0 => fighter, 1 => cleric
         randrange = self._canned_randrange([0, 1])
         result = regular.reroll(
-            self.world, randrange, "scroll", ("fighter", "cleric")
+            self.world, randrange, Party.SCROLL, (Party.FIGHTER, Party.CLERIC)
         )
         # One scroll consumed
-        assert result.party.scroll == 1
+        assert result.party[Party.SCROLL] == 1
         # fighter: 2 - 1 + 1(rolled) = 2; cleric: 1 - 1 + 1(rolled) = 1
-        assert result.party.fighter == 2
-        assert result.party.cleric == 1
+        assert result.party[Party.FIGHTER] == 2
+        assert result.party[Party.CLERIC] == 1
         # Dungeon unchanged
         assert result.dungeon == self.world.dungeon
 
@@ -67,50 +79,44 @@ class TestRerollParty:
         # Dungeon roll: value 0 => goblin; Party roll: value 2 => mage
         randrange = self._canned_randrange([0, 2])
         result = regular.reroll(
-            self.world, randrange, "scroll", ("goblin", "fighter")
+            self.world, randrange, Party.SCROLL, (Dungeon.GOBLIN, Party.FIGHTER)
         )
         # One scroll consumed
-        assert result.party.scroll == 1
+        assert result.party[Party.SCROLL] == 1
         # Dungeon: goblin was 2, removed 1, re-rolled as goblin (+1) => 2
-        assert result.dungeon.goblin == 2
+        assert result.dungeon[Dungeon.GOBLIN] == 2
         # Party: fighter was 2, removed 1, re-rolled as mage (+1)
-        assert result.party.fighter == 1
-        assert result.party.mage == 1
+        assert result.party[Party.FIGHTER] == 1
+        assert result.party[Party.MAGE] == 1
 
     def test_reroll_party_die_not_present_raises(self):
         """Rerolling a party die that is not present raises DrollError."""
         randrange = self._canned_randrange([])
         with pytest.raises(DrollError):
-            regular.reroll(self.world, randrange, "scroll", ("mage",))
-
-    def test_reroll_unknown_target_raises(self):
-        """Rerolling an unknown target raises DrollError."""
-        randrange = self._canned_randrange([])
-        with pytest.raises(DrollError):
-            regular.reroll(self.world, randrange, "scroll", ("nonexistent",))
+            regular.reroll(self.world, randrange, Party.SCROLL, (Party.MAGE,))
 
     def test_reroll_requires_hero_before_rolling(self):
         """A rolled scroll cannot pay the cost of the reroll (issue #105)."""
-        w = replace(self.world, party=replace(self.world.party, scroll=0))
+        w = replace(self.world, party=frozen({**self.world.party, Party.SCROLL: 0}))
         with pytest.raises(DrollError):
             regular.reroll(
-                w, self._canned_randrange([5, 5, 5, 5, 5]), "scroll", ("fighter",)
+                w, self._canned_randrange([5, 5, 5, 5, 5]), Party.SCROLL, (Party.FIGHTER,)
             )
 
 
 def test_all_distinct_no_options():
     """All different heroes are fully distinct."""
-    assert regular.distinct_heroes(["fighter", "cleric", "mage"]) == 3
+    assert regular.distinct_heroes([Party.FIGHTER, Party.CLERIC, Party.MAGE]) == 3
 
 
 def test_duplicates_reduce_count():
     """Duplicate heroes reduce distinct count."""
-    assert regular.distinct_heroes(["fighter", "fighter", "mage"]) == 2
+    assert regular.distinct_heroes([Party.FIGHTER, Party.FIGHTER, Party.MAGE]) == 2
 
 
 def test_all_same():
     """All identical heroes yield 1."""
-    assert regular.distinct_heroes(["fighter", "fighter", "fighter"]) == 1
+    assert regular.distinct_heroes([Party.FIGHTER, Party.FIGHTER, Party.FIGHTER]) == 1
 
 
 def test_empty():
@@ -120,15 +126,15 @@ def test_empty():
 
 def test_single():
     """Single hero is 1 distinct."""
-    assert regular.distinct_heroes(["mage"]) == 1
+    assert regular.distinct_heroes([Party.MAGE]) == 1
 
 
 def test_wildcard_adds_one_each():
     """Each wildcard counts as a distinct hero."""
     assert (
         regular.distinct_heroes(
-            ["cleric", "thief", "scroll"],
-            wildcard=frozenset({"scroll"}),
+            [Party.CLERIC, Party.THIEF, Party.SCROLL],
+            wildcard=frozenset({Party.SCROLL}),
         )
         == 3
     )
@@ -138,8 +144,8 @@ def test_multiple_wildcards():
     """Multiple wildcards each contribute 1."""
     assert (
         regular.distinct_heroes(
-            ["fighter", "scroll", "scroll"],
-            wildcard=frozenset({"scroll"}),
+            [Party.FIGHTER, Party.SCROLL, Party.SCROLL],
+            wildcard=frozenset({Party.SCROLL}),
         )
         == 3
     )
@@ -149,8 +155,8 @@ def test_all_wildcards():
     """All wildcards still count as distinct."""
     assert (
         regular.distinct_heroes(
-            ["scroll", "scroll", "scroll"],
-            wildcard=frozenset({"scroll"}),
+            [Party.SCROLL, Party.SCROLL, Party.SCROLL],
+            wildcard=frozenset({Party.SCROLL}),
         )
         == 3
     )
@@ -160,8 +166,8 @@ def test_wildcard_does_not_help_duplicates():
     """Wildcards don't fix duplicate non-wildcards."""
     assert (
         regular.distinct_heroes(
-            ["mage", "mage", "scroll"],
-            wildcard=frozenset({"scroll"}),
+            [Party.MAGE, Party.MAGE, Party.SCROLL],
+            wildcard=frozenset({Party.SCROLL}),
         )
         == 2
     )
@@ -171,8 +177,8 @@ def test_interchangeable_two_from_pool():
     """Two interchangeable heroes contribute 2 distinct."""
     assert (
         regular.distinct_heroes(
-            ["fighter", "cleric", "mage"],
-            interchangeable=frozenset({"fighter", "cleric"}),
+            [Party.FIGHTER, Party.CLERIC, Party.MAGE],
+            interchangeable=frozenset({Party.FIGHTER, Party.CLERIC}),
         )
         == 3
     )
@@ -182,8 +188,8 @@ def test_interchangeable_capped_by_pool_size():
     """Interchangeable contribution capped at pool size."""
     assert (
         regular.distinct_heroes(
-            ["mage", "mage", "mage"],
-            interchangeable=frozenset({"mage", "fighter"}),
+            [Party.MAGE, Party.MAGE, Party.MAGE],
+            interchangeable=frozenset({Party.MAGE, Party.FIGHTER}),
         )
         == 2
     )
@@ -193,8 +199,8 @@ def test_interchangeable_all_same_type():
     """All same type from a 2-member pool still capped at 2."""
     assert (
         regular.distinct_heroes(
-            ["fighter", "fighter", "fighter"],
-            interchangeable=frozenset({"mage", "fighter"}),
+            [Party.FIGHTER, Party.FIGHTER, Party.FIGHTER],
+            interchangeable=frozenset({Party.MAGE, Party.FIGHTER}),
         )
         == 2
     )
@@ -204,8 +210,8 @@ def test_interchangeable_mixed_overflow():
     """Mixed interchangeable heroes exceeding pool size."""
     assert (
         regular.distinct_heroes(
-            ["fighter", "mage", "mage"],
-            interchangeable=frozenset({"mage", "fighter"}),
+            [Party.FIGHTER, Party.MAGE, Party.MAGE],
+            interchangeable=frozenset({Party.MAGE, Party.FIGHTER}),
         )
         == 2
     )
@@ -215,8 +221,8 @@ def test_interchangeable_with_regular():
     """Interchangeable heroes + distinct regular hero."""
     assert (
         regular.distinct_heroes(
-            ["fighter", "cleric", "thief"],
-            interchangeable=frozenset({"fighter", "cleric"}),
+            [Party.FIGHTER, Party.CLERIC, Party.THIEF],
+            interchangeable=frozenset({Party.FIGHTER, Party.CLERIC}),
         )
         == 3
     )
@@ -226,8 +232,8 @@ def test_interchangeable_single_member_present():
     """One hero from interchangeable set contributes 1."""
     assert (
         regular.distinct_heroes(
-            ["cleric", "thief", "fighter"],
-            interchangeable=frozenset({"fighter"}),
+            [Party.CLERIC, Party.THIEF, Party.FIGHTER],
+            interchangeable=frozenset({Party.FIGHTER}),
         )
         == 3
     )
@@ -237,8 +243,8 @@ def test_interchangeable_single_member_absent():
     """No heroes from interchangeable set contribute 0 from pool."""
     assert (
         regular.distinct_heroes(
-            ["cleric", "thief", "mage"],
-            interchangeable=frozenset({"fighter"}),
+            [Party.CLERIC, Party.THIEF, Party.MAGE],
+            interchangeable=frozenset({Party.FIGHTER}),
         )
         == 3
     )
@@ -247,18 +253,18 @@ def test_interchangeable_single_member_absent():
 def test_dragon_wildcard_less_interesting_successful_cases():
     """Test valid dragon defeats with wildcard heroes."""
     regular.defeat_dragon_heroes(
-        "cleric",
-        "thief",
-        "mage",
+        Party.CLERIC,
+        Party.THIEF,
+        Party.MAGE,
         disallowed_heroes=frozenset(),
-        wildcard=frozenset({"scroll"}),
+        wildcard=frozenset({Party.SCROLL}),
     )
     regular.defeat_dragon_heroes(
-        "cleric",
-        "thief",
-        "fighter",
+        Party.CLERIC,
+        Party.THIEF,
+        Party.FIGHTER,
         disallowed_heroes=frozenset(),
-        wildcard=frozenset({"scroll"}),
+        wildcard=frozenset({Party.SCROLL}),
     )
 
 
@@ -266,35 +272,35 @@ def test_dragon_wildcard_less_interesting_failure_cases():
     """Test invalid dragon defeats with wildcard heroes."""
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "cleric",
-            "thief",
+            Party.CLERIC,
+            Party.THIEF,
             disallowed_heroes=frozenset(),
-            wildcard=frozenset({"scroll"}),
+            wildcard=frozenset({Party.SCROLL}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "cleric",
-            "fighter",
+            Party.CLERIC,
+            Party.FIGHTER,
             disallowed_heroes=frozenset(),
-            wildcard=frozenset({"fighter"}),
+            wildcard=frozenset({Party.FIGHTER}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "cleric",
-            "thief",
-            "champion",
-            "mage",
+            Party.CLERIC,
+            Party.THIEF,
+            Party.CHAMPION,
+            Party.MAGE,
             disallowed_heroes=frozenset(),
-            wildcard=frozenset({"fighter"}),
+            wildcard=frozenset({Party.FIGHTER}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "cleric",
-            "thief",
-            "champion",
-            "fighter",
+            Party.CLERIC,
+            Party.THIEF,
+            Party.CHAMPION,
+            Party.FIGHTER,
             disallowed_heroes=frozenset(),
-            wildcard=frozenset({"fighter"}),
+            wildcard=frozenset({Party.FIGHTER}),
         )
 
 
@@ -302,35 +308,35 @@ def test_dragon_wildcard_more_interesting_failure_cases():
     """Test invalid dragon defeats with multiple wildcard heroes."""
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "mage",
-            "mage",
-            "scroll",
+            Party.MAGE,
+            Party.MAGE,
+            Party.SCROLL,
             disallowed_heroes=frozenset(),
-            wildcard=frozenset({"scroll"}),
+            wildcard=frozenset({Party.SCROLL}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "fighter",
-            "fighter",
-            "fighter",
+            Party.FIGHTER,
+            Party.FIGHTER,
+            Party.FIGHTER,
             disallowed_heroes=frozenset(),
-            wildcard=frozenset({"mage"}),
+            wildcard=frozenset({Party.MAGE}),
         )
 
 
 def test_dragon_interchangeable_less_interesting_successful_cases():
     """Test valid dragon defeats with interchangeable heroes."""
     regular.defeat_dragon_heroes(
-        "cleric",
-        "thief",
-        "mage",
-        interchangeable=frozenset({"fighter"}),
+        Party.CLERIC,
+        Party.THIEF,
+        Party.MAGE,
+        interchangeable=frozenset({Party.FIGHTER}),
     )
     regular.defeat_dragon_heroes(
-        "cleric",
-        "thief",
-        "fighter",
-        interchangeable=frozenset({"fighter"}),
+        Party.CLERIC,
+        Party.THIEF,
+        Party.FIGHTER,
+        interchangeable=frozenset({Party.FIGHTER}),
     )
 
 
@@ -338,31 +344,31 @@ def test_dragon_interchangeable_less_interesting_failure_cases():
     """Test invalid dragon defeats with interchangeable heroes."""
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "cleric",
-            "thief",
-            interchangeable=frozenset({"fighter"}),
+            Party.CLERIC,
+            Party.THIEF,
+            interchangeable=frozenset({Party.FIGHTER}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "cleric",
-            "fighter",
-            interchangeable=frozenset({"fighter"}),
+            Party.CLERIC,
+            Party.FIGHTER,
+            interchangeable=frozenset({Party.FIGHTER}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "cleric",
-            "thief",
-            "champion",
-            "mage",
-            interchangeable=frozenset({"fighter"}),
+            Party.CLERIC,
+            Party.THIEF,
+            Party.CHAMPION,
+            Party.MAGE,
+            interchangeable=frozenset({Party.FIGHTER}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "cleric",
-            "thief",
-            "champion",
-            "fighter",
-            interchangeable=frozenset({"fighter"}),
+            Party.CLERIC,
+            Party.THIEF,
+            Party.CHAMPION,
+            Party.FIGHTER,
+            interchangeable=frozenset({Party.FIGHTER}),
         )
 
 
@@ -370,31 +376,31 @@ def test_dragon_interchangeable_more_interesting_failure_cases():
     """Invalid dragon defeats with multiple interchangeable hero types."""
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "mage",
-            "mage",
-            "mage",
-            interchangeable=frozenset({"mage", "fighter"}),
+            Party.MAGE,
+            Party.MAGE,
+            Party.MAGE,
+            interchangeable=frozenset({Party.MAGE, Party.FIGHTER}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "fighter",
-            "fighter",
-            "fighter",
-            interchangeable=frozenset({"mage", "fighter"}),
+            Party.FIGHTER,
+            Party.FIGHTER,
+            Party.FIGHTER,
+            interchangeable=frozenset({Party.MAGE, Party.FIGHTER}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "fighter",
-            "mage",
-            "mage",
-            interchangeable=frozenset({"mage", "fighter"}),
+            Party.FIGHTER,
+            Party.MAGE,
+            Party.MAGE,
+            interchangeable=frozenset({Party.MAGE, Party.FIGHTER}),
         )
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "mage",
-            "fighter",
-            "fighter",
-            interchangeable=frozenset({"mage", "fighter"}),
+            Party.MAGE,
+            Party.FIGHTER,
+            Party.FIGHTER,
+            interchangeable=frozenset({Party.MAGE, Party.FIGHTER}),
         )
 
 
@@ -404,10 +410,10 @@ class TestDragon:
         """Set up fixture for a game containing dragons and party members."""
         self.game = replace(
             world.new_world(),
-            dungeon=struct.Dungeon(
+            dungeon=make_dungeon(
                 goblin=0, skeleton=0, ooze=0, chest=1, potion=2, dragon=3
             ),
-            party=struct.Party(*([2] * len(fields(struct.Party)))),
+            party=all_party(2),
         )
         self.randrange = random.Random(4).randrange
 
@@ -422,12 +428,12 @@ class TestDragon:
             "cleric",
             "mage",
         )
-        assert game.party.fighter == 1
-        assert game.party.cleric == 1
-        assert game.party.mage == 1
-        assert game.dungeon.dragon == 0
+        assert game.party[Party.FIGHTER] == 1
+        assert game.party[Party.CLERIC] == 1
+        assert game.party[Party.MAGE] == 1
+        assert game.dungeon[Dungeon.DRAGON] == 0
         assert game.experience == 1
-        assert sum(struct.field_values(game.treasure.own)) == 1
+        assert sum(game.treasure.own.values()) == 1
 
     def test_treasure_slot1(self):
         """Sword treasure can substitute for fighter in dragon combat."""
@@ -435,10 +441,10 @@ class TestDragon:
             self.game,
             treasure=replace(
                 self.game.treasure,
-                own=replace(self.game.treasure.own, sword=7),
+                own=frozen({**self.game.treasure.own, Artifact.SWORD: 7}),
             ),
         )
-        game = replace(game, party=replace(game.party, fighter=0))
+        game = replace(game, party=frozen({**game.party, Party.FIGHTER: 0}))
         game = player.apply(
             player.Default,
             game,
@@ -448,17 +454,20 @@ class TestDragon:
             "cleric",
             "mage",
         )
-        assert game.treasure.own.sword == 6
-        assert game.party.fighter == 0
-        assert game.party.cleric == 1
-        assert game.party.mage == 1
-        assert game.dungeon.dragon == 0
+        assert game.treasure.own[Artifact.SWORD] == 6
+        assert game.party[Party.FIGHTER] == 0
+        assert game.party[Party.CLERIC] == 1
+        assert game.party[Party.MAGE] == 1
+        assert game.dungeon[Dungeon.DRAGON] == 0
         assert game.experience == 1
-        assert sum(struct.field_values(game.treasure.own)) == 7
+        assert sum(game.treasure.own.values()) == 7
 
     def test_monsters_remain(self):
         """Dragon cannot be attacked while monsters remain in dungeon."""
-        game = replace(self.game, dungeon=replace(self.game.dungeon, goblin=1))
+        game = replace(
+            self.game,
+            dungeon=frozen({**self.game.dungeon, Dungeon.GOBLIN: 1}),
+        )
         with pytest.raises(DrollError):
             player.apply(
                 player.Default,
@@ -554,88 +563,88 @@ class TestDragon:
 
 def test_decrement_dungeon_zero_target():
     """Cannot decrement a dungeon target that is already zero."""
-    dungeon = struct.Dungeon(goblin=0, skeleton=1)
+    dungeon = make_dungeon(goblin=0, skeleton=1)
     with pytest.raises(DrollError):
-        decrement_dungeon(dungeon, "goblin")
+        decrement_dungeon(dungeon, Dungeon.GOBLIN)
 
 
 def test_eliminate_dungeon_zero_target():
     """Cannot eliminate a dungeon target that is already zero."""
-    dungeon = struct.Dungeon(goblin=0, skeleton=1)
+    dungeon = make_dungeon(goblin=0, skeleton=1)
     with pytest.raises(DrollError):
-        eliminate_dungeon(dungeon, "goblin")
+        eliminate_dungeon(dungeon, Dungeon.GOBLIN)
 
 
 def test_open_one_before_monsters_defeated():
     """Cannot open chests while monsters remain."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1, chest=1),
-        party=struct.Party(thief=1),
+        dungeon=make_dungeon(goblin=1, chest=1),
+        party=make_party(thief=1),
     )
     with pytest.raises(DrollError):
-        regular.open_one(w, _UNUSED, "thief", ("chest",))
+        regular.open_one(w, _UNUSED, Party.THIEF, (Dungeon.CHEST,))
 
 
 def test_open_all_before_monsters_defeated():
     """Cannot open all chests while monsters remain."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1, chest=2),
-        party=struct.Party(thief=1),
+        dungeon=make_dungeon(goblin=1, chest=2),
+        party=make_party(thief=1),
     )
     with pytest.raises(DrollError):
-        regular.open_all(w, _UNUSED, "thief", ("chest",))
+        regular.open_all(w, _UNUSED, Party.THIEF, (Dungeon.CHEST,))
 
 
 def test_quaff_no_potions():
     """Cannot quaff when no potions are available."""
     w = struct.World(
-        dungeon=struct.Dungeon(potion=0),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(potion=0),
+        party=make_party(fighter=1),
     )
     with pytest.raises(DrollError):
-        regular.quaff(w, _UNUSED, "fighter", ("potion",))
+        regular.quaff(w, _UNUSED, Party.FIGHTER, (Dungeon.POTION,))
 
 
 def test_reroll_no_targets():
     """Reroll requires at least one target."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(scroll=1),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(scroll=1),
     )
     with pytest.raises(DrollError):
-        regular.reroll(w, _UNUSED, "scroll", ())
+        regular.reroll(w, _UNUSED, Party.SCROLL, ())
 
 
 def test_reroll_dragon_disallowed():
     """Cannot reroll dragon dice by default."""
     w = struct.World(
-        dungeon=struct.Dungeon(dragon=3),
-        party=struct.Party(scroll=1),
+        dungeon=make_dungeon(dragon=3),
+        party=make_party(scroll=1),
     )
     with pytest.raises(DrollError):
-        regular.reroll(w, _UNUSED, "scroll", ("dragon",))
+        regular.reroll(w, _UNUSED, Party.SCROLL, (Dungeon.DRAGON,))
 
 
 def test_interchangeable_disallowed_hero():
     """Scrolls cannot defeat a dragon via interchangeable heroes."""
     with pytest.raises(DrollError):
         regular.defeat_dragon_heroes(
-            "scroll",
-            "fighter",
-            "thief",
-            interchangeable=frozenset({"fighter", "mage"}),
+            Party.SCROLL,
+            Party.FIGHTER,
+            Party.THIEF,
+            interchangeable=frozenset({Party.FIGHTER, Party.MAGE}),
         )
 
 
 def test_bait_non_dragon_target():
     """Bait can only target dragons."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(fighter=1),
-        treasure=struct.Treasure(own=struct.Artifacts(bait=1)),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(fighter=1),
+        treasure=struct.Treasure(own=make_artifacts(bait=1)),
     )
     with pytest.raises(DrollError):
-        regular.bait_dragon(w, _UNUSED, "bait", ("goblin",))
+        regular.bait_dragon(w, _UNUSED, Action.BAIT, (Dungeon.GOBLIN,))
 
 
 def test_regroup_discard_after_quaff():
@@ -651,15 +660,15 @@ def test_regroup_discard_after_quaff():
         depth=1,
         experience=0,
         ability=False,
-        dungeon=struct.Dungeon(potion=1),
-        party=struct.Party(thief=1),
-        regroup=struct.Regroup(discard=struct.Party(thief=1)),
+        dungeon=make_dungeon(potion=1),
+        party=make_party(thief=1),
+        regroup=struct.Regroup(discard=make_party(thief=1)),
     )
     # Thief quaffs potion, reviving another thief
-    post = regular.quaff(pre, None, "thief", ("potion", "thief"))
+    post = regular.quaff(pre, None, Party.THIEF, (Dungeon.POTION, Party.THIEF))
     # The marked thief was consumed so the discard counter must drop
-    assert post.regroup.discard.thief == 0
-    assert post.party.thief == 1
+    assert post.regroup.discard[Party.THIEF] == 0
+    assert post.party[Party.THIEF] == 1
 
     # After descending the revived thief must survive regroup
     descended = world.descend(
@@ -667,7 +676,7 @@ def test_regroup_discard_after_quaff():
         dice.roll_dungeon,
         random.Random(4).randrange,
     )
-    assert descended.party.thief == 1
+    assert descended.party[Party.THIEF] == 1
 
 
 def test_regroup_discard_after_elixir1():
@@ -678,21 +687,21 @@ def test_regroup_discard_after_elixir1():
         depth=1,
         experience=0,
         ability=False,
-        dungeon=struct.Dungeon(ooze=1),
-        party=struct.Party(thief=1),
-        regroup=struct.Regroup(discard=struct.Party(thief=1)),
-        treasure=struct.Treasure(own=struct.Artifacts(elixir=1)),
+        dungeon=make_dungeon(ooze=1),
+        party=make_party(thief=1),
+        regroup=struct.Regroup(discard=make_party(thief=1)),
+        treasure=struct.Treasure(own=make_artifacts(elixir=1)),
     )
 
     # Force-discard thief kills the ooze
-    post1 = regular.defeat_one(pre, None, "thief", ("ooze",))
-    assert post1.regroup.discard.thief == 0
-    assert post1.party.thief == 0
+    post1 = regular.defeat_one(pre, None, Party.THIEF, (Dungeon.OOZE,))
+    assert post1.regroup.discard[Party.THIEF] == 0
+    assert post1.party[Party.THIEF] == 0
 
     # Elixir revives a new thief
-    post2 = regular.elixir(post1, None, "elixir", ("thief",))
-    assert post2.regroup.discard.thief == 0
-    assert post2.party.thief == 1
+    post2 = regular.elixir(post1, None, Action.ELIXIR, (Party.THIEF,))
+    assert post2.regroup.discard[Party.THIEF] == 0
+    assert post2.party[Party.THIEF] == 1
 
     # After descending the revived thief must survive regroup
     descended = world.descend(
@@ -700,7 +709,7 @@ def test_regroup_discard_after_elixir1():
         dice.roll_dungeon,
         random.Random(4).randrange,
     )
-    assert descended.party.thief == 1
+    assert descended.party[Party.THIEF] == 1
 
 
 def test_regroup_discard_after_elixir2():
@@ -711,21 +720,21 @@ def test_regroup_discard_after_elixir2():
         depth=1,
         experience=0,
         ability=False,
-        dungeon=struct.Dungeon(ooze=1),
-        party=struct.Party(thief=1),
-        regroup=struct.Regroup(discard=struct.Party(thief=1)),
-        treasure=struct.Treasure(own=struct.Artifacts(elixir=1)),
+        dungeon=make_dungeon(ooze=1),
+        party=make_party(thief=1),
+        regroup=struct.Regroup(discard=make_party(thief=1)),
+        treasure=struct.Treasure(own=make_artifacts(elixir=1)),
     )
 
     # Elixir revives a new thief
-    post1 = regular.elixir(pre, None, "elixir", ("thief",))
-    assert post1.regroup.discard.thief == 1
-    assert post1.party.thief == 2
+    post1 = regular.elixir(pre, None, Action.ELIXIR, (Party.THIEF,))
+    assert post1.regroup.discard[Party.THIEF] == 1
+    assert post1.party[Party.THIEF] == 2
 
     # Force-discard thief kills the ooze
-    post2 = regular.defeat_one(post1, None, "thief", ("ooze",))
-    assert post2.regroup.discard.thief == 0
-    assert post2.party.thief == 1
+    post2 = regular.defeat_one(post1, None, Party.THIEF, (Dungeon.OOZE,))
+    assert post2.regroup.discard[Party.THIEF] == 0
+    assert post2.party[Party.THIEF] == 1
 
     # After descending the revived thief must survive regroup
     descended = world.descend(
@@ -733,4 +742,4 @@ def test_regroup_discard_after_elixir2():
         dice.roll_dungeon,
         random.Random(4).randrange,
     )
-    assert descended.party.thief == 1
+    assert descended.party[Party.THIEF] == 1

--- a/tests/test_shell.py
+++ b/tests/test_shell.py
@@ -10,8 +10,8 @@ import pytest
 from dataclasses import replace
 from unittest.mock import patch
 
-from droll import struct
 from droll.display import DisplayMode
+from droll.struct import Dungeon, Party, make_dungeon, make_party
 from droll.struct import DrollError
 from droll.game import Game
 from droll.player import Default
@@ -78,7 +78,7 @@ def test_shell_retreat():
     s.preloop()
     s.onecmd("descend")
     # Need a monster present so retreat is valid
-    s._game._world = replace(s._game._world, dungeon=struct.Dungeon(goblin=1))
+    s._game._world = replace(s._game._world, dungeon=make_dungeon(goblin=1))
     s.onecmd("retreat")
 
 
@@ -157,7 +157,7 @@ def test_undo():
     onecmd("descend")
 
     # (delve=1, depth=2, dungeon=(goblin=2), ...)
-    assert s._game._world.dungeon.goblin == 2
+    assert s._game._world.dungeon[Dungeon.GOBLIN] == 2
     with pytest.raises(DrollError):
         onecmd("undo")
     onecmd("thief goblin")
@@ -168,9 +168,9 @@ def test_undo():
     onecmd("descend")
 
     # (delve=1, depth=3, dungeon=(ooze=1, chest=1, potion=1), ...)
-    assert s._game._world.dungeon.ooze == 1
-    assert s._game._world.dungeon.chest == 1
-    assert s._game._world.dungeon.potion == 1
+    assert s._game._world.dungeon[Dungeon.OOZE] == 1
+    assert s._game._world.dungeon[Dungeon.CHEST] == 1
+    assert s._game._world.dungeon[Dungeon.POTION] == 1
     with pytest.raises(DrollError):
         onecmd("undo")
     onecmd("cleric ooze")
@@ -228,7 +228,7 @@ def test_quaff_wrong_revive_count_prints_error():
     # Replace dungeon with a single potion and no monsters
     s._game._world = replace(
         s._game._world,
-        dungeon=struct.Dungeon(potion=1),
+        dungeon=make_dungeon(potion=1),
     )
     # Quaff 1 potion providing 0 revive targets:
     # - regular.py quaff raises "Specify exactly 1 to revive after 'potion'."
@@ -263,7 +263,7 @@ def test_command_counter_increments_on_mutation():
 
     # Two successful undos in a row each decrement
     s._game._world = replace(
-        s._game._world, dungeon=struct.Dungeon(goblin=1, ooze=1)
+        s._game._world, dungeon=make_dungeon(goblin=1, ooze=1)
     )
     s.onecmd("fighter goblin")  # count -> 2; undo stack: [before_1st]
     assert s._command_count == 2

--- a/tests/test_special.py
+++ b/tests/test_special.py
@@ -6,7 +6,7 @@
 import pytest
 
 from droll import special, struct
-from droll.struct import DrollError
+from droll.struct import Dungeon, DrollError, Party, make_dungeon, make_party
 
 # Known to be unused because it would raise NameErrors on any use
 _UNUSED = object()
@@ -15,172 +15,172 @@ _UNUSED = object()
 def test_defeats_all_plus_one_additional():
     """Defeats all of one type plus one additional."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(champion=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(champion=1),
     )
     result = special.defeat_all_plus_additional(
-        w, _UNUSED, "champion", ("goblin", "skeleton")
+        w, _UNUSED, Party.CHAMPION, (Dungeon.GOBLIN, Dungeon.SKELETON)
     )
-    assert result.dungeon.goblin == 0
-    assert result.dungeon.skeleton == 0
-    assert result.party.champion == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 0
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.party[Party.CHAMPION] == 0
 
 
 def test_defeat_all_no_additional_when_cleared():
     """No additional needed when monsters cleared."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=2),
-        party=struct.Party(champion=1),
+        dungeon=make_dungeon(goblin=2),
+        party=make_party(champion=1),
     )
     result = special.defeat_all_plus_additional(
-        w, _UNUSED, "champion", ("goblin",)
+        w, _UNUSED, Party.CHAMPION, (Dungeon.GOBLIN,)
     )
-    assert result.dungeon.goblin == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 0
 
 
 def test_defeat_all_rejects_extra_additional():
     """Rejects more than one additional target."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1, skeleton=2),
-        party=struct.Party(champion=1),
+        dungeon=make_dungeon(goblin=1, skeleton=2),
+        party=make_party(champion=1),
     )
     with pytest.raises(DrollError):
         special.defeat_all_plus_additional(
             w,
             _UNUSED,
-            "champion",
-            ("goblin", "skeleton", "skeleton"),
+            Party.CHAMPION,
+            (Dungeon.GOBLIN, Dungeon.SKELETON, Dungeon.SKELETON),
         )
 
 
 def test_defeat_all_requires_additional_when_monsters_remain():
     """Requires additional target when monsters remain."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1, skeleton=1),
-        party=struct.Party(champion=1),
+        dungeon=make_dungeon(goblin=1, skeleton=1),
+        party=make_party(champion=1),
     )
     with pytest.raises(DrollError):
         special.defeat_all_plus_additional(
             w,
             _UNUSED,
-            "champion",
-            ("goblin",),
+            Party.CHAMPION,
+            (Dungeon.GOBLIN,),
         )
 
 
 def test_defeats_one_plus_one_additional():
     """Defeats one of primary target plus one additional."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=2, skeleton=1),
-        party=struct.Party(champion=1),
+        dungeon=make_dungeon(goblin=2, skeleton=1),
+        party=make_party(champion=1),
     )
     result = special.defeat_one_plus_additional(
-        w, _UNUSED, "champion", ("goblin", "skeleton")
+        w, _UNUSED, Party.CHAMPION, (Dungeon.GOBLIN, Dungeon.SKELETON)
     )
-    assert result.dungeon.goblin == 1
-    assert result.dungeon.skeleton == 0
-    assert result.party.champion == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 1
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.party[Party.CHAMPION] == 0
 
 
 def test_defeat_one_no_additional_when_cleared():
     """No additional needed when all monsters cleared after defeating one."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(fighter=1),
     )
     result = special.defeat_one_plus_additional(
-        w, _UNUSED, "fighter", ("goblin",)
+        w, _UNUSED, Party.FIGHTER, (Dungeon.GOBLIN,)
     )
-    assert result.dungeon.goblin == 0
-    assert result.party.fighter == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 0
+    assert result.party[Party.FIGHTER] == 0
 
 
 def test_defeat_one_rejects_additional_when_cleared():
     """Rejects additional target when all monsters already cleared."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=1),
+        party=make_party(fighter=1),
     )
     with pytest.raises(DrollError):
         special.defeat_one_plus_additional(
-            w, _UNUSED, "fighter", ("goblin", "skeleton")
+            w, _UNUSED, Party.FIGHTER, (Dungeon.GOBLIN, Dungeon.SKELETON)
         )
 
 
 def test_defeat_one_requires_additional_when_monsters_remain():
     """Requires additional target when monsters remain after defeating one."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1, skeleton=1),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=1, skeleton=1),
+        party=make_party(fighter=1),
     )
     with pytest.raises(DrollError):
-        special.defeat_one_plus_additional(w, _UNUSED, "fighter", ("goblin",))
+        special.defeat_one_plus_additional(w, _UNUSED, Party.FIGHTER, (Dungeon.GOBLIN,))
 
 
 def test_defeat_one_rejects_extra_additional():
     """Rejects more than one additional target."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=1, skeleton=1, ooze=1),
-        party=struct.Party(champion=1),
+        dungeon=make_dungeon(goblin=1, skeleton=1, ooze=1),
+        party=make_party(champion=1),
     )
     with pytest.raises(DrollError):
         special.defeat_one_plus_additional(
             w,
             _UNUSED,
-            "champion",
-            ("goblin", "skeleton", "ooze"),
+            Party.CHAMPION,
+            (Dungeon.GOBLIN, Dungeon.SKELETON, Dungeon.OOZE),
         )
 
 
 def test_defeat_one_only_decrements_one_of_primary():
     """Defeats only one of the primary target, not all."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=3, skeleton=1),
-        party=struct.Party(champion=1),
+        dungeon=make_dungeon(goblin=3, skeleton=1),
+        party=make_party(champion=1),
     )
     result = special.defeat_one_plus_additional(
-        w, _UNUSED, "champion", ("goblin", "skeleton")
+        w, _UNUSED, Party.CHAMPION, (Dungeon.GOBLIN, Dungeon.SKELETON)
     )
-    assert result.dungeon.goblin == 2
-    assert result.dungeon.skeleton == 0
-    assert result.party.champion == 0
+    assert result.dungeon[Dungeon.GOBLIN] == 2
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.party[Party.CHAMPION] == 0
 
 
 def test_convert_dungeon_to_party_up_to_max_count():
     """Converts min(available, max_count) dungeon dice to party dice."""
     w = struct.World(
-        dungeon=struct.Dungeon(goblin=3),
-        party=struct.Party(fighter=1),
+        dungeon=make_dungeon(goblin=3),
+        party=make_party(fighter=1),
     )
     result = special.convert_dungeon_to_party(
-        w, source="goblin", destination="thief", max_count=2
+        w, source=Dungeon.GOBLIN, destination=Party.THIEF, max_count=2
     )
-    assert result.dungeon.goblin == 1
-    assert result.party.thief == 2
-    assert result.regroup.discard.thief == 2
+    assert result.dungeon[Dungeon.GOBLIN] == 1
+    assert result.party[Party.THIEF] == 2
+    assert result.regroup.discard[Party.THIEF] == 2
 
 
 def test_convert_dungeon_to_party_zero_source_raises():
     """Raises DrollError when zero of the requested source exist in dungeon."""
     w = struct.World(
-        dungeon=struct.Dungeon(skeleton=2),
-        party=struct.Party(),
+        dungeon=make_dungeon(skeleton=2),
+        party=make_party(),
     )
     with pytest.raises(DrollError):
         special.convert_dungeon_to_party(
-            w, source="goblin", destination="thief", max_count=1
+            w, source=Dungeon.GOBLIN, destination=Party.THIEF, max_count=1
         )
 
 
 def test_convert_dungeon_to_party_fewer_when_limited():
     """Converts only available count when fewer than max_count."""
     w = struct.World(
-        dungeon=struct.Dungeon(skeleton=1),
-        party=struct.Party(),
+        dungeon=make_dungeon(skeleton=1),
+        party=make_party(),
     )
     result = special.convert_dungeon_to_party(
-        w, source="skeleton", destination="fighter", max_count=2
+        w, source=Dungeon.SKELETON, destination=Party.FIGHTER, max_count=2
     )
-    assert result.dungeon.skeleton == 0
-    assert result.party.fighter == 1
-    assert result.regroup.discard.fighter == 1
+    assert result.dungeon[Dungeon.SKELETON] == 0
+    assert result.party[Party.FIGHTER] == 1
+    assert result.regroup.discard[Party.FIGHTER] == 1

--- a/tests/test_treasure.py
+++ b/tests/test_treasure.py
@@ -3,11 +3,12 @@
 # file, You can obtain one at http://mozilla.org/MPL/2.0/.
 """Testing of world-to-world transitions stemming from using treasure."""
 
-from dataclasses import fields, replace
+from dataclasses import replace
 import random
 import pytest
 
 from droll import player, struct, world
+from droll.struct import Artifact, Dungeon, Party, make_dungeon, make_party, make_artifacts, all_dungeon, all_party
 from droll.treasure import replace_treasure
 
 
@@ -17,8 +18,8 @@ class TestTreasure:
         """Fixture with a game containing dungeon items but no party."""
         self.game = replace(
             world.new_world(),
-            dungeon=struct.Dungeon(*([2] * len(fields(struct.Dungeon)))),
-            party=struct.Party(),
+            dungeon=all_dungeon(2),
+            party=make_party(),
         )
         self.randrange = random.Random(4).randrange
 
@@ -28,14 +29,14 @@ class TestTreasure:
             self.game,
             treasure=replace(
                 self.game.treasure,
-                own=replace(self.game.treasure.own, elixir=1),
+                own=make_artifacts(elixir=1),
             ),
         )
         game = player.apply(
             player.Default, game, self.randrange, "elixir", "cleric"
         )
-        assert game.party.cleric == 1
-        assert game.treasure.own.elixir == 0
+        assert game.party[Party.CLERIC] == 1
+        assert game.treasure.own[Artifact.ELIXIR] == 0
 
         with pytest.raises(struct.DrollError):
             player.apply(
@@ -47,17 +48,17 @@ class TestTreasure:
         game = replace(
             self.game,
             treasure=replace(
-                self.game.treasure, own=replace(self.game.treasure.own, bait=2)
+                self.game.treasure, own=make_artifacts(bait=2)
             ),
         )
         game = player.apply(
             player.Default, game, self.randrange, "bait", "dragon"
         )
-        assert game.treasure.own.bait == 1
-        assert game.dungeon.goblin == 0
-        assert game.dungeon.skeleton == 0
-        assert game.dungeon.ooze == 0
-        assert game.dungeon.dragon == 8
+        assert game.treasure.own[Artifact.BAIT] == 1
+        assert game.dungeon[Dungeon.GOBLIN] == 0
+        assert game.dungeon[Dungeon.SKELETON] == 0
+        assert game.dungeon[Dungeon.OOZE] == 0
+        assert game.dungeon[Dungeon.DRAGON] == 8
 
         with pytest.raises(struct.DrollError):
             player.apply(player.Default, game, self.randrange, "bait")
@@ -68,18 +69,18 @@ class TestTreasure:
             self.game,
             treasure=replace(
                 self.game.treasure,
-                own=replace(self.game.treasure.own, **{artifact: 2}),
+                own=make_artifacts(**{artifact: 2}),
             ),
         )
         game = player.apply(player.Default, game, None, artifact, specialty)
-        assert getattr(game.treasure.own, artifact) == 1
-        assert getattr(game.party, hero) == 0
-        assert getattr(game.dungeon, specialty) == 0
+        assert game.treasure.own[Artifact(artifact)] == 1
+        assert game.party[Party(hero)] == 0
+        assert game.dungeon[Dungeon(specialty)] == 0
 
         game = player.apply(player.Default, game, None, artifact, other)
-        assert getattr(game.treasure.own, artifact) == 0
-        assert getattr(game.party, hero) == 0
-        assert getattr(game.dungeon, other) == 1
+        assert game.treasure.own[Artifact(artifact)] == 0
+        assert game.party[Party(hero)] == 0
+        assert game.dungeon[Dungeon(other)] == 1
 
         with pytest.raises(struct.DrollError):
             player.apply(player.Default, game, None, artifact, other)
@@ -102,13 +103,13 @@ class TestTreasure:
             self.game,
             treasure=replace(
                 self.game.treasure,
-                own=replace(self.game.treasure.own, tools=1),
+                own=make_artifacts(tools=1),
             ),
         )
         game = player.apply(player.Default, game, None, "tools", "goblin")
-        assert game.treasure.own.tools == 0
-        assert game.party.thief == 0
-        assert game.dungeon.goblin == 1
+        assert game.treasure.own[Artifact.TOOLS] == 0
+        assert game.party[Party.THIEF] == 0
+        assert game.dungeon[Dungeon.GOBLIN] == 1
 
 
 class TestPhantomTreasure:
@@ -118,8 +119,8 @@ class TestPhantomTreasure:
         """Fixture with party members but no treasures owned."""
         self.game = replace(
             world.new_world(),
-            dungeon=struct.Dungeon(*([2] * len(fields(struct.Dungeon)))),
-            party=struct.Party(*([2] * len(fields(struct.Party)))),
+            dungeon=all_dungeon(2),
+            party=all_party(2),
         )
 
     def test_sword_without_treasure(self):
@@ -150,8 +151,8 @@ class TestTreasureAsRecoveryType:
         """Fixture with monsters cleared and potions available."""
         self.game = replace(
             world.new_world(),
-            dungeon=struct.Dungeon(potion=2),
-            party=struct.Party(fighter=2, champion=2),
+            dungeon=make_dungeon(potion=2),
+            party=make_party(fighter=2, champion=2),
         )
 
     def test_sword_rejected_as_recovery(self):
@@ -176,13 +177,12 @@ class TestTreasureAsRecoveryType:
             player.Default, self.game, None,
             "champion", "potion", "fighter", "mage",
         )
-        assert game.party.fighter == 3
-        assert game.party.mage == 1
-        assert game.dungeon.potion == 0
+        assert game.party[Party.FIGHTER] == 3
+        assert game.party[Party.MAGE] == 1
+        assert game.dungeon[Dungeon.POTION] == 0
 
 
 def test_replace_treasure_invalid_type():
-    """replace_treasure raises DrollError for non-treasure names."""
-    treasure = struct.Treasure(own=struct.Artifacts(sword=1))
-    with pytest.raises(struct.DrollError, match="not a valid treasure type"):
-        replace_treasure(treasure, "cleric")
+    """Non-treasure names cannot be converted to Artifact enum."""
+    with pytest.raises(ValueError):
+        Artifact("cleric")

--- a/tests/test_world.py
+++ b/tests/test_world.py
@@ -8,11 +8,12 @@ import random
 import pytest
 
 from droll import dice, dungeon, struct, treasure, world
+from droll.struct import Artifact, Dungeon, Party, make_dungeon, make_party, make_artifacts
 
 
 def _roll_all_goblins(n, _randrange):
     """Deterministic roll where every die lands on goblin."""
-    return struct.Dungeon(goblin=n)
+    return make_dungeon(goblin=n)
 
 
 class TestWorld:
@@ -27,7 +28,7 @@ class TestWorld:
         game = world.delve(game, dice.roll_party, self.state.randrange)
         assert game.depth == 0
         assert game.ability is True
-        assert sum(struct.field_values(game.party)) == 7
+        assert sum(game.party.values()) == 7
 
     def test_dungeon_initial(self):
         """Test descending into first dungeon level rolls dice correctly."""
@@ -35,7 +36,7 @@ class TestWorld:
         game = world.delve(game, dice.roll_party, self.state.randrange)
         game = world.descend(game, dice.roll_dungeon, self.state.randrange)
         assert game.depth == 1
-        assert sum(struct.field_values(game.dungeon)) == 1
+        assert sum(game.dungeon.values()) == 1
 
     def test_draw_treasure(self):
         """Test drawing treasure moves one item from box to own."""
@@ -44,11 +45,11 @@ class TestWorld:
             pre.treasure, self.state.randrange
         )
         post = replace(pre, treasure=post_treasure)
-        assert sum(struct.field_values(pre.treasure.own)) == 0
-        assert sum(struct.field_values(post.treasure.own)) == 1
+        assert sum(pre.treasure.own.values()) == 0
+        assert sum(post.treasure.own.values()) == 1
         assert (
-            sum(struct.field_values(pre.treasure.box))
-            - sum(struct.field_values(post.treasure.box))
+            sum(pre.treasure.box.values())
+            - sum(post.treasure.box.values())
             == 1
         )
 
@@ -57,7 +58,7 @@ class TestWorld:
         pre = world.new_world()
         pre = replace(
             pre,
-            treasure=replace(pre.treasure, box=struct.Artifacts()),
+            treasure=replace(pre.treasure, box=struct.empty_artifact_counts()),
         )
         with pytest.raises(struct.DrollError):
             treasure.draw_treasure(pre.treasure, self.state.randrange)
@@ -68,16 +69,16 @@ class TestWorld:
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, elixir=1)
+                pre.treasure, own=make_artifacts(elixir=1)
             ),
         )
-        post_treasure = treasure.replace_treasure(pre.treasure, "elixir")
+        post_treasure = treasure.replace_treasure(pre.treasure, Artifact.ELIXIR)
         post = replace(pre, treasure=post_treasure)
-        assert sum(struct.field_values(pre.treasure.own)) == 1
-        assert sum(struct.field_values(post.treasure.own)) == 0
+        assert sum(pre.treasure.own.values()) == 1
+        assert sum(post.treasure.own.values()) == 0
         assert (
-            sum(struct.field_values(post.treasure.box))
-            - sum(struct.field_values(pre.treasure.box))
+            sum(post.treasure.box.values())
+            - sum(pre.treasure.box.values())
             == 1
         )
 
@@ -88,9 +89,7 @@ class TestWorld:
         pre = replace(
             pre,
             depth=3,
-            dungeon=struct.Dungeon(
-                goblin=0, skeleton=0, ooze=0, chest=2, potion=5, dragon=0
-            ),
+            dungeon=make_dungeon(chest=2, potion=5),
         )
         assert pre.depth > 0
         post = world.retire(pre)
@@ -103,9 +102,7 @@ class TestWorld:
         pre = replace(
             pre,
             depth=3,
-            dungeon=struct.Dungeon(
-                goblin=0, skeleton=1, ooze=0, chest=2, potion=5, dragon=0
-            ),
+            dungeon=make_dungeon(skeleton=1, chest=2, potion=5),
         )
         assert pre.depth > 0
 
@@ -117,7 +114,7 @@ class TestWorld:
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=1)
+                pre.treasure, own=make_artifacts(ring=1)
             ),
         )
         with pytest.raises(struct.DrollError):
@@ -127,12 +124,12 @@ class TestWorld:
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, portal=1)
+                pre.treasure, own=make_artifacts(portal=1)
             ),
         )
         post = world.retire(pre)
         assert post.experience == pre.depth + pre.experience
-        assert post.treasure.own.portal == 0
+        assert post.treasure.own[Artifact.PORTAL] == 0
 
     def test_retire_dragon(self):
         """Test retiring with dragons uses ring or portal."""
@@ -141,9 +138,7 @@ class TestWorld:
         pre = replace(
             pre,
             depth=3,
-            dungeon=struct.Dungeon(
-                goblin=0, skeleton=0, ooze=0, chest=2, potion=5, dragon=3
-            ),
+            dungeon=make_dungeon(chest=2, potion=5, dragon=3),
         )
         assert pre.depth > 0
 
@@ -155,37 +150,37 @@ class TestWorld:
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=1, portal=0)
+                pre.treasure, own=make_artifacts(ring=1)
             ),
         )
         post1 = world.retire(pre)
         assert post1.experience == pre.depth + pre.experience
-        assert post1.treasure.own.ring == 0
-        assert post1.treasure.own.portal == 0
+        assert post1.treasure.own[Artifact.RING] == 0
+        assert post1.treasure.own[Artifact.PORTAL] == 0
 
         # Town portal
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=0, portal=1)
+                pre.treasure, own=make_artifacts(portal=1)
             ),
         )
         post2 = world.retire(pre)
         assert post2.experience == pre.depth + pre.experience
-        assert post2.treasure.own.ring == 0
-        assert post2.treasure.own.portal == 0
+        assert post2.treasure.own[Artifact.RING] == 0
+        assert post2.treasure.own[Artifact.PORTAL] == 0
 
         # Both should consume the ring of invisibility first
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=1, portal=1)
+                pre.treasure, own=make_artifacts(ring=1, portal=1)
             ),
         )
         post3 = world.retire(pre)
         assert post3.experience == pre.depth + pre.experience
-        assert post3.treasure.own.ring == 0
-        assert post3.treasure.own.portal == 1
+        assert post3.treasure.own[Artifact.RING] == 0
+        assert post3.treasure.own[Artifact.PORTAL] == 1
 
     def test_descend_simple(self):
         """Test descending to next level with no obstacles increments depth."""
@@ -194,9 +189,7 @@ class TestWorld:
         pre = replace(
             pre,
             depth=3,
-            dungeon=struct.Dungeon(
-                goblin=0, skeleton=0, ooze=0, chest=2, potion=5, dragon=0
-            ),
+            dungeon=make_dungeon(chest=2, potion=5),
         )
         post = world.descend(pre, dice.roll_dungeon, self.state.randrange)
         assert post.depth == pre.depth + 1
@@ -208,9 +201,7 @@ class TestWorld:
         pre = replace(
             pre,
             depth=3,
-            dungeon=struct.Dungeon(
-                goblin=0, skeleton=1, ooze=0, chest=2, potion=5, dragon=1
-            ),
+            dungeon=make_dungeon(skeleton=1, chest=2, potion=5, dragon=1),
         )
         assert pre.depth > 0
 
@@ -222,7 +213,7 @@ class TestWorld:
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=1, portal=0)
+                pre.treasure, own=make_artifacts(ring=1)
             ),
         )
         with pytest.raises(struct.DrollError):
@@ -232,7 +223,7 @@ class TestWorld:
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=1, portal=0)
+                pre.treasure, own=make_artifacts(ring=1)
             ),
         )
         with pytest.raises(struct.DrollError):
@@ -245,9 +236,7 @@ class TestWorld:
         pre = replace(
             pre,
             depth=3,
-            dungeon=struct.Dungeon(
-                goblin=0, skeleton=0, ooze=0, chest=2, potion=5, dragon=3
-            ),
+            dungeon=make_dungeon(chest=2, potion=5, dragon=3),
         )
         assert pre.depth > 0
 
@@ -259,19 +248,19 @@ class TestWorld:
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=1, portal=0)
+                pre.treasure, own=make_artifacts(ring=1)
             ),
         )
         post1 = world.descend(pre, dice.roll_dungeon, self.state.randrange)
         assert post1.depth == pre.depth + 1
-        assert post1.treasure.own.ring == 0
-        assert post1.treasure.own.portal == 0
+        assert post1.treasure.own[Artifact.RING] == 0
+        assert post1.treasure.own[Artifact.PORTAL] == 0
 
         # Town portal
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=0, portal=1)
+                pre.treasure, own=make_artifacts(portal=1)
             ),
         )
         with pytest.raises(struct.DrollError):
@@ -281,88 +270,65 @@ class TestWorld:
         pre = replace(
             pre,
             treasure=replace(
-                pre.treasure, own=replace(pre.treasure.own, ring=1, portal=1)
+                pre.treasure, own=make_artifacts(ring=1, portal=1)
             ),
         )
         post3 = world.descend(pre, dice.roll_dungeon, self.state.randrange)
         assert post3.depth == pre.depth + 1
-        assert post3.treasure.own.ring == 0
-        assert post3.treasure.own.portal == 1
+        assert post3.treasure.own[Artifact.RING] == 0
+        assert post3.treasure.own[Artifact.PORTAL] == 1
 
     def test_regroup_discard(self):
         """Temporary party dice must be discarded during next regroup phase."""
-        # Largely the same test case for descending, retiring, and retreating
         pre1 = world.new_world()
         pre1 = world.delve(pre1, dice.roll_party, self.state.randrange)
         pre1 = replace(
             pre1,
             depth=3,
-            party=struct.Party(
-                fighter=5, cleric=4, mage=3, thief=2, champion=1, scroll=0
-            ),
+            party=make_party(fighter=5, cleric=4, mage=3, thief=2, champion=1, scroll=0),
             regroup=struct.Regroup(
-                discard=struct.Party(
-                    fighter=0, cleric=5, mage=3, thief=1, champion=0, scroll=0
-                )
+                discard=make_party(fighter=0, cleric=5, mage=3, thief=1, champion=0, scroll=0)
             ),
         )
+
+        expected_party = make_party(fighter=5, cleric=0, mage=0, thief=1, champion=1, scroll=0)
+        expected_discard = make_party()
 
         # First, confirm descending works as expected
         descended = world.descend(
             pre1, dice.roll_dungeon, self.state.randrange
         )
-        assert descended.party == struct.Party(
-            fighter=5, cleric=0, mage=0, thief=1, champion=1, scroll=0
-        )
-        assert descended.regroup.discard == struct.Party(
-            fighter=0, cleric=0, mage=0, thief=0, champion=0, scroll=0
-        )
+        assert descended.party == expected_party
+        assert descended.regroup.discard == expected_discard
 
         # Second, confirm retiring works as expected
         retired = world.retire(pre1)
-        assert retired.party == struct.Party(
-            fighter=5, cleric=0, mage=0, thief=1, champion=1, scroll=0
-        )
-        assert retired.regroup.discard == struct.Party(
-            fighter=0, cleric=0, mage=0, thief=0, champion=0, scroll=0
-        )
+        assert retired.party == expected_party
+        assert retired.regroup.discard == expected_discard
 
         # Third, confirm retreating works as expected
         pre2 = replace(
-            pre1, dungeon=struct.Dungeon(goblin=1)
+            pre1, dungeon=make_dungeon(goblin=1)
         )  # Threat required!
         retreated = world.retreat(pre2)
-        assert retreated.party == struct.Party(
-            fighter=5, cleric=0, mage=0, thief=1, champion=1, scroll=0
-        )
-        assert retreated.regroup.discard == struct.Party(
-            fighter=0, cleric=0, mage=0, thief=0, champion=0, scroll=0
-        )
+        assert retreated.party == expected_party
+        assert retreated.regroup.discard == expected_discard
 
     def test_finished_dungeon(self):
         """Test finished_dungeon detects when no actions remain."""
-        # None dungeon is exhausted
         assert dungeon.finished_dungeon(None)
-
-        # Empty dungeon is exhausted
-        assert dungeon.finished_dungeon(struct.Dungeon())
-
-        # Dungeon with only dragons (blocking) is not exhausted
-        assert not dungeon.finished_dungeon(struct.Dungeon(dragon=3))
-
-        # Dungeon with monsters is not exhausted
-        assert not dungeon.finished_dungeon(struct.Dungeon(goblin=1))
-        assert not dungeon.finished_dungeon(struct.Dungeon(skeleton=2))
-        assert not dungeon.finished_dungeon(struct.Dungeon(ooze=1))
-
-        # Dungeon with chests/potions still has actions (not exhausted)
-        assert not dungeon.finished_dungeon(struct.Dungeon(chest=2, potion=3))
+        assert dungeon.finished_dungeon(make_dungeon())
+        assert not dungeon.finished_dungeon(make_dungeon(dragon=3))
+        assert not dungeon.finished_dungeon(make_dungeon(goblin=1))
+        assert not dungeon.finished_dungeon(make_dungeon(skeleton=2))
+        assert not dungeon.finished_dungeon(make_dungeon(ooze=1))
+        assert not dungeon.finished_dungeon(make_dungeon(chest=2, potion=3))
 
     def test_retreat_valid(self):
         """Test valid retreat scenarios."""
         game = world.new_world()
         game = world.delve(game, dice.roll_party, self.state.randrange)
-        game = replace(game, depth=2, dungeon=struct.Dungeon(goblin=1))
+        game = replace(game, depth=2, dungeon=make_dungeon(goblin=1))
         result = world.retreat(game)
         assert result.depth == 0
         assert result.dungeon is None
@@ -371,7 +337,7 @@ class TestWorld:
         """Test retreat succeeds at depth 1 when a monster is present"""
         game = world.new_world()
         game = world.delve(game, dice.roll_party, self.state.randrange)
-        game = replace(game, depth=1, dungeon=struct.Dungeon(goblin=1))
+        game = replace(game, depth=1, dungeon=make_dungeon(goblin=1))
         result = world.retreat(game)
         assert result.depth == 0
         assert result.dungeon is None
@@ -389,7 +355,6 @@ class TestWorld:
         game = world.new_world()
         game = world.delve(game, dice.roll_party, self.state.randrange)
         assert game.depth == 0
-
         with pytest.raises(struct.DrollError):
             world.retreat(game)
 
@@ -397,8 +362,7 @@ class TestWorld:
         """Test retreat fails when dungeon is defeated."""
         game = world.new_world()
         game = world.delve(game, dice.roll_party, self.state.randrange)
-        game = replace(game, depth=2, dungeon=struct.Dungeon())
-
+        game = replace(game, depth=2, dungeon=make_dungeon())
         with pytest.raises(struct.DrollError):
             world.retreat(game)
 
@@ -406,8 +370,7 @@ class TestWorld:
         """Test maximum dungeon depth limit is enforced."""
         game = world.new_world()
         game = world.delve(game, dice.roll_party, self.state.randrange)
-        game = replace(game, depth=10, dungeon=struct.Dungeon())
-
+        game = replace(game, depth=10, dungeon=make_dungeon())
         with pytest.raises(struct.DrollError):
             world.descend(game, dice.roll_dungeon, self.state.randrange)
 
@@ -430,73 +393,28 @@ class TestWorld:
             ability=False,
             dungeon=None,
             treasure=struct.Treasure(
-                own=struct.Artifacts(
-                    sword=0,
-                    talisman=0,
-                    sceptre=0,
-                    tools=0,
-                    scroll=0,
-                    elixir=0,
-                    bait=1,
-                    portal=0,
-                    ring=0,
-                    scale=2,
-                ),
+                own=make_artifacts(bait=1, scale=2),
             ),
         )
         assert world.score(game) == 20
 
     def test_dragon_carryforward(self):
-        """Exhaustively check new dice = min(7 - dragons, depth) per rules.
-
-        The rules state one rolls dice equal to the level number, capped
-        by available dice (7 minus those set aside in the Dragon's Lair).
-        At most 2 dragons can carry forward (3+ require a ring, resetting
-        to 0).  The table below covers every (level, dragons) combination.
-        """
+        """Exhaustively check new dice = min(7 - dragons, depth) per rules."""
         game = world.new_world()
         game = world.delve(game, dice.roll_party, self.state.randrange)
-        #                depth  dragons  new_dice
         for depth, dragons, new_dice in [
-            # dragons=0: always roll depth dice (all 7 available)
-            (1, 0, 1),
-            (2, 0, 2),
-            (3, 0, 3),
-            (4, 0, 4),
-            (5, 0, 5),
-            (6, 0, 6),
-            (7, 0, 7),
-            (8, 0, 7),
-            (9, 0, 7),
-            (10, 0, 7),
-            # dragons=1: min(depth, 6)
-            (1, 1, 1),
-            (2, 1, 2),
-            (3, 1, 3),
-            (4, 1, 4),
-            (5, 1, 5),
-            (6, 1, 6),
-            (7, 1, 6),
-            (8, 1, 6),
-            (9, 1, 6),
-            (10, 1, 6),
-            # dragons=2: min(depth, 5)
-            (1, 2, 1),
-            (2, 2, 2),
-            (3, 2, 3),
-            (4, 2, 4),
-            (5, 2, 5),
-            (6, 2, 5),
-            (7, 2, 5),
-            (8, 2, 5),
-            (9, 2, 5),
-            (10, 2, 5),
+            (1, 0, 1), (2, 0, 2), (3, 0, 3), (4, 0, 4), (5, 0, 5),
+            (6, 0, 6), (7, 0, 7), (8, 0, 7), (9, 0, 7), (10, 0, 7),
+            (1, 1, 1), (2, 1, 2), (3, 1, 3), (4, 1, 4), (5, 1, 5),
+            (6, 1, 6), (7, 1, 6), (8, 1, 6), (9, 1, 6), (10, 1, 6),
+            (1, 2, 1), (2, 2, 2), (3, 2, 3), (4, 2, 4), (5, 2, 5),
+            (6, 2, 5), (7, 2, 5), (8, 2, 5), (9, 2, 5), (10, 2, 5),
         ]:
             g = replace(
-                game, depth=depth - 1, dungeon=struct.Dungeon(dragon=dragons)
+                game, depth=depth - 1, dungeon=make_dungeon(dragon=dragons)
             )
             result = world.descend(g, _roll_all_goblins, self.state.randrange)
             assert result.depth == depth
-            assert result.dungeon == struct.Dungeon(
+            assert result.dungeon == make_dungeon(
                 goblin=new_dice, dragon=dragons
             ), f"depth={depth}, dragons={dragons}"


### PR DESCRIPTION
## Summary

This PR replaces magic string literals throughout the codebase with type-safe enums, and converts three overloaded dataclasses (`Dungeon`, `Party`, `Artifacts`) into enum-backed frozen mappings. This provides better static type checking, clearer intent, and eliminates the need for union types that served multiple incompatible roles.

## Key Changes

- **New Enums**: Introduced `Dungeon`, `Party`, `Artifact`, and `Action` enums to replace string literals like `"fighter"`, `"goblin"`, `"sword"`, etc.

- **Frozen Mappings**: Replaced dataclass-based containers with `MappingProxyType` frozen dictionaries:
  - `DungeonState` (was `Dungeon` dataclass with int fields) - maps `Dungeon` enum to counts
  - `PartyState` (was `Party` dataclass with int fields) - maps `Party` enum to counts
  - `ArtifactCounts` (was `Artifacts` dataclass) - maps `Artifact` enum to counts
  - `HeroActions` and `PartyActions` - maps for command dispatch (was nested dataclass fields)
  - `ArtifactMapping` - maps `Party` enum to optional `Artifact` enum

- **Helper Functions**: Added factory functions for creating frozen mappings:
  - `frozen()` - wraps dict in MappingProxyType
  - `make_dungeon()`, `make_party()`, `make_artifacts()` - convenience constructors
  - `empty_dungeon()`, `empty_party()`, `empty_artifact_counts()` - zero-initialized states
  - `all_dungeon()`, `all_party()` - uniform-value states

- **Type Signature Updates**: Updated function signatures throughout to use enum types instead of strings:
  - Command handlers now accept `Party` enum and `tuple[Union[Dungeon, Party], ...]` instead of strings
  - Removed `field_names()` and `field_items()` utilities (replaced with direct enum iteration)
  - Updated `field_values()` to work with mappings via `.values()`

- **Test Updates**: Converted all test fixtures and assertions to use enums and the new factory functions, replacing attribute access (e.g., `party.fighter`) with mapping access (e.g., `party[Party.FIGHTER]`)

## Implementation Details

- Enums use lowercase string values (e.g., `Party.FIGHTER.value == "fighter"`) for backward compatibility with shell input parsing
- `MappingProxyType` provides immutability equivalent to frozen dataclasses
- All existing dataclass instances are replaced with `frozen({...})` calls using enum keys
- The `Command` type signature changed from `Callable[..., str, tuple[str, ...], ...]` to `Callable[..., Party, tuple[Union[Dungeon, Party], ...], ...]`

https://claude.ai/code/session_01KSH13vw3mFFwqFWjGicQbx