### PR TITLE
Fix README and docstrings from rulebook/card audit

### DIFF
--- a/README.md
+++ b/README.md
@@ -255,7 +255,7 @@ different types.  Defeating a dragon earns 1 experience and
 draws 1 treasure.
 
 Two treasures affect dungeon progress:
-a ring lets you ignore a blocking dragon without removing the
+a ring lets you sneak past a blocking dragon, removing all
 dragon dice, and a portal immediately ends the delve, earning
 experience equal to your current depth.  When monsters or
 dragons block, retiring or retreating consumes a portal

--- a/README.md
+++ b/README.md
@@ -292,20 +292,22 @@ Display notation:
 ### Level-up progression
 
 At 5+ experience, each hero advances to a stronger form with an
-upgraded ability and a party change.  "Interchangeable" means
-those party types can substitute for each other in any command;
-other entries describe different mechanical bonuses:
+upgraded ability.  The "Specialty" column lists passive bonuses
+shared by both the base and advanced forms.  "Interchangeable"
+means those party types can substitute for each other in any
+command; other entries describe different mechanical bonuses.
+The "Party upgrade" column lists bonuses gained only at level-up:
 
-| Base        | Advanced      | New ability                          | Party change                            |
-|-------------|---------------|--------------------------------------|-----------------------------------------|
-| Crusader    | Paladin       | Consume treasure to clear dungeon    | Heroes fighter and cleric are interchangeable           |
-| Enchantress | Beguiler      | Transform up to 2 monsters to potion | *(unchanged)*                                      |
-| HalfGoblin  | Chieftain     | Transform up to 2 goblins to thieves | Open chests/quaff potions before clearing monsters |
-| Knight      | DragonSlayer  | *(unchanged)*                        | Dragon requires only 2 party members of different types |
-| Mercenary   | Commander     | Reroll any number of dice            | Each fighter defeats one additional monster         |
-| Minstrel    | Bard          | *(unchanged)*                        | Each champion defeats one additional monster        |
-| Occultist   | Necromancer   | Transform up to 2 skeletons to fighters | Heroes cleric and mage are interchangeable            |
-| Spellsword  | Battlemage    | Discard all monsters, chests, potions | Heroes fighter and mage are interchangeable              |
+| Base        | Advanced      | New ability                          | Specialty                                          | Party upgrade                                           |
+|-------------|---------------|--------------------------------------|----------------------------------------------------|---------------------------------------------------------|
+| Crusader    | Paladin       | Consume treasure to clear dungeon    | Heroes fighter and cleric are interchangeable      | —                                                       |
+| Enchantress | Beguiler      | Transform up to 2 monsters to potion | —                                                  | —                                                       |
+| HalfGoblin  | Chieftain     | Transform up to 2 goblins to thieves | Open chests/quaff potions before clearing monsters  | —                                                       |
+| Knight      | DragonSlayer  | *(unchanged)*                        | —                                                  | Dragon requires only 2 party members of different types |
+| Mercenary   | Commander     | Reroll any number of dice            | —                                                  | Each fighter defeats one additional monster              |
+| Minstrel    | Bard          | *(unchanged)*                        | Thieves and mages are interchangeable              | Each champion defeats one additional monster             |
+| Occultist   | Necromancer   | Transform up to 2 skeletons to fighters | Heroes cleric and mage are interchangeable      | —                                                       |
+| Spellsword  | Battlemage    | Discard all monsters, chests, potions | Heroes fighter and mage are interchangeable        | —                                                       |
 
 ## How does scoring work?
 

--- a/droll/ability.py
+++ b/droll/ability.py
@@ -320,7 +320,6 @@ def necromancer_ability(
     targets: tuple[str, ...] = (),
 ) -> struct.World:
     """Transform up to 2 skeletons into fighters, discarding on regroup.
-    Heroes cleric and mage are interchangeable.
 
     Example: ability"""
     return _convert_two(world, targets, source="skeleton", destination="fighter")

--- a/droll/ability.py
+++ b/droll/ability.py
@@ -346,7 +346,6 @@ def paladin_ability(
     """Consume treasure to clear dungeon, open chests, and quaff potions.
     Specify consumed treasure as first argument.
     For each potion, add one argument for the hero to revive.
-    Heroes fighter and cleric are interchangeable.
 
     Example: ability sword
     Example: ability talisman mage"""

--- a/droll/ability.py
+++ b/droll/ability.py
@@ -158,7 +158,6 @@ def chieftain_ability(
     targets: tuple[str, ...] = (),
 ) -> struct.World:
     """Transform up to 2 goblins into thieves, discarding them on regroup.
-    Open chests and quaff potions before clearing monsters.
 
     Example: ability"""
     return _convert_two(world, targets, source="goblin", destination="thief")


### PR DESCRIPTION
## Summary

- Fix ring description: README said dragon dice are kept, but the rulebook and code both remove them (Closes #200)
- Restructure the level-up table to separate shared specialties (active at both base and advanced levels) from genuine party upgrades gained only at level-up (Closes #201, #202, #203, #204, #209)
- Remove shared specialty lines from advanced ability docstrings (`necromancer_ability`, `paladin_ability`, `chieftain_ability`) to match the approach taken for Beguiler in PR #199 (Closes #205, #206, #207)

## Context

Audit of the entire codebase against the original Dungeon Roll rulebook PDF and physical hero cards. In all cases the code was correct — only documentation was wrong.

## Test plan

- [ ] Verify the README level-up table renders correctly with the new Specialty and Party upgrade columns
- [ ] Verify `help ability` in-game for Necromancer, Paladin, and Chieftain no longer mentions shared specialties
- [ ] Verify ring description reads correctly in context

---
_Generated by [Claude Code](https://claude.ai/code/session_01Vongyv2jm9pPVrHgy9t6Sc)_