### PR TITLE
Fix Enchantress/Beguiler scroll docs: specialty is shared

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,7 +245,7 @@ adds a fighter to your party.
 
 Scroll behavior varies by hero (see
 [Hero abilities](#hero-abilities) below): Enchantress/Beguiler can
-use a scroll offensively against skeletons, Knight converts scrolls
+use a scroll as any companion, Knight converts scrolls
 to champions during party roll, and Mercenary/Commander receives one
 bonus scroll, discarded on regroup.
 
@@ -299,7 +299,7 @@ other entries describe different mechanical bonuses:
 | Base        | Advanced      | New ability                          | Party change                            |
 |-------------|---------------|--------------------------------------|-----------------------------------------|
 | Crusader    | Paladin       | Consume treasure to clear dungeon    | Heroes fighter and cleric are interchangeable           |
-| Enchantress | Beguiler      | Transform up to 2 monsters to potion | Scrolls target monsters like party members         |
+| Enchantress | Beguiler      | Transform up to 2 monsters to potion | *(unchanged)*                                      |
 | HalfGoblin  | Chieftain     | Transform up to 2 goblins to thieves | Open chests/quaff potions before clearing monsters |
 | Knight      | DragonSlayer  | *(unchanged)*                        | Dragon requires only 2 party members of different types |
 | Mercenary   | Commander     | Reroll any number of dice            | Each fighter defeats one additional monster         |

--- a/droll/ability.py
+++ b/droll/ability.py
@@ -133,7 +133,6 @@ def beguiler_ability(
 ) -> struct.World:
     """Transform at most 2 monsters into 1 potion.
     Requires transforming 2 monsters when 2+ monsters available.
-    Scrolls target monsters like party members.
 
     Example: ability goblin skeleton
     Example: ability goblin"""

--- a/droll/shell.py
+++ b/droll/shell.py
@@ -423,9 +423,10 @@ class Shell(cmd.Cmd):
         if name in ("Enchantress", "Beguiler"):
             print(textwrap.dedent("""\
 
-            As Enchantress/Beguiler, scrolls target monsters like party members:
+            As Enchantress/Beguiler, scrolls may be used as any companion:
 
-                    scroll skeleton             # Kill all skeletons"""))
+                    scroll goblin               # Defeat all goblins
+                    scroll skeleton             # Defeat all skeletons"""))
         elif name in ("Knight", "DragonSlayer"):
             print(
                 "\nAs Knight/DragonSlayer, scrolls become champions during party roll."


### PR DESCRIPTION
## Summary

- The Enchantress and Beguiler share the same scroll specialty ("Scrolls may be used as any Companion"), but documentation described it as Beguiler-only or limited to skeletons.
- Fixed README (scroll overview and level-up table), `beguiler_ability` docstring, and `help_scroll` shell text to match the actual game cards.

## Changes

- **README.md**: "against skeletons" → "as any companion"; Beguiler party change → "*(unchanged)*"
- **droll/ability.py**: Removed "Scrolls target monsters like party members" from `beguiler_ability` docstring (shared specialty, not ability-specific)
- **droll/shell.py**: `help_scroll` now says "scrolls may be used as any companion" and adds a goblin example alongside the skeleton one

## Test plan

- [x] All 221 existing tests pass
- [x] Verified with seed 0 that both `scroll goblin` (offensive) and `reroll goblin` (reroll) work correctly for the Enchantress

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vongyv2jm9pPVrHgy9t6Sc)_